### PR TITLE
Add workflow_call support in unittests workflow

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -68,12 +68,16 @@ jobs:
       run: python -m pip install -e .[dev] --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
 
     - name: Install specified luxonis-ml
+      shell: bash
       env:
         ML_REF: ${{ inputs.ml_ref || steps.determine-refs.outputs.ml_ref }}
       if: ${{ github.event_name != 'pull_request' }}
       run: |
-        pip uninstall luxonis-ml -y;
-        pip install "luxonis-ml[data,nn_archive] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" --upgrade --force-reinstall
+        pip uninstall luxonis-ml -y
+        pip install \
+          "luxonis-ml[data,nn_archive] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" \
+          --upgrade --force-reinstall
+
 
     - name: Run Unit Tests
       working-directory: modelconverter

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -72,7 +72,7 @@ jobs:
         ML_REF: ${{ inputs.ml_ref || steps.determine-refs.outputs.ml_ref }}
       if: ${{ github.event_name != 'pull_request' }}
       run: |
-        pip uninstall luxonis-ml -y
+        pip uninstall luxonis-ml -y;
         pip install "luxonis-ml[data,nn_archive] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" --upgrade --force-reinstall
 
     - name: Run Unit Tests

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -68,11 +68,10 @@ jobs:
       run: python -m pip install -e .[dev] --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
 
     - name: Install specified luxonis-ml
-      if: ${{ github.event_name != 'pull_request'}}
+      if: ${{ github.event_name != 'pull_request' }}
       run: |
-        pip uninstall luxonis-ml -y || true
-        pip install "luxonis-ml[data,nn_archive] @ git+https://github.com/luxonis/luxonis-ml.git@${{ inputs.ml_ref || steps.determine-refs.outputs.ml_ref }}" \
-          --upgrade --force-reinstall
+        pip uninstall luxonis-ml -y;
+        pip install "luxonis-ml[data,nn_archive] @ git+https://github.com/luxonis/luxonis-ml.git@${{ inputs.ml_ref || steps.determine-refs.outputs.ml_ref }}" --upgrade --force-reinstall
 
     - name: Run Unit Tests
       working-directory: modelconverter

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -43,8 +43,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout at conv_ref (workflow_call)
-      if: ${{ github.event_name == 'workflow_call' }}
+    - name: Checkout at conv_ref
+      if: ${{ github.event_name != 'pull_request' }}
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.conv_ref }}
@@ -63,7 +63,7 @@ jobs:
       run: python -m pip install -e .[dev] --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
 
     - name: Install specified luxonis-ml
-      if: ${{ github.event_name == 'workflow_call' }}
+      if: ${{ github.event_name != 'pull_request'}}
       run: |
         pip uninstall luxonis-ml -y || true
         pip install "luxonis-ml[all] @ git+https://github.com/luxonis/luxonis-ml.git@${{ inputs.ml_ref || steps.determine-refs.outputs.ml_ref }}" \

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -20,6 +20,19 @@ on:
         description: 'modelconverter version (branch/tag/SHA)'
         required: true
         type: string
+  
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_S3_ENDPOINT_URL:
+        required: true
+      GCP_CREDENTIALS:
+        description: 'Google service account JSON'
+        required: true
+      HUBAI_API_KEY:
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - name: Checkout at modelconv_ref
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ inputs.modelconv_ref != '' }}
       uses: actions/checkout@v4
       with:
         repository: Luxonis/modelconverter
@@ -71,7 +71,7 @@ jobs:
       shell: bash
       env:
         ML_REF: ${{ inputs.ml_ref || steps.determine-refs.outputs.ml_ref }}
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ inputs.ml_ref != '' }}
       run: |
         pip uninstall luxonis-ml -y
         pip install \

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -68,10 +68,12 @@ jobs:
       run: python -m pip install -e .[dev] --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
 
     - name: Install specified luxonis-ml
+      env:
+        ML_REF: ${{ inputs.ml_ref || steps.determine-refs.outputs.ml_ref }}
       if: ${{ github.event_name != 'pull_request' }}
       run: |
-        pip uninstall luxonis-ml -y;
-        pip install "luxonis-ml[data,nn_archive] @ git+https://github.com/luxonis/luxonis-ml.git@${{ inputs.ml_ref || steps.determine-refs.outputs.ml_ref }}" --upgrade --force-reinstall
+        pip uninstall luxonis-ml -y
+        pip install "luxonis-ml[data,nn_archive] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" --upgrade --force-reinstall
 
     - name: Run Unit Tests
       working-directory: modelconverter

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -70,7 +70,7 @@ jobs:
     - name: Install specified luxonis-ml
       shell: bash
       env:
-        ML_REF: ${{ inputs.ml_ref || steps.determine-refs.outputs.ml_ref }}
+        ML_REF: ${{ inputs.ml_ref }}
       if: ${{ inputs.ml_ref != '' }}
       run: |
         pip uninstall luxonis-ml -y

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -10,6 +10,17 @@ on:
       - 'modelconverter/**'
       - '.github/workflows/unittests.yaml'
 
+  workflow_call:
+    inputs:
+      ml_ref:
+        description: 'luxonis-ml version (branch/tag/SHA)'
+        required: true
+        type: string
+      conv_ref:
+        description: 'modelconverter version (branch/tag/SHA)'
+        required: true
+        type: string
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -19,7 +30,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout at conv_ref (workflow_call)
+      if: ${{ github.event_name == 'workflow_call' }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.conv_ref }}
+
     - name: Checkout code
+      if: ${{ github.event_name == 'pull_request' }}
       uses: actions/checkout@v4
 
     - name: Set up Python
@@ -30,6 +48,13 @@ jobs:
 
     - name: Install package
       run: python -m pip install -e .[dev] --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
+
+    - name: Install specified luxonis-ml
+      if: ${{ github.event_name == 'workflow_call' }}
+      run: |
+        pip uninstall luxonis-ml -y || true
+        pip install "luxonis-ml[all] @ git+https://github.com/luxonis/luxonis-ml.git@${{ inputs.ml_ref || steps.determine-refs.outputs.ml_ref }}" \
+          --upgrade --force-reinstall
 
     - name: Run Unit Tests
       env:

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -47,11 +47,15 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.conv_ref }}
+        repository: Luxonis/modelconverter
+        ref:        ${{ inputs.conv_ref }}
+        path:       modelconverter
 
     - name: Checkout code
       if: ${{ github.event_name == 'pull_request' }}
       uses: actions/checkout@v4
+      with:
+        path: modelconverter
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -60,6 +64,7 @@ jobs:
         cache: pip
 
     - name: Install package
+      working-directory: modelconverter
       run: python -m pip install -e .[dev] --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/
 
     - name: Install specified luxonis-ml
@@ -70,6 +75,7 @@ jobs:
           --upgrade --force-reinstall
 
     - name: Run Unit Tests
+      working-directory: modelconverter
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -16,7 +16,7 @@ on:
         description: 'luxonis-ml version (branch/tag/SHA)'
         required: true
         type: string
-      conv_ref:
+      modelconv_ref:
         description: 'modelconverter version (branch/tag/SHA)'
         required: true
         type: string
@@ -43,12 +43,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout at conv_ref
+    - name: Checkout at modelconv_ref
       if: ${{ github.event_name != 'pull_request' }}
       uses: actions/checkout@v4
       with:
         repository: Luxonis/modelconverter
-        ref:        ${{ inputs.conv_ref }}
+        ref:        ${{ inputs.modelconv_ref }}
         path:       modelconverter
 
     - name: Checkout code
@@ -71,7 +71,7 @@ jobs:
       if: ${{ github.event_name != 'pull_request'}}
       run: |
         pip uninstall luxonis-ml -y || true
-        pip install "luxonis-ml[all] @ git+https://github.com/luxonis/luxonis-ml.git@${{ inputs.ml_ref || steps.determine-refs.outputs.ml_ref }}" \
+        pip install "luxonis-ml[data,nn_archive] @ git+https://github.com/luxonis/luxonis-ml.git@${{ inputs.ml_ref || steps.determine-refs.outputs.ml_ref }}" \
           --upgrade --force-reinstall
 
     - name: Run Unit Tests


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

**PR Description:**  
- Introduce `workflow_call` with `ml_ref` and `conv_ref` inputs  
- Checkout `modelconverter` at specified ref when invoked externally  
- Install the target `luxonis-ml` version via `ml_ref`  
- Preserve existing behavior for PR-triggered runs  
- Enables BOM tests on external repos to validate integration in `modelconverter`


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable