### PR TITLE
Feature: Dealing with dynamic batch size

### DIFF
--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -159,6 +159,16 @@ class InputConfig(OutputConfig):
 
         return self
 
+    @model_validator(mode="after")
+    def _validate_dynamic_batch_size(self) -> Self:
+        if self.shape is not None and self.shape[0] == 0:
+            logger.info(
+                "Detected dynamic batch size (the first element "
+                "of the shape is set to 0). Setting batch size to 1. "
+            )
+            self.shape[0] = 1
+        return self
+
     @model_validator(mode="before")
     @classmethod
     def _validate_encoding(cls, data: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Some ONNX models (like the `mnist.onnx` we use for testing) are exported with a dynamic batch size. This makes it less flexible to work with unless the user explicitly provides the input shapes. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
When a dynamic batch size is detected, it is set to 1.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable