### PR TITLE
Added dai_type, updated encoding flags, and removed reverse_input_channels flag 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+    python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-    python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.2

--- a/README.md
+++ b/README.md
@@ -135,25 +135,25 @@ The `encoding` flag in the YAML configuration file allows you to specify color e
   ```
   This configuration specifies that the input data is in RGB format and will be converted to BGR format during processing.
 
-> \[!NOTE\] Note on Default Encoding
+> [!NOTE]
 > If the encoding is not specified in the YAML configuration, the default values are set to `encoding.from=RGB` and `encoding.to=BGR`.
 
-> \[!NOTE\] Note on Global Settings
+> [!NOTE]
 > Certain options can be set **globally**, applying to all inputs of the model, or **per input**. If specified per input, these settings will override the global configuration for that input alone. The options that support this flexibility include `scale_values`, `mean_values`, `encoding`, `data_type`, `shape`, and `layout`.
 
 #### NN Archive Configuration File
 
 In the NN Archive configuration, there are two flags related to color encoding control:
 
-- **`reverse_channels` (Deprecated)**:
-  Determines the input color format of the model: when set to *True*, the input is considered to be *"RGB"*, and when set to *False*, it is treated as *"BGR"*. This flag is deprecated and will be replaced by the `dai_type` flag in future versions.
 - **`dai_type`**:
   Provides a more comprehensive control over the input type compatible with the DAI backend. It is read by DepthAI to automatically configure the processing pipeline, including any necessary modifications to the input image format.
+- **`reverse_channels` (Deprecated)**:
+  Determines the input color format of the model: when set to *True*, the input is considered to be *"RGB"*, and when set to *False*, it is treated as *"BGR"*. This flag is deprecated and will be replaced by the `dai_type` flag in future versions.
 
-> \[!NOTE\] Note on Default Settings
-> If neither `dai_type` nor `reverse_channels` the input to the model is considered to be *"BGR"*.
+> [!NOTE]
+> If neither `dai_type` nor `reverse_channels` the input to the model is considered to be *"RGB"*.
 
-> \[!NOTE\] Note on Conflicting Settings
+> [!NOTE]
 > If both `dai_type` and `reverse_channels` are provided, the converter will give priority to `dai_type`.
 
 ### Sharing Files
@@ -264,7 +264,7 @@ modelconverter convert rvc2 input_model models/yolov6n.onnx \
                         outputs.2.name out_2
 ```
 
-> \[!WARNING\]
+> [!WARNING]
 > If you modify the default stages names (`stages.stage_name`) in the configuration file (`config.yaml`), you need to provide the full path to each stage in the command-line arguments. For instance, if a stage name is changed to `stage1`, use `stages.stage1.inputs.0.name` instead of `inputs.0.name`.
 
 ## Multi-Stage Conversion

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ You can run the built image either manually using the `docker run` command or us
 1. Execute the conversion:
 
 - If using the `docker run` command:
+
   ```bash
   docker run --rm -it \
     -v $(pwd)/shared_with_container:/app/shared_with_container/ \
@@ -168,11 +169,15 @@ You can run the built image either manually using the `docker run` command or us
     convert <target> \
     --path <s3_url_or_path> [ config overrides ]
   ```
+
 - If using the `modelconverter` CLI:
+
   ```bash
   modelconverter convert <target> --path <s3_url_or_path> [ config overrides ]
   ```
+
 - If using `docker-compose`:
+
   ```bash
   docker compose run <target> convert <target> ...
   ```
@@ -207,6 +212,8 @@ modelconverter convert rvc2 input_model models/yolov6n.onnx \
                         outputs.1.name out_1 \
                         outputs.2.name out_2
 ```
+
+:warning: **Important Note**: If you modify the default stages names (`stages.stage_name`) in the configuration file (`config.yaml`), you need to provide the full path to each stage in the command-line arguments. For instance, if a stage name is changed to `stage1`, use `stages.stage1.inputs.0.name` instead of `inputs.0.name`.
 
 ## Multi-Stage Conversion
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ In the NN Archive configuration, there are two flags related to color encoding c
 > [!NOTE]
 > If both `dai_type` and `reverse_channels` are provided, the converter will give priority to `dai_type`.
 
+> [!IMPORTANT]
+> Provide mean/scale values in the original color format used during model training (e.g., RGB or BGR). Any necessary channel permutation is handled internally—do not reorder values manually.
+
 ### Sharing Files
 
 When using the supplied `docker-compose.yaml`, the `shared_with_container` directory facilitates file sharing between the host and container. This directory is mounted as `/app/shared_with_container/` inside the container. You can place your models, calibration data, and config files here. The directory structure is:

--- a/README.md
+++ b/README.md
@@ -101,9 +101,15 @@ To enable GPU acceleration for `hailo` conversion, install the [Nvidia Container
 
 ## Running ModelConverter
 
-Configuration for the conversion predominantly relies on a `yaml` config file. For reference, see [defaults.yaml](shared_with_container/configs/defaults.yaml) and other examples located in the [shared_with_container/configs](shared_with_container/configs) directory.
+There are two main ways to execute configure the conversion process:
 
-However, you have the flexibility to modify specific settings without altering the config file itself. This is done using command line arguments. You provide the arguments in the form of `key value` pairs. For better understanding, see [Examples](#examples).
+1. **YAML Config File (Primary Method)**:
+   The primary way to configure the conversion is through a YAML configuration file. For reference, you can check [defaults.yaml](shared_with_container/configs/defaults.yaml) and other examples located in the [shared_with_container/configs](shared_with_container/configs) directory.
+1. **NN Archive**:
+   Alternatively, you can use an [NN Archive](https://rvc4.docs.luxonis.com/software/ai-inference/nn-archive/#NN%20Archive) as input. An NN Archive includes a model in one of the supported formats—ONNX (.onnx), OpenVINO IR (.xml and .bin), or TensorFlow Lite (.tflite)—alongside a `config.json` file. The config.json file follows a specific configuration format as described in the [NN Archive Configuration Guide](https://rvc4.docs.luxonis.com/software/ai-inference/nn-archive/#NN%20Archive-Configuration).
+
+**Modifying Settings with Command-Line Arguments**:
+In addition to these two configuration methods, you have the flexibility to override specific settings directly via command-line arguments. By supplying `key-value` pairs in the CLI, you can adjust particular settings without explicitly altering the config files (YAML or NN Archive). For further details, refer to the [Examples](#examples) section.
 
 ### Sharing Files
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ Specify all options via the command line without a config file:
 ```bash
 modelconverter convert rvc2 input_model models/yolov6n.onnx \
                         scale_values "[255,255,255]" \
-                        reverse_input_channels True \
+                        inputs.0.encoding.from RGB \
+                        inputs.0.encoding.to BGR \
                         shape "[1,3,256,256]" \
                         outputs.0.name out_0 \
                         outputs.1.name out_1 \

--- a/README.md
+++ b/README.md
@@ -21,13 +21,18 @@ Convert your **ONNX** models to a format compatible with any generation of Luxon
 
 ## Table of Contents
 
