### PR TITLE
RVC2 - Fix Incorrect Name in Archive

### DIFF
--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -415,8 +415,16 @@ def convert(
             if to == Format.NN_ARCHIVE:
                 logger.info("Converting to NN archive")
                 assert main_stage is not None
+                if len(out_models) > 1:
+                    model_name = f"{main_stage}{out_models[0].suffix}"
+                else:
+                    model_name = out_models[0].name
                 nn_archive = modelconverter_config_to_nn(
-                    cfg, target, archive_cfg, preprocessing, main_stage
+                    cfg,
+                    Path(model_name),
+                    archive_cfg,
+                    preprocessing,
+                    main_stage,
                 )
                 generator = ArchiveGenerator(
                     archive_name=cfg.name,

--- a/modelconverter/packages/rvc2/exporter.py
+++ b/modelconverter/packages/rvc2/exporter.py
@@ -21,9 +21,9 @@ from ..base_exporter import Exporter
 
 logger = getLogger(__name__)
 
-COMPILE_TOOL: Final[
-    str
-] = f'{env["INTEL_OPENVINO_DIR"]}/tools/compile_tool/compile_tool'
+COMPILE_TOOL: Final[str] = (
+    f'{env["INTEL_OPENVINO_DIR"]}/tools/compile_tool/compile_tool'
+)
 
 DEFAULT_SUPER_SHAVES: Final[int] = 8
 
@@ -141,9 +141,9 @@ class RVC2Exporter(Exporter):
         if self.superblob:
             return self.compile_superblob(args)
 
-        return self.compile(args)
+        return self.compile_blob(args)
 
-    def compile(self, args: list) -> Path:
+    def compile_blob(self, args: list) -> Path:
         output_path = (
             self.output_dir / f"{self.model_name}-{self.target.name.lower()}"
         )
@@ -172,7 +172,7 @@ class RVC2Exporter(Exporter):
 
         orig_args = args.copy()
 
-        default_blob_path = self.compile(
+        default_blob_path = self.compile_blob(
             orig_args
             + [
                 "-o",

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -14,7 +14,6 @@ from luxonis_ml.nn_archive.config_building_blocks import (
 
 from modelconverter.utils.config import Config
 from modelconverter.utils.constants import MISC_DIR
-from modelconverter.utils.types import Target
 
 
 def get_archive_input(cfg: NNArchiveConfig, name: str) -> NNArchiveInput:
@@ -116,15 +115,12 @@ def process_nn_archive(
 
 def modelconverter_config_to_nn(
     config: Config,
-    target: Target,
+    model_name: Path,
     orig_nn: Optional[NNArchiveConfig],
     preprocessing: Dict[str, PreprocessingBlock],
     main_stage_key: str,
 ) -> NNArchiveConfig:
     is_multistage = len(config.stages) > 1
-
-    if main_stage_key is None:
-        main_stage_key = next(iter(config.stages.keys()))
 
     cfg = config.stages[main_stage_key]
     archive_cfg = NNArchiveConfig(
@@ -132,8 +128,8 @@ def modelconverter_config_to_nn(
             "config_version": "1.0",
             "model": {
                 "metadata": {
-                    "name": main_stage_key,
-                    "path": f"{main_stage_key}{target.suffix}",
+                    "name": model_name.stem,
+                    "path": str(model_name),
                 },
                 "inputs": [
                     {
@@ -183,5 +179,7 @@ def modelconverter_config_to_nn(
                 "Multistage NN Archives must sxpecify 1 head in the archive config"
             )
         head = archive_cfg.model.heads[0]
-        head.metadata.postprocessor_path = f"{post_stage_key}{target.suffix}"
+        head.metadata.postprocessor_path = (
+            f"{post_stage_key}{model_name.suffix}"
+        )
     return archive_cfg

--- a/modelconverter/utils/types.py
+++ b/modelconverter/utils/types.py
@@ -166,15 +166,6 @@ class Target(Enum):
     RVC3 = "rvc3"
     RVC4 = "rvc4"
 
-    @property
-    def suffix(self) -> str:
-        return {
-            "hailo": ".hef",
-            "rvc2": ".blob",
-            "rvc3": ".blob",
-            "rvc4": ".dlc",
-        }[self.value]
-
 
 class InputFileType(Enum):
     ONNX = "ONNX"


### PR DESCRIPTION
Fixed incorrect name in the NN Archive when compiling to `superblob`.