### PR TITLE
Fix failing build of rvc2-2021.4.0

### DIFF
--- a/docker/rvc2/requirements.txt
+++ b/docker/rvc2/requirements.txt
@@ -1,4 +1,5 @@
 tflite2onnx
 bsdiff4
+tokenizers==0.20.0
 openvino==${VERSION}
 openvino-dev==${VERSION}


### PR DESCRIPTION
Fixed version of `tokenizers` that caused the build of RVC2 image for `2021.4.0` to fail.