### PR TITLE
Remove `number_of_cmx_slices` from RVC2 config.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+    python: python3
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.2

--- a/modelconverter/packages/rvc2/exporter.py
+++ b/modelconverter/packages/rvc2/exporter.py
@@ -40,7 +40,7 @@ class RVC2Exporter(Exporter):
         super().__init__(config=config, output_dir=output_dir)
         self.compress_to_fp16 = config.rvc2.compress_to_fp16
         self.number_of_shaves = config.rvc2.number_of_shaves
-        self.number_of_cmx_slices = config.rvc2.number_of_cmx_slices
+        self.number_of_cmx_slices = config.rvc2.number_of_shaves
         self.superblob = config.rvc2.superblob
         self.mo_args = config.rvc2.mo_args
         self.compile_tool_args = config.rvc2.compile_tool_args

--- a/modelconverter/packages/rvc2/exporter.py
+++ b/modelconverter/packages/rvc2/exporter.py
@@ -40,6 +40,7 @@ class RVC2Exporter(Exporter):
         super().__init__(config=config, output_dir=output_dir)
         self.compress_to_fp16 = config.rvc2.compress_to_fp16
         self.number_of_shaves = config.rvc2.number_of_shaves
+        # Setting the number_of_cmx_slices equal to the number_of_shaves is intentional from the DAI's perspective to maximize RVC2 pipeline performance.
         self.number_of_cmx_slices = config.rvc2.number_of_shaves
         self.superblob = config.rvc2.superblob
         self.mo_args = config.rvc2.mo_args

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -248,9 +248,10 @@ class RVC2Config(BlobBaseConfig):
     superblob: bool = True
 
     @model_validator(mode="after")
-    def _validate_cmx_slices(self) -> Self:
-        if self.superblob:
-            self.number_of_cmx_slices = self.number_of_shaves = 8
+    def _validate_superblob(self) -> Self:
+        if self.superblob and self.number_of_shaves != 8:
+            logger.warning("Changing number_of_shaves to 8 for superblob.")
+            self.numer_of_shaves = 8
 
         return self
 

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -245,7 +245,6 @@ class BlobBaseConfig(TargetConfig):
 
 class RVC2Config(BlobBaseConfig):
     number_of_shaves: int = 8
-    number_of_cmx_slices: int = 8
     superblob: bool = True
 
     @model_validator(mode="after")
@@ -253,14 +252,6 @@ class RVC2Config(BlobBaseConfig):
         if self.superblob:
             self.number_of_cmx_slices = self.number_of_shaves = 8
 
-        elif self.number_of_cmx_slices < self.number_of_shaves:
-            logger.warning(
-                "Number of CMX slices must be greater than or equal "
-                "to the number of shaves. "
-                "Setting `number_of_cmx_slices` to "
-                f"`number_of_shaves` ({self.number_of_shaves})."
-            )
-            self.number_of_cmx_slices = self.number_of_shaves
         return self
 
 

--- a/shared_with_container/configs/defaults.yaml
+++ b/shared_with_container/configs/defaults.yaml
@@ -144,9 +144,6 @@ stages:
       # Specifies number of shaves.
       number_of_shaves: 8
 
-      # Specifies number of CMX slices.
-      number_of_cmx_slices: 8
-
       # List of additional arguments to pass to the model optimizer.
       # The additional arguments are passed as-is and always take precedence
       # over the default arguments.

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -44,7 +44,6 @@ DEFAULT_TARGET_CONFIGS = {
         "compile_tool_args": [],
         "superblob": True,
         "number_of_shaves": 8,
-        "number_of_cmx_slices": 8,
         "disable_calibration": False,
         "compress_to_fp16": True,
     },


### PR DESCRIPTION
## Purpose
Remove the number_of_cmx_slices from RVC2 config which caused some performance drop when deploying models with DAI.

## Specification
Removed number_of_cmx_slices as an option from RVC2 config and always set this equal to the number_of_shaves.

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
None / not applicable