-- [MLOps - Compilation Library](#mlops---compilation-library)
+- [ModelConverter - Compilation Library](#modelconverter---compilation-library)
+  - [Status](#status)
   - [Table of Contents](#table-of-contents)
   - [Installation](#installation)
+    - [System Requirements](#system-requirements)
     - [Before You Begin](#before-you-begin)
     - [Instructions](#instructions)
     - [GPU Support](#gpu-support)
   - [Running ModelConverter](#running-modelconverter)
+    - [Encoding Configuration Flags](#encoding-configuration-flags)
+      - [YAML Configuration File](#yaml-configuration-file)
+      - [NN Archive Configuration File](#nn-archive-configuration-file)
     - [Sharing Files](#sharing-files)
     - [Usage](#usage)
     - [Examples](#examples)
@@ -110,6 +115,46 @@ There are two main ways to execute configure the conversion process:
 
 **Modifying Settings with Command-Line Arguments**:
 In addition to these two configuration methods, you have the flexibility to override specific settings directly via command-line arguments. By supplying `key-value` pairs in the CLI, you can adjust particular settings without explicitly altering the config files (YAML or NN Archive). For further details, refer to the [Examples](#examples) section.
+
+### Encoding Configuration Flags
+
+In the conversion process, you have options to control the color encoding format in both the YAML configuration file and the NN Archive configuration. Here’s a breakdown of each available flag:
+
+#### YAML Configuration File
+
+The `encoding` flag in the YAML configuration file allows you to specify color encoding as follows:
+
+- **Single-Value `encoding`**:
+  Setting encoding to a single value, such as *"RGB"*, *"BGR"*, *"GRAY"*, or *"NONE"*, will automatically apply this setting to both `encoding.from` and `encoding.to`. For example, `encoding: RGB` sets both `encoding.from` and `encoding.to` to *"RGB"* internally.
+- **Multi-Value `encoding.from` and `encoding.to`**:
+  Alternatively, you can explicitly set `encoding.from` and `encoding.to` to different values. For example:
+  ```yaml
+  encoding:
+    from: RGB
+    to: BGR
+  ```
+  This configuration specifies that the input data is in RGB format and will be converted to BGR format during processing.
+
+> \[!NOTE\] Note on Default Encoding
+> If the encoding is not specified in the YAML configuration, the default values are set to `encoding.from=RGB` and `encoding.to=BGR`.
+
+> \[!NOTE\] Note on Global Settings
+> Certain options can be set **globally**, applying to all inputs of the model, or **per input**. If specified per input, these settings will override the global configuration for that input alone. The options that support this flexibility include `scale_values`, `mean_values`, `encoding`, `data_type`, `shape`, and `layout`.
+
+#### NN Archive Configuration File
+
+In the NN Archive configuration, there are two flags related to color encoding control:
+
+- **`reverse_channels` (Deprecated)**:
+  Determines the input color format of the model: when set to *True*, the input is considered to be *"RGB"*, and when set to *False*, it is treated as *"BGR"*. This flag is deprecated and will be replaced by the `dai_type` flag in future versions.
+- **`dai_type`**:
+  Provides a more comprehensive control over the input type compatible with the DAI backend. It is read by DepthAI to automatically configure the processing pipeline, including any necessary modifications to the input image format.
+
+> \[!NOTE\] Note on Default Settings
+> If neither `dai_type` nor `reverse_channels` the input to the model is considered to be *"BGR"*.
+
+> \[!NOTE\] Note on Conflicting Settings
+> If both `dai_type` and `reverse_channels` are provided, the converter will give priority to `dai_type`.
 
 ### Sharing Files
 
@@ -219,7 +264,8 @@ modelconverter convert rvc2 input_model models/yolov6n.onnx \
                         outputs.2.name out_2
 ```
 
-:warning: **Important Note**: If you modify the default stages names (`stages.stage_name`) in the configuration file (`config.yaml`), you need to provide the full path to each stage in the command-line arguments. For instance, if a stage name is changed to `stage1`, use `stages.stage1.inputs.0.name` instead of `inputs.0.name`.
+> \[!WARNING\]
+> If you modify the default stages names (`stages.stage_name`) in the configuration file (`config.yaml`), you need to provide the full path to each stage in the command-line arguments. For instance, if a stage name is changed to `stage1`, use `stages.stage1.inputs.0.name` instead of `inputs.0.name`.
 
 ## Multi-Stage Conversion
 

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -210,8 +210,8 @@ def extract_preprocessing(
     stage_cfg = next(iter(cfg.stages.values()))
     preprocessing = {}
     for inp in stage_cfg.inputs:
-        mean = inp.mean_values
-        scale = inp.scale_values
+        mean = inp.mean_values or [0, 0, 0]
+        scale = inp.scale_values or [1, 1, 1]
         encoding = inp.encoding
         layout = inp.layout
 

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -217,13 +217,10 @@ def extract_preprocessing(
 
         dai_type = encoding.from_.value
         if dai_type != "NONE":
-            if (
-                inp.data_type == DataType.FLOAT32
-                or inp.data_type == DataType.INT8
-            ):
-                type = "888"
-            elif inp.data_type == DataType.FLOAT16:
+            if inp.data_type == DataType.FLOAT16:
                 type = "F16F16F16"
+            else:
+                type = "888"
             dai_type += type
             dai_type += "i" if layout == "NHWC" else "p"
 

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -230,8 +230,8 @@ def extract_preprocessing(
         preproc_block = PreprocessingBlock(
             mean=mean,
             scale=scale,
-            reverse_channels=True if encoding.from_ != encoding.to else False,
-            interleaved_to_planar=True if layout == "NHWC" else False,
+            reverse_channels=encoding.from_ != encoding.to,
+            interleaved_to_planar=layout == "NHWC",
             dai_type=dai_type,
         )
         preprocessing[inp.name] = preproc_block

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -114,7 +114,7 @@ TargetArgument: TypeAlias = Annotated[
 DevOption: TypeAlias = Annotated[
     bool,
     typer.Option(
-        help="Builds a new iamge and uses the development docker-compose file."
+        help="Builds a new image and uses the development docker-compose file."
     ),
 ]
 

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -37,7 +37,7 @@ from modelconverter.utils.constants import (
     MODELS_DIR,
     OUTPUTS_DIR,
 )
-from modelconverter.utils.types import Encoding, Target
+from modelconverter.utils.types import DataType, Encoding, Target
 
 logger = logging.getLogger(__name__)
 
@@ -217,7 +217,15 @@ def extract_preprocessing(
 
         dai_type = encoding.from_.value
         if dai_type != "NONE":
-            dai_type += "888i" if layout == "NHWC" else "888p"
+            if (
+                inp.data_type == DataType.FLOAT32
+                or inp.data_type == DataType.INT8
+            ):
+                type = "888"
+            elif inp.data_type == DataType.FLOAT16:
+                type = "F16F16F16"
+            dai_type += type
+            dai_type += "i" if layout == "NHWC" else "p"
 
         preproc_block = PreprocessingBlock(
             mean=mean,

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -215,7 +215,7 @@ def extract_preprocessing(
         encoding = inp.encoding
         layout = inp.layout
 
-        dai_type = encoding.from_.value
+        dai_type = encoding.to.value
         if dai_type != "NONE":
             if inp.data_type == DataType.FLOAT16:
                 type = "F16F16F16"
@@ -227,7 +227,7 @@ def extract_preprocessing(
         preproc_block = PreprocessingBlock(
             mean=mean,
             scale=scale,
-            reverse_channels=encoding.from_ != encoding.to,
+            reverse_channels=encoding.to == Encoding.RGB,
             interleaved_to_planar=layout == "NHWC",
             dai_type=dai_type,
         )

--- a/modelconverter/packages/hailo/exporter.py
+++ b/modelconverter/packages/hailo/exporter.py
@@ -237,7 +237,7 @@ class HailoExporter(Exporter):
                 f"{mean_values},{scale_values},{hn_name})"
             )
 
-            if inp.encoding.from_ != inp.encoding.to:
+            if inp.encoding_mismatch:
                 alls.append(
                     f"bgr_to_rgb_{safe_name} = input_conversion("
                     f"{hn_name},bgr_to_rgb)"

--- a/modelconverter/packages/hailo/exporter.py
+++ b/modelconverter/packages/hailo/exporter.py
@@ -237,7 +237,7 @@ class HailoExporter(Exporter):
                 f"{mean_values},{scale_values},{hn_name})"
             )
 
-            if inp.reverse_input_channels:
+            if inp.encoding.from_ != inp.encoding.to:
                 alls.append(
                     f"bgr_to_rgb_{safe_name} = input_conversion("
                     f"{hn_name},bgr_to_rgb)"

--- a/modelconverter/packages/rvc2/exporter.py
+++ b/modelconverter/packages/rvc2/exporter.py
@@ -109,15 +109,9 @@ class RVC2Exporter(Exporter):
                 reverse_only=True,
             )
             for inp in self.inputs.values():
-                if (
-                    inp.mean_values is not None
-                    and inp.encoding.from_ != inp.encoding.to
-                ):
+                if inp.mean_values is not None and inp.encoding_mismatch:
                     inp.mean_values = inp.mean_values[::-1]
-                if (
-                    inp.scale_values is not None
-                    and inp.encoding.from_ != inp.encoding.to
-                ):
+                if inp.scale_values is not None and inp.encoding_mismatch:
                     inp.scale_values = inp.scale_values[::-1]
                 inp.encoding.from_ = Encoding.BGR
                 inp.encoding.to = Encoding.BGR
@@ -148,8 +142,7 @@ class RVC2Exporter(Exporter):
 
         # Append reverse_input_channels flag only once if needed
         reverse_input_flag = any(
-            inp.encoding.from_ != inp.encoding.to
-            for inp in self.inputs.values()
+            inp.encoding_mismatch for inp in self.inputs.values()
         )
         if reverse_input_flag:
             args.append("--reverse_input_channels")
@@ -162,10 +155,7 @@ class RVC2Exporter(Exporter):
         return self.input_model.with_suffix(".xml")
 
     def _check_reverse_channels(self):
-        reverses = [
-            inp.encoding.from_ != inp.encoding.to
-            for inp in self.inputs.values()
-        ]
+        reverses = [inp.encoding_mismatch for inp in self.inputs.values()]
         return all(reverses) or not any(reverses)
 
     @staticmethod

--- a/modelconverter/packages/rvc2/exporter.py
+++ b/modelconverter/packages/rvc2/exporter.py
@@ -109,25 +109,50 @@ class RVC2Exporter(Exporter):
                 reverse_only=True,
             )
             for inp in self.inputs.values():
-                if inp.mean_values is not None and inp.reverse_input_channels:
+                if (
+                    inp.mean_values is not None
+                    and inp.encoding.from_ != inp.encoding.to
+                ):
                     inp.mean_values = inp.mean_values[::-1]
-                if inp.scale_values is not None and inp.reverse_input_channels:
+                if (
+                    inp.scale_values is not None
+                    and inp.encoding.from_ != inp.encoding.to
+                ):
                     inp.scale_values = inp.scale_values[::-1]
-                inp.reverse_input_channels = False
+                inp.encoding.from_ = Encoding.BGR
+                inp.encoding.to = Encoding.BGR
 
+        mean_values_str = ""
+        scale_values_str = ""
         for name, inp in self.inputs.items():
+            # Append mean values in a similar style
             if inp.mean_values is not None:
-                self._add_args(
-                    args,
-                    ["--mean_values", f"{name}{_lst_join(inp.mean_values)}"],
+                if mean_values_str:
+                    mean_values_str += ","
+                mean_values_str += (
+                    f"{name}[{', '.join(str(v) for v in inp.mean_values)}]"
                 )
+
+            # Append scale values in a similar style
             if inp.scale_values is not None:
-                self._add_args(
-                    args,
-                    ["--scale_values", f"{name}{_lst_join(inp.scale_values)}"],
+                if scale_values_str:
+                    scale_values_str += ","
+                scale_values_str += (
+                    f"{name}[{', '.join(str(v) for v in inp.scale_values)}]"
                 )
-            if inp.reverse_input_channels:
-                self._add_args(args, ["--reverse_input_channels"])
+        # Extend args with mean and scale values if they were collected
+        if mean_values_str:
+            args.extend(["--mean_values", mean_values_str])
+        if scale_values_str:
+            args.extend(["--scale_values", scale_values_str])
+
+        # Append reverse_input_channels flag only once if needed
+        reverse_input_flag = any(
+            inp.encoding.from_ != inp.encoding.to
+            for inp in self.inputs.values()
+        )
+        if reverse_input_flag:
+            args.append("--reverse_input_channels")
 
         self._add_args(args, ["--input_model", self.input_model])
 
@@ -137,7 +162,10 @@ class RVC2Exporter(Exporter):
         return self.input_model.with_suffix(".xml")
 
     def _check_reverse_channels(self):
-        reverses = [inp.reverse_input_channels for inp in self.inputs.values()]
+        reverses = [
+            inp.encoding.from_ != inp.encoding.to
+            for inp in self.inputs.values()
+        ]
         return all(reverses) or not any(reverses)
 
     @staticmethod

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -163,6 +163,14 @@ class InputConfig(OutputConfig):
             return data
         if isinstance(encoding, str):
             data["encoding"] = {"from": encoding, "to": encoding}
+        if isinstance(encoding, dict):
+            if (
+                "from" in encoding
+                and encoding["from"] == "GRAY"
+                or "to" in encoding
+                and encoding["to"] == "GRAY"
+            ):
+                data["encoding"] = {"from": "GRAY", "to": "GRAY"}
         return data
 
     @model_validator(mode="before")

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -198,7 +198,7 @@ class InputConfig(OutputConfig):
     ) -> Any:
         """Resolves named values from the config."""
         if value is None:
-            return None
+            return [0, 0, 0] if values_type == "mean" else [1, 1, 1]
         if isinstance(value, str):
             if value in NAMED_VALUES:
                 return NAMED_VALUES[value][values_type]

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -198,7 +198,7 @@ class InputConfig(OutputConfig):
     ) -> Any:
         """Resolves named values from the config."""
         if value is None:
-            return [0, 0, 0] if values_type == "mean" else [1, 1, 1]
+            return None
         if isinstance(value, str):
             if value in NAMED_VALUES:
                 return NAMED_VALUES[value][values_type]

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -137,6 +137,10 @@ class InputConfig(OutputConfig):
     frozen_value: Optional[Any] = None
     encoding: EncodingConfig = EncodingConfig()
 
+    @property
+    def encoding_mismatch(self) -> bool:
+        return self.encoding.from_ != self.encoding.to
+
     @model_validator(mode="after")
     def _validate_grayscale_inputs(self) -> Self:
         if self.layout is None:

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -134,40 +134,8 @@ class InputConfig(OutputConfig):
     ] = RandomCalibrationConfig()
     scale_values: Optional[Annotated[List[float], Field(min_length=1)]] = None
     mean_values: Optional[Annotated[List[float], Field(min_length=1)]] = None
-    reverse_input_channels: bool = False
     frozen_value: Optional[Any] = None
     encoding: EncodingConfig = EncodingConfig()
-
-    @model_validator(mode="before")
-    @classmethod
-    def _validate_encoding(cls, data: Dict[str, Any]) -> Dict[str, Any]:
-        encoding = data.get("encoding")
-        if encoding is None:
-            return data
-        if isinstance(encoding, str):
-            data["encoding"] = {"from": encoding, "to": encoding}
-        return data
-
-    @model_validator(mode="after")
-    def _validate_reverse_input_channels(self) -> Self:
-        if self.reverse_input_channels:
-            return self
-
-        if self.encoding.from_ == Encoding.NONE:
-            self.reverse_input_channels = False
-            return self
-
-        if (
-            self.encoding.from_ == Encoding.GRAY
-            or self.encoding.to == Encoding.GRAY
-        ):
-            self.encoding.from_ = self.encoding.to = Encoding.GRAY
-            self.reverse_input_channels = False
-
-        if self.encoding.from_ != self.encoding.to:
-            self.reverse_input_channels = True
-
-        return self
 
     @model_validator(mode="after")
     def _validate_grayscale_inputs(self) -> Self:
@@ -185,6 +153,17 @@ class InputConfig(OutputConfig):
             self.encoding.from_ = self.encoding.to = Encoding.GRAY
 
         return self
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_encoding(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        encoding = data.get("encoding")
+        if encoding is None or encoding == {}:
+            data["encoding"] = {"from": "RGB", "to": "BGR"}
+            return data
+        if isinstance(encoding, str):
+            data["encoding"] = {"from": encoding, "to": encoding}
+        return data
 
     @model_validator(mode="before")
     @classmethod
@@ -218,63 +197,6 @@ class InputConfig(OutputConfig):
         if isinstance(value, (float, int)):
             return [value, value, value]
         return value
-
-    @model_validator(mode="before")
-    @classmethod
-    def _validate_deprecated_reverse_channels(
-        cls, data: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        if "reverse_input_channels" not in data:
-            return data
-        logger.warning(
-            "Field `reverse_input_channels` is deprecated. "
-            "Please use `encoding.from` and `encoding.to` instead."
-        )
-        reverse = data["reverse_input_channels"]
-        calib = data.get("calibration", {}) or {}
-        if isinstance(calib, str):
-            calib_encoding = Encoding.BGR
-        else:
-            calib_encoding = calib.get("encoding", Encoding.BGR)
-
-        if reverse:
-            if calib_encoding == Encoding.GRAY:
-                raise ValueError(
-                    "Cannot reverse channels for grayscale images."
-                )
-            else:
-                encoding = {"from": Encoding.RGB, "to": Encoding.BGR}
-        else:
-            if calib_encoding == Encoding.GRAY:
-                encoding = "GRAY"
-            else:
-                encoding = {"from": Encoding.BGR, "to": Encoding.BGR}
-
-        data["encoding"] = encoding
-        return data
-
-    @model_validator(mode="before")
-    @classmethod
-    def _validate_deprecated_reverse_calib_encoding(
-        cls, data: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        calib = data.get("calibration", {}) or {}
-        if isinstance(calib, str):
-            return data
-
-        calib_encoding = calib.pop("encoding", None)
-        if calib_encoding is None:
-            return data
-
-        logger.warning(
-            "Field `calibration.encoding` is deprecated. Please use `encoding.to` instead."
-        )
-        encoding = data.get("encoding", {})
-        if isinstance(encoding, str):
-            encoding = {"from": encoding, "to": encoding}
-        encoding["to"] = calib_encoding
-        data["encoding"] = encoding
-        return data
 
 
 class TargetConfig(CustomBaseModel):
@@ -363,7 +285,6 @@ class SingleStageConfig(CustomBaseModel):
         data_type = data.pop("data_type", None)
         shape = data.pop("shape", None)
         layout = data.pop("layout", None)
-        reverse_input_channels = data.pop("reverse_input_channels", None)
         top_level_calibration = data.pop("calibration", {})
 
         input_file_type = InputFileType.from_path(data["input_model"])
@@ -407,14 +328,6 @@ class SingleStageConfig(CustomBaseModel):
             inp["encoding"] = inp.get("encoding") or encoding
             inp["mean_values"] = inp.get("mean_values") or mean_values
             inp["scale_values"] = inp.get("scale_values") or scale_values
-
-            if (
-                inp.get("reverse_input_channels") is not None
-                or reverse_input_channels is not None
-            ):
-                inp["reverse_input_channels"] = inp.get(
-                    "reverse_input_channels"
-                ) or (reverse_input_channels or False)
 
             inp_calibration: Dict[str, Any] = inp.get("calibration", {})
             if not inp_calibration and not top_level_calibration:
@@ -462,7 +375,6 @@ class SingleStageConfig(CustomBaseModel):
                 data[target] = {}
 
             data[target]["disable_calibration"] = disable_calibration
-
         return data
 
     @model_validator(mode="before")
@@ -522,7 +434,6 @@ class Config(LuxonisConfig):
                 for key, value in extra.items():
                     if key not in stage:
                         stage[key] = value
-
         return data
 
     @model_validator(mode="after")

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -334,8 +334,16 @@ class SingleStageConfig(CustomBaseModel):
             inp["layout"] = inp.get("layout") or layout
             inp["data_type"] = inp.get("data_type") or data_type or onnx_dtype
             inp["encoding"] = inp.get("encoding") or encoding
-            inp["mean_values"] = inp.get("mean_values") or mean_values
-            inp["scale_values"] = inp.get("scale_values") or scale_values
+            inp["mean_values"] = (
+                inp.get("mean_values")
+                if inp.get("mean_values") is not None
+                else mean_values
+            )
+            inp["scale_values"] = (
+                inp.get("scale_values")
+                if inp.get("scale_values") is not None
+                else scale_values
+            )
 
             inp_calibration: Dict[str, Any] = inp.get("calibration", {})
             if not inp_calibration and not top_level_calibration:

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -18,7 +18,7 @@ from modelconverter.utils.config import Config
 from modelconverter.utils.constants import MISC_DIR
 from modelconverter.utils.layout import guess_new_layout, make_default_layout
 from modelconverter.utils.metadata import get_metadata
-from modelconverter.utils.types import DataType
+from modelconverter.utils.types import DataType, Encoding
 
 logger = logging.getLogger(__name__)
 
@@ -235,7 +235,7 @@ def modelconverter_config_to_nn(
                         if inp.scale_values
                         else None
                     ),
-                    "reverse_channels": inp.encoding.from_ != inp.encoding.to,
+                    "reverse_channels": inp.encoding.to == Encoding.RGB,
                     "interleaved_to_planar": layout == "NHWC",
                     "dai_type": dai_type,
                 },

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -75,7 +75,7 @@ def process_nn_archive(
         if inp.input_type == InputType.IMAGE:
             if dai_type is not None:
                 if (reverse and dai_type.startswith("BGR")) or (
-                    not reverse and dai_type.startswith("RGB")
+                    reverse is False and dai_type.startswith("RGB")
                 ):
                     logger.warning(
                         "'reverse_channels' and 'dai_type' are conflicting, using dai_type"
@@ -92,7 +92,7 @@ def process_nn_archive(
                     encoding = {"from": "RGB", "to": "BGR"}
 
                 if (interleaved_to_planar and dai_type.endswith("p")) or (
-                    not interleaved_to_planar and dai_type.endswith("i")
+                    interleaved_to_planar is False and dai_type.endswith("i")
                 ):
                     logger.warning(
                         "'interleaved_to_planar' and 'dai_type' are conflicting, using dai_type"

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -74,8 +74,8 @@ def process_nn_archive(
         encoding = "NONE"
         if inp.input_type == InputType.IMAGE:
             if dai_type is not None:
-                if (reverse is True and dai_type.startswith("BGR")) or (
-                    reverse is False and dai_type.startswith("RGB")
+                if (reverse and dai_type.startswith("BGR")) or (
+                    not reverse and dai_type.startswith("RGB")
                 ):
                     logger.warning(
                         "'reverse_channels' and 'dai_type' are conflicting, using dai_type"
@@ -91,10 +91,8 @@ def process_nn_archive(
                     logger.warning("unknown dai_type, using RGB888p")
                     encoding = {"from": "RGB", "to": "BGR"}
 
-                if (
-                    interleaved_to_planar is True and dai_type.endswith("p")
-                ) or (
-                    interleaved_to_planar is False and dai_type.endswith("i")
+                if (interleaved_to_planar and dai_type.endswith("p")) or (
+                    not interleaved_to_planar and dai_type.endswith("i")
                 ):
                     logger.warning(
                         "'interleaved_to_planar' and 'dai_type' are conflicting, using dai_type"
@@ -128,7 +126,7 @@ def process_nn_archive(
                 if layout and "C" in layout
                 else None
             )
-            if channels is not None and channels == 1:
+            if channels and channels == 1:
                 encoding = "GRAY"
 
         mean = inp.preprocessing.mean or [0, 0, 0]

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -70,7 +70,7 @@ def onnx_attach_normalization_to_inputs(
         last_output = input_name
 
         # 1. Reverse channels if needed
-        if cfg.encoding.from_ != cfg.encoding.to:
+        if cfg.encoding_mismatch:
             split_names = [f"split_{i}_{input_name}" for i in range(3)]
             split_node = helper.make_node(
                 "Split",

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -95,6 +95,9 @@ def onnx_attach_normalization_to_inputs(
             and cfg.mean_values is not None
             and any(v != 0 for v in cfg.mean_values)
         ):
+            if cfg.encoding_mismatch:
+                cfg.mean_values = cfg.mean_values[::-1]
+
             sub_out = f"sub_out_{input_name}"
             sub_node = helper.make_node(
                 "Sub",
@@ -120,6 +123,9 @@ def onnx_attach_normalization_to_inputs(
             and cfg.scale_values is not None
             and any(v != 1 for v in cfg.scale_values)
         ):
+            if cfg.encoding_mismatch:
+                cfg.scale_values = cfg.scale_values[::-1]
+
             div_out = f"div_out_{input_name}"
             div_node = helper.make_node(
                 "Mul",

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -41,7 +41,7 @@ def onnx_attach_normalization_to_inputs(
             continue
         cfg = input_configs[input_name]
         if (
-            not cfg.reverse_input_channels
+            cfg.encoding.from_ == cfg.encoding.to
             and cfg.mean_values is None
             and cfg.scale_values is None
         ):
@@ -70,7 +70,7 @@ def onnx_attach_normalization_to_inputs(
         last_output = input_name
 
         # 1. Reverse channels if needed
-        if cfg.reverse_input_channels:
+        if cfg.encoding.from_ != cfg.encoding.to:
             split_names = [f"split_{i}_{input_name}" for i in range(3)]
             split_node = helper.make_node(
                 "Split",

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -89,8 +89,12 @@ def onnx_attach_normalization_to_inputs(
             new_nodes.append(concat_node)
             last_output = f"normalized_{input_name}"
 
-        # 2. Subtract (mean) if mean_values is not None
-        if not reverse_only and cfg.mean_values is not None:
+        # 2. Subtract (mean) if mean_values is not None and not all 0
+        if (
+            not reverse_only
+            and cfg.mean_values is not None
+            and any(v != 0 for v in cfg.mean_values)
+        ):
             sub_out = f"sub_out_{input_name}"
             sub_node = helper.make_node(
                 "Sub",
@@ -110,8 +114,12 @@ def onnx_attach_normalization_to_inputs(
             )
             new_initializers.append(mean_tensor)
 
-        # 3. Divide (scale) if scale_values is not None
-        if not reverse_only and cfg.scale_values is not None:
+        # 3. Divide (scale) if scale_values is not None and not all 1
+        if (
+            not reverse_only
+            and cfg.scale_values is not None
+            and any(v != 1 for v in cfg.scale_values)
+        ):
             div_out = f"div_out_{input_name}"
             div_node = helper.make_node(
                 "Mul",

--- a/modelconverter/utils/types.py
+++ b/modelconverter/utils/types.py
@@ -24,6 +24,7 @@ class DataType(Enum):
     FLOAT16 = "float16"
     FLOAT32 = "float32"
     FLOAT64 = "float64"
+    INT4 = "int4"
     INT8 = "int8"
     INT16 = "int16"
     INT32 = "int32"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Pillow
 PyYAML
 gcsfs
-luxonis-ml[data,nn_archive] >= 0.4.0
+luxonis-ml[data,nn_archive] >= 0.5.0
 onnx<1.17.0
 onnxruntime
 onnxsim

--- a/shared_with_container/configs/defaults.yaml
+++ b/shared_with_container/configs/defaults.yaml
@@ -94,7 +94,9 @@ stages:
     #    shape: [ 1, 3, 256, 256 ]
     #    data_type: float32 (default)
     #    scale_values: [ 255., 255., 255. ]
-    #    reverse_input_channels: false
+    #    encoding:
+    #      from: RGB
+    #      to: BGR
     #  - name: is_training
     #    freeze_value: false
     #  - name: sequence_len

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -739,10 +739,6 @@ def test_modified_onnx(key: List[str], value: List[str]):
     normalize_inputs = {inp.name: [False, False] for inp in inputs}
     for node in modified_onnx.graph.node:
         if node.op_type == "Split":
-            next_node = modified_onnx.graph.node[
-                modified_onnx.graph.node.index(node) + 1
-            ]
-            assert next_node.op_type == "Concat"
             reverse_inputs[node.input[0]] = True
         elif node.op_type == "Sub":
             inp_name = node.input[1].split("mean_")[1]

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -729,7 +729,7 @@ def test_modified_onnx(keys: List[str], values: List[str]):
     )
     inputs = next(iter(config.stages.values())).inputs
     input_configs = {inp.name: inp for inp in inputs}
-    print(input_configs)
+
     modified_onnx_path = onnx_attach_normalization_to_inputs(
         DATA_DIR / "dummy_model.onnx",
         DATA_DIR / "dummy_model_modified.onnx",


### PR DESCRIPTION
Main changes:
-  Updated the `encoding.from` and `encoding.to` flags to replace the `reverse_input_channels`.
-  Removed `reverse_input_channels`.
-  Added `dai_type` (its still not 100% compatible with all DAI data types).
-  Fixed a bug with mean and scale values on RVC2 conversion with multiple inputs.
-  Removed the extra nodes added to the onnx model when `mean=[0,0,0]` and `scale=[1,1,1]`
-  Added extra unit tests for the encoding
