### PR TITLE
Opting out of `mo` telemetry

### DIFF
--- a/docker/rvc2/Dockerfile
+++ b/docker/rvc2/Dockerfile
@@ -138,6 +138,10 @@ RUN <<EOF
     echo "alias compile_tool=${COMPILE_TOOL}"  >> ~/.bashrc
     chmod +x /app/entrypoint.sh
 
+    if [ "${VERSION}" = "2022.3.0" ]; then
+        opt_in_out --opt_out
+    fi
+
 EOF
 
 


### PR DESCRIPTION
Automatically opting out of `mo` telemetry when building docker images for `RVC2` and `RVC3` using OpenVINO version `2022.3.0`. 

This removes the telemetry question when `mo` is run for the first time in `modelconverter shell`. 