### PR TITLE
Fix for Top-Level `reverse_input_channels`

### DIFF
--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -373,7 +373,7 @@ class SingleStageConfig(CustomBaseModel):
 
             if (
                 inp.get("reverse_input_channels") is not None
-                or reverse_input_channels
+                or reverse_input_channels is not None
             ):
                 inp["reverse_input_channels"] = inp.get(
                     "reverse_input_channels"


### PR DESCRIPTION
Fixed handling of deprecated `reverse_input_channels` when defined as a top-level field in the configuration file. 