### PR TITLE
TFLITE Conversion Support for RVC2 and RVC3

### DIFF
--- a/docker/rvc2/Dockerfile
+++ b/docker/rvc2/Dockerfile
@@ -13,9 +13,9 @@ COPY --link --from=BASE /usr/lib /usr/lib
 COPY --link --from=BASE /usr/lib_openvino /usr/lib
 COPY --link --from=BASE /usr/local/lib_38 /usr/local/lib
 
-RUN pip install pip-autoremove bsdiff4 && \
-    pip-autoremove -y pot addict pip-autoremove && \
-    pip cache purge
+COPY docker/rvc2/requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY --link docker/rvc2/entrypoint.sh /app/entrypoint.sh
 

--- a/docker/rvc2/Dockerfile.public
+++ b/docker/rvc2/Dockerfile.public
@@ -18,10 +18,12 @@ RUN sed -i 's/libtbb2/libtbbmalloc2/g' \
     bash /opt/intel/install_dependencies/install_openvino_dependencies.sh -y
 
 COPY  requirements.txt .
+COPY docker/rvc2/requirements.txt rvc2_requirements.txt
 
 RUN pip install --upgrade pip && \
     pip install /opt/intel/tools/*.whl && \
     pip install -r requirements.txt && \
+    pip install -r rvc2_requirements.txt && \
     pip install bsdiff4
 
 COPY docker/extra_packages/mo_patch.diff .

--- a/docker/rvc2/requirements.txt
+++ b/docker/rvc2/requirements.txt
@@ -1,0 +1,2 @@
+tflite2onnx
+bsdiff4

--- a/docker/rvc3/Dockerfile
+++ b/docker/rvc3/Dockerfile
@@ -15,6 +15,10 @@ COPY --link --from=BASE /usr/local/lib_38 /usr/local/lib
 
 COPY --link docker/rvc3/entrypoint.sh /app/entrypoint.sh
 
+COPY docker/rvc2/requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
 RUN echo "alias compile_tool='/opt/intel/tools/compile_tool/compile_tool'" \
     >> ~/.bashrc && \
     chmod +x /app/entrypoint.sh && \

--- a/docker/rvc3/Dockerfile.public
+++ b/docker/rvc3/Dockerfile.public
@@ -18,10 +18,12 @@ RUN sed -i 's/libtbb2/libtbbmalloc2/g' \
     bash /opt/intel/install_dependencies/install_openvino_dependencies.sh -y
 
 COPY  requirements.txt .
+COPY docker/rvc3/requirements.txt rvc3_requirements.txt
 
 RUN pip install --upgrade pip && \
     pip install /opt/intel/tools/*.whl && \
     pip install -r requirements.txt && \
+    pip install -r rvc3_requirements.txt && \
     pip install bsdiff4
 
 COPY docker/extra_packages/mo_patch.diff .

--- a/docker/rvc3/requirements.txt
+++ b/docker/rvc3/requirements.txt
@@ -1,0 +1,1 @@
+tflite2onnx

--- a/modelconverter/packages/rvc3/exporter.py
+++ b/modelconverter/packages/rvc3/exporter.py
@@ -37,6 +37,9 @@ class RVC3Exporter(RVC2Exporter):
         self._device_specific_buildinfo = {}
 
     def export(self) -> Path:
+        if self.input_file_type == InputFileType.TFLITE:
+            self._transform_tflite_to_onnx()
+
         if self.input_file_type == InputFileType.ONNX:
             xml_path = self._export_openvino_ir()
         elif self.input_file_type == InputFileType.IR:


### PR DESCRIPTION
Added support for conversion from `tflite` format to RVC2 and RVC3 platforms.