### PR TITLE
Tansform hub cli tasks argument to uppercase

### DIFF
--- a/modelconverter/cli/types.py
+++ b/modelconverter/cli/types.py
@@ -254,6 +254,9 @@ TasksOption = Annotated[
                 "image_embedding",
             ]
         ),
+        callback=lambda _, value: [item.upper() for item in value]
+        if value
+        else None,
     ),
 ]
 


### PR DESCRIPTION
## Purpose  
Transform the hub cli `--tasks `argument to upper case for consistency with Hub BE.  Using lower case resulted in an error.

## Specification  
Converted input values to upper case using a callback function in `modelconverter/cli/types.py`.  

## Dependencies & Potential Impact  
No breaking changes expected.  

## Deployment Plan  
No special deployment steps required.  

## Testing & Validation  
Basic functionality verified.