### PR TITLE
Fix README Typo: Correct OpenVINO Package File Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,15 +168,15 @@ In order for the images to be build successfully, you need to download additiona
 
 Requires `openvino-<version>.tar.gz` to be present in `docker/extra_packages/`.
 
-- Version `2023.2.0` archive can be downloaded from [here](https://drive.google.com/file/d/1IXtYi1Mwpsg3pr5cDXlEHdSUZlwJRTVP/view?usp=share_link).
+- Version `2022.3.0` archive can be downloaded from [here](https://drive.google.com/file/d/1IXtYi1Mwpsg3pr5cDXlEHdSUZlwJRTVP/view?usp=share_link).
 
 - Version `2021.4.0` archive can be downloaded from [here](https://storage.openvinotoolkit.org/repositories/openvino/packages/2021.4/l_openvino_toolkit_dev_ubuntu20_p_2021.4.582.tgz)
 
-You only need to rename the archive to either `openvino-2023.2.0.tar.gz` or `openvino-2021.4.0.tar.gz` and place it in the `docker/extra_packages` directory.
+You only need to rename the archive to either `openvino-2022.3.0.tar.gz` or `openvino-2021.4.0.tar.gz` and place it in the `docker/extra_packages` directory.
 
 **RVC3**
 
-Only the version `2023.2.0` of `OpenVino` is supported for `RVC3`. Follow the same instructions as for `RVC2` to use the correct archive.
+Only the version `2022.3.0` of `OpenVino` is supported for `RVC3`. Follow the same instructions as for `RVC2` to use the correct archive.
 
 **RVC4**
 


### PR DESCRIPTION
### Description

This pull request fixes a typo in the README regarding the OpenVINO package file name. The README currently instructs users to rename the downloaded file to:

```
openvino-2023.2.0.tar.gz
```

However, the correct file name is:

```
openvino-2022.3.0.tar.gz
```

### Issue

If the incorrect file name is used, the Docker build fails because it cannot find the expected file. For example, running the build command:

```bash
docker build -t luxonis/modelconverter-rvc2 -f docker/rvc2/Dockerfile .
```

results in an error similar to:

```
[+] Building 0.0s (0/0)
2025/02/11 13:24:50 http2: server: error reading preface from client //./pipe/docker_engine: file has already been clos
[+] Building 3.3s (7/26)
 => [internal] load .dockerignore                                                                                 0.0s
 => => transferring context: 70B                                                                                  0.0s
 => [internal] load build definition from Dockerfile                                                              0.0s
 => => transferring dockerfile: 3.69kB                                                                            0.0s
 ...
 => ERROR [base  3/12] COPY --link docker/extra_packages/openvino-2022.3.0.tar.gz .                               0.0s
------
 > [base  3/12] COPY --link docker/extra_packages/openvino-2022.3.0.tar.gz .:
------
Dockerfile:24
--------------------
  22 |     EOF
  23 |
  24 | >>> COPY --link docker/extra_packages/openvino-${VERSION}.tar.gz .
  25 |
  26 |     COPY --link requirements.txt requirements.txt
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref moby::29xj5d9bb442s3aq0ug8lnnru: "/docker/extra_packages/openvino-2022.3.0.tar.gz": not found
```

### How to Reproduce

1. Download the file `openvino_2022_3_vpux_drop_patched.tar.gz` from the provided link.
2. Rename it as instructed in the current README (incorrectly) to `openvino-2023.2.0.tar.gz`.
3. Run the Docker build command:
   ```bash
   docker build -t luxonis/modelconverter-rvc2 -f docker/rvc2/Dockerfile .
   ```
4. Observe the error indicating that the expected file `openvino-2022.3.0.tar.gz` cannot be found.

### Fix

This PR updates the README to instruct users to rename the file to the correct name:

```
openvino-2022.3.0.tar.gz
```

This change ensures that the Docker build process can locate the file and proceed without errors.
```