### PR TITLE
Fix `shutil.move` config

### DIFF
--- a/modelconverter/cli/utils.py
+++ b/modelconverter/cli/utils.py
@@ -85,7 +85,6 @@ def get_configs(
         path_ = resolve_path(path, MISC_DIR)
         if path_.is_dir() or is_nn_archive(path_):
             return process_nn_archive(path_, overrides)
-        shutil.move(str(path_), CONFIGS_DIR / path_.name)
     cfg = Config.get_config(path, overrides)
 
     main_stage_key = None


### PR DESCRIPTION
Removed call to move config from the `--input-path` directory to `shared_with_container/configs` so user files are not silently moved to other places.