### PR TITLE
Add link to the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ environ.HUBAI_API_KEY = "your_api_key"
 converted_model = convert("rvc4", path="configs/resnet18.yaml")
 ```
 
+We have prepared several examples for you to check and are actively working on providing more. You can find them [here](https://github.com/luxonis/depthai-ml-training/tree/main/conversion).
+
 > \[!NOTE\]
 > To learn more about the available options, use `modelconverter hub convert --help`.
 


### PR DESCRIPTION
This PR adds the link to the `depthai-ml-training` conversion tutorials.