### PR TITLE
Fix online conversion to FP32 and FP16

### DIFF
--- a/modelconverter/hub/__main__.py
+++ b/modelconverter/hub/__main__.py
@@ -641,8 +641,8 @@ def convert(
     if path is not None and not is_archive and not is_yaml(path):
         opts.extend(["input_model", path])
 
-    if is_yaml(path):
-        opts.extend(["calibration", "random"])
+    if target_precision in {"FP16", "FP32"}:
+        opts.extend(["disable_calibration", "True"])
 
     config_path = None
     if path and (is_archive or is_yaml(path)):


### PR DESCRIPTION
Disabling calibration when `target_precision` is set to `"FP32"` or `"FP16"`