### PR TITLE
Fix allowed number of threads for RVC4 benchmark

### DIFF
--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -198,7 +198,7 @@ def benchmark(
 
     - `--repetitions`: The number of repetitions to perform (dai-benchmark only). Default: `10`
 
-    - `--num-threads`: The number of threads to use for inference (dai-benchmark only). Default: `1`
+    - `--num-threads`: The number of threads to use for inference (dai-benchmark only). Default: `2`
 
     - `--num-messages`: The number of messages to measure for each report (dai-benchmark only). Default: `50`
 

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -97,7 +97,7 @@ class RVC4Benchmark(Benchmark):
             "num_images": 1000,
             "dai_benchmark": True,
             "repetitions": 10,
-            "num_threads": 1,
+            "num_threads": 2,
             "num_messages": 50,
         }
 
@@ -410,11 +410,7 @@ class RVC4Benchmark(Benchmark):
                     "performance_profile": profile,
                 }
             )
-            if num_threads > 1:
-                logger.warning(
-                    "num_threads > 1 is not supported for RVC4. Setting num_threads to 1."
-                )
-                num_threads = 1
+
             neuralNetwork.setNumInferenceThreads(num_threads)
 
             benchmarkIn = pipeline.create(dai.node.BenchmarkIn)

--- a/requirements-bench.txt
+++ b/requirements-bench.txt
@@ -1,2 +1,2 @@
-depthai>=3.0.0a12
+depthai>=3.0.0a13
 pandas

--- a/requirements-bench.txt
+++ b/requirements-bench.txt
@@ -1,2 +1,2 @@
-depthai>=3.0.0a13
+depthai>=3.0.0a14
 pandas


### PR DESCRIPTION
## Purpose
Update RVC4 benchmark to be able to work with threads > 1.

## Specification
Removed the respective code that was forcing the RVC4 benchmark to only run on a single thread due to some issues with DAI library.

## Dependencies & Potential Impact
No breaking changes.

## Deployment Plan
Standard rollout with existing deployment pipeline.

## Testing & Validation
Tested with various models on different RVC4 devices