### PR TITLE
Add hub CLI YOLO models converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ modelconverter hub login
 modelconverter hub convert rvc4 --path configs/resnet18.yaml
 ```
 
+**CLI YOLO Example:**
+
+```bash
+modelconverter hub convert rvc4 --path yolov6nr4.pt --name "YOLOv6R4" --yolo-input-shape "480 480" --yolo-version "yolov6r4" --yolo-class-names "person, rabbit, cactus"
+```
+
 **Python Example:**
 
 ```python

--- a/modelconverter/cli/types.py
+++ b/modelconverter/cli/types.py
@@ -50,6 +50,8 @@ class ModelType(str, Enum):
             return cls.TFLITE
         elif suffix in [".xml", ".bin"]:
             return cls.IR
+        elif suffix in [".pt", ".pth"]:
+            return cls.PYTORCH
         else:
             raise ValueError(f"Unsupported model format: {suffix}")
 
@@ -425,5 +427,43 @@ QuantizationOption = Annotated[
         click_type=click.Choice(
             ["driving", "food", "general", "indoors", "random", "warehouse"]
         ),
+    ),
+]
+
+YoloVersionOption = Annotated[
+    Optional[str],
+    typer.Option(
+        help="YOLO version",
+        click_type=click.Choice(
+            [
+                "yolov5",
+                "yolov6r1",
+                "yolov6r3",
+                "yolov6r4",
+                "yolov7",
+                "yolov8",
+                "yolov9",
+                "yolov10",
+                "yolov11",
+                "goldyolo",
+            ]
+        ),
+        show_default=False,
+    ),
+]
+
+YoloClassNamesOption = Annotated[
+    Optional[List[str]],
+    typer.Option(
+        help="Class names for YOLO model in the format 'class1, class2 ...'",
+        show_default=False,
+    ),
+]
+
+YoloInputShapeOption = Annotated[
+    Optional[str],
+    typer.Option(
+        help="Input shape for YOLO models in the format 'width height' or 'width'",
+        show_default=False,
     ),
 ]

--- a/modelconverter/hub/__main__.py
+++ b/modelconverter/hub/__main__.py
@@ -73,6 +73,7 @@ from modelconverter.cli import (
     wait_for_export,
 )
 from modelconverter.utils import environ
+from modelconverter.utils.types import InputFileType
 
 from .hub_requests import Request
 
@@ -534,7 +535,7 @@ def _export(
         json["class_names"] = yolo_class_names
     if yolo_version and not yolo_class_names:
         logger.warning(
-            "YOLO class names are required for YOLO models. Please provide them using `--yolo-class-names`. Otherwise, default class names will be used."
+            "It's recommended to provide YOLO class names via --yolo-class-names. If omitted, class names will be extracted from model weights if present, otherwise default names will be used."
         )
     if target == "RVC4":
         json["target_precision"] = target_precision
@@ -661,6 +662,11 @@ def convert(
 
     if path is not None and not is_archive and not is_yaml(path):
         opts.extend(["input_model", path])
+        input_file_type = InputFileType.from_path(path)
+        if input_file_type == InputFileType.PYTORCH and yolo_version is None:
+            raise ValueError(
+                "YOLO version is required for PyTorch YOLO models. Use --yolo-version to specify the version."
+            )
 
     if target_precision in {"FP16", "FP32"}:
         opts.extend(["disable_calibration", "True"])

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -317,7 +317,7 @@ class SingleStageConfig(CustomBaseModel):
                 logger.warning(
                     "yolo_input_shape is not provided. Using default shape [640, 640]."
                 )
-            input_shapes = {"images": input_shape}
+            input_shapes = {"images": input_shape[::-1]}
             input_dtypes = {"images": DataType.FLOAT32}
             output_shapes = {"dummy": [0]}
             output_dtypes = {"dummy": DataType.FLOAT32}

--- a/modelconverter/utils/types.py
+++ b/modelconverter/utils/types.py
@@ -229,6 +229,7 @@ class InputFileType(Enum):
     TFLITE = "TFLITE"
     DLC = "DLC"
     HAR = "HAR"
+    PYTORCH = "PYTORCH"
 
     @classmethod
     def from_path(cls, path: Union[str, Path]) -> "InputFileType":
@@ -243,4 +244,6 @@ class InputFileType(Enum):
             return cls.DLC
         if path.suffix == ".har":
             return cls.HAR
+        if path.suffix in [".pt", ".pth"]:
+            return cls.PYTORCH
         raise ValueError(f"Unsupported file type: `{path}`")


### PR DESCRIPTION
## Purpose
Added support for converting YOLO models using the hub CLI.

## Specification
Introduced CLI options for YOLO input shape, version, and class names. Updated model validation to handle YOLO models and enforce required parameters.

## Dependencies & Potential Impact
No breaking changes.

## Deployment Plan
Standard rollout with existing deployment pipeline.

## Testing & Validation
Tested via CLI with different YOLO versions and input configurations.