### PR TITLE
Fix typo on RVC2Config number_of_shaves

### DIFF
--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -252,7 +252,7 @@ class RVC2Config(BlobBaseConfig):
     def _validate_superblob(self) -> Self:
         if self.superblob and self.number_of_shaves != 8:
             logger.warning("Changing number_of_shaves to 8 for superblob.")
-            self.numer_of_shaves = 8
+            self.number_of_shaves = 8
 
         return self
 


### PR DESCRIPTION
## Purpose
Fix a typo form previous [PR](https://github.com/luxonis/modelconverter/pull/86) on RVC2Config number_of_shaves.

## Specification
Fixing a typo on class attribute `numer_of_shaves` -> `number_of_shaves`

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
None / not applicable