### PR TITLE
Docs: Migration from `blobconverter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ In the NN Archive configuration, there are two flags related to color encoding c
 
 The preferred way of using ModelConverter is in the online mode, where the conversion is performed on a remote server.
 
+For more detailed documentation on the online conversion, please refer to the documentation available [here](modelconverter/hub/README.md).
+
 To start with the online conversion, you need to create an account on the [HubAI](https://hub.luxonis.com) platform and obtain the API key for your team.
 
 To log in to HubAI, use the following command:
@@ -152,7 +154,7 @@ from modelconverter.utils import environ
 
 environ.HUBAI_API_KEY = "your_api_key"
 
-converted_model = convert("rvc4", path="configs/resnet18.yaml")
+converted_model = convert.RVC4("configs/resnet18.yaml")
 ```
 
 We have prepared several examples for you to check and are actively working on providing more. You can find them [here](https://github.com/luxonis/depthai-ml-training/tree/main/conversion).

--- a/modelconverter/cli/utils.py
+++ b/modelconverter/cli/utils.py
@@ -84,7 +84,7 @@ def init_dirs() -> None:
 
 
 def get_configs(
-    path: str | None, opts: list[str] | None = None
+    path: str | None, opts: list[str] | dict[str, Any] | None = None
 ) -> tuple[Config, NNArchiveConfig | None, str | None]:
     """Sets up the configuration.
 
@@ -98,11 +98,16 @@ def get_configs(
     """
 
     opts = opts or []
-    if len(opts) % 2 != 0:
-        raise ValueError(
-            "Invalid number of overrides. See --help for more information."
-        )
-    overrides: Params = {opts[i]: opts[i + 1] for i in range(0, len(opts), 2)}
+    if isinstance(opts, list):
+        if len(opts) % 2 != 0:
+            raise ValueError(
+                "Invalid number of overrides. See --help for more information."
+            )
+        overrides: Params = {
+            opts[i]: opts[i + 1] for i in range(0, len(opts), 2)
+        }
+    else:
+        overrides = opts
     if path is not None:
         path_ = resolve_path(path, MISC_DIR)
         if path_.is_dir() or is_nn_archive(path_):

--- a/modelconverter/hub/README.md
+++ b/modelconverter/hub/README.md
@@ -298,3 +298,8 @@ blob = convert.RVC2(
 ### `Caffe` Conversion
 
 Conversion from the `Caffe` framework is not supported.
+
+## CLI Reference
+
+The conversion can be also done using the command line interface.
+See `modelconverter hub --help` for the full list of options.

--- a/modelconverter/hub/README.md
+++ b/modelconverter/hub/README.md
@@ -1,0 +1,169 @@
+# Online Conversion
+
+Besides offline conversion, `modelconverter` can be also used for online conversion of models using [HubAI](https://hub.luxonis.com/ai).
+
+## Migration from `blobconverter`
+
+[BlobConverter](https://pypi.org/project/blobconverter/) is our previous library for converting models to the BLOB format usable with `RVC2` and `RVC3` devices. This library is being replaced by `modelconverter`, which eventually become the only supported way of converting models in the future.
+
+The following table shows the mapping between the parameters of `blobconverter` and `modelconverter`. The parameters are grouped by their purpose. The first column shows the parameters of `blobconverter`, the second column shows the equivalent parameters in `modelconverter`, and the third column contains additional notes.
+
+| `blobconverter`    | `modelconverter`    | Notes                                                                                                     |
+| ------------------ | ------------------- | --------------------------------------------------------------------------------------------------------- |
+| `model`            | `path`              | The model file path.                                                                                      |
+| `xml`              | `path`              | The XML file path. Only for conversion from OpenVINO IR                                                   |
+| `bin`              | `opts["input_bin"]` | The BIN file path. Only for conversion from OpenVINO IR. See the [example](#conversion-from-openvino-ir). |
+| `version`          | `tool_version`      | The version of the conversion tool.                                                                       |
+| `data_type`        | `target_precision`  | The precision of the model.                                                                               |
+| `shaves`           | `number_of_shaves`  | The number of shaves to use.                                                                              |
+| `optimizer_params` | `mo_args`           | The arguments to pass to the model optimizer.                                                             |
+| `compile_params`   | `compile_tool_args` | The arguments to pass to the BLOB compiler.                                                               |
+
+### Simple Conversion
+
+**Simple ONNX conversion using `blobconverter`**
+
+```python
+
+import blobconverter
+
+blob = blobconverter.from_onnx(
+    model="resnet18.onnx",
+)
+```
+
+**Equivalent code using `modelconverter.hub.convert.RVC2`**
+
+```python
+from modelconverter.hub import convert
+
+blob = convert.RVC2(
+    path="resnet18.onnx",
+)
+```
+
+### Conversion from OpenVINO IR
+
+**`blobconverter` example**
+
+```python
+import blobconverter
+
+blob = blobconverter.from_openvino(
+    xml="resnet18.xml",
+    bin="resnet18.bin",
+)
+```
+
+**`modelconverter` example**
+
+```python
+from modelconverter.hub import convert
+
+# When the XML and BIN files are at the same location,
+# only the XML needs to be specified
+blob = convert.RVC2("resnet18.xml")
+
+# Otherwise, the BIN file can be specified using
+# the `opts` parameter
+blob = convert.RVC2(
+    path="resnet18.xml",
+    opts={
+        "input_bin": "resnet18.bin",
+    }
+)
+```
+
+### Conversion from `tflite`
+
+> \[!WARNING\]
+> `modelconverter` does not support conversion from frozen PB files, only TFLITE files are supported.
+
+`blobconverter`
+
+```python
+
+import blobconverter
+
+blob = blobconverter.from_tf(
+    frozen_pb="resnet18.tflite",
+)
+```
+
+**Equivalent code using `modelconverter.hub.convert.RVC2`**
+
+```python
+from modelconverter.hub import convert
+
+blob = convert.RVC2(
+    path="resnet18.tflite",
+
+)
+```
+
+### RVC3 Conversion
+
+**Simple ONNX conversion using `blobconverter`**
+
+```python
+
+import blobconverter
+
+blob = blobconverter.from_onnx(
+    model="resnet18.onnx",
+    version="2022.3_RVC3",
+)
+```
+
+**Equivalent code using `modelconverter.hub.convert.RVC3`**
+
+```python
+from modelconverter.hub import convert
+
+blob = convert.RVC3(
+    path="resnet18.onnx",
+)
+```
+
+### Advanced Parameters
+
+**`blobconverter.from_onnx` with advanced parameters**
+
+```python
+import blobconverter
+
+blob = blobconverter.from_onnx(
+    model="resnet18.onnx",
+    data_type="FP16",
+    version="2021.4",
+    shaves=6,
+    optimizer_params=[
+        "--mean_values=[127.5,127.5,127.5]",
+        "--scale_values=[255,255,255]",
+    ],
+    compile_params=["-ip U8"],
+
+)
+```
+
+**Equivalent code using `modelconverter`**
+
+```python
+from modelconverter.hub import convert
+
+blob = convert.RVC2(
+    path="resnet18.onnx",
+    target_precision="FP16",
+    tool_version="2021.4.0",
+    number_of_shaves=6,
+    mo_args=[
+        "mean_values=[127.5,127.5,127.5]",
+        "scale_values=[255,255,255]"
+    ],
+    compile_tool_args=["-ip", "U8"],
+)
+```
+
+### `Caffe` Conversion
+
+Conversion from the `Caffe` framework is not supported.

--- a/modelconverter/hub/README.md
+++ b/modelconverter/hub/README.md
@@ -44,18 +44,18 @@ These parameters are only relevant if you're converting a YOLO model.
 
 Parameters that specify creation of a new `Model` resource on HubAI.
 
-| argument            | type                                                                                                                                                                                                          | description                                                                                  |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `model_id`          | `str?`                                                                                                                                                                                                        | The ID of an already existing model in case you don't want to create a new `Model` resource. |
-| `name`              | `str?`                                                                                                                                                                                                        | The name of the model. If undefined, it will be the same as the stem of the model file.      |
-| `license_type`      | `Literal["undefined", "MIT", "GNU General Public License v3.0", "GNU Affero General Public License v3.0", "Apache 2.0", "NTU S-Lab 1.0", "Ultralytics Enterprise", "CreativeML Open RAIL-M", "BSD 3-Clause"]` | The license type of the model.                                                               |
-| `is_public`         | `bool?`                                                                                                                                                                                                       | Whether the model is public or private.                                                      |
-| `description`       | `str?`                                                                                                                                                                                                        | The full description of the model.                                                           |
-| `description_short` | `str?`                                                                                                                                                                                                        | The short description of the model. Defaults to `"<empty>"`                                  |
-| `architecture_id`   | `str?`                                                                                                                                                                                                        | The architecture ID of the model.                                                            |
-| `tasks`             | `list[str]?`                                                                                                                                                                                                  | The tasks of the model.                                                                      |
-| `links`             | `list[str]?`                                                                                                                                                                                                  | Additional links for the model.                                                              |
-| `is_yolo`           | `bool?`                                                                                                                                                                                                       | Whether the model is a YOLO model.                                                           |
+| argument            | type                                                                                                                                                                                                                                                                        | description                                                                                  |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `model_id`          | `str?`                                                                                                                                                                                                                                                                      | The ID of an already existing model in case you don't want to create a new `Model` resource. |
+| `name`              | `str?`                                                                                                                                                                                                                                                                      | The name of the model. If undefined, it will be the same as the stem of the model file.      |
+| `license_type`      | `Literal["undefined", "MIT", "GNU General Public License v3.0", "GNU Affero General Public License v3.0", "Apache 2.0", "NTU S-Lab 1.0", "Ultralytics Enterprise", "CreativeML Open RAIL-M", "BSD 3-Clause"]`                                                               | The license type of the model.                                                               |
+| `is_public`         | `bool?`                                                                                                                                                                                                                                                                     | Whether the model is public or private.                                                      |
+| `description`       | `str?`                                                                                                                                                                                                                                                                      | The full description of the model.                                                           |
+| `description_short` | `str?`                                                                                                                                                                                                                                                                      | The short description of the model. Defaults to `"<empty>"`                                  |
+| `architecture_id`   | `str?`                                                                                                                                                                                                                                                                      | The architecture ID of the model.                                                            |
+| `tasks`             | `list[Literal["classification", "object_detection", "segmentation", "keypoint_detection", "depth_estimation", "line_detection", "feature_detection", "denoising", "low_light_enhancement", "super_resolution", "regression", "instance_segmentation", "image_embedding"]]?` | The tasks of the model.                                                                      |
+| `links`             | `list[str]?`                                                                                                                                                                                                                                                                | Additional links for the model.                                                              |
+| `is_yolo`           | `bool?`                                                                                                                                                                                                                                                                     | Whether the model is a YOLO model.                                                           |
 
 **Model Variant Parameters**
 
@@ -75,17 +75,18 @@ Parameters that specify creation of a new `ModelVersion` resource on HubAI.
 
 Parameters that specify creation of a new `ModelInstance` resource on HubAI.
 
-| argument               | type         | description                                                                                                              |
-| ---------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------ |
-| `variant_id`           | `str`        | The ID of the associated variant. Use in case you want to add a new model instance to an already existing model variant. |
-| `parent_id`            | `str?`       | Unique identifier of the parent `ModelInstance`.                                                                         |
-| `model_precision_type` | `str?`       | The precision type of the model.                                                                                         |
-| `quantization_data`    | `str?`       | The domain of data used to quantize this `ModelInstance`.                                                                |
-| `tags`                 | `list[str]?` | Tags associated with this instance.                                                                                      |
-| `input_shape`          | `list[int]?` | The input shape of the model.                                                                                            |
-| `is_deployable`        | `bool?`      | Whether the model is deployable.                                                                                         |
+| argument               | type                                                                       | description                                                                                                              |
+| ---------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `variant_id`           | `str`                                                                      | The ID of the associated variant. Use in case you want to add a new model instance to an already existing model variant. |
+| `parent_id`            | `str?`                                                                     | Unique identifier of the parent `ModelInstance`.                                                                         |
+| `model_precision_type` | `str?`                                                                     | The precision type of the model.                                                                                         |
+| `quantization_data`    | `Literal["driving", "food", "general", "indoors", "random", "warehouse"]?` | The domain of data used to quantize this `ModelInstance`.                                                                |
+| `tags`                 | `list[str]?`                                                               | Tags associated with this instance.                                                                                      |
+| `input_shape`          | `list[int]?`                                                               | The input shape of the model.                                                                                            |
+| `is_deployable`        | `bool?`                                                                    | Whether the model is deployable.                                                                                         |
 
 **RVC2 Parameters**
+
 Parameters specific to the `RVC2` conversion.
 
 | argument            | type         | description                                                                    |
@@ -97,6 +98,7 @@ Parameters specific to the `RVC2` conversion.
 | `superblob`         | `bool`       | Whether to create a superblob. Defaults to `True`.                             |
 
 **RVC3 Parameters**
+
 Parameters specific to the `RVC3` conversion.
 
 | argument            | type                    | description                                                                    |
@@ -107,6 +109,7 @@ Parameters specific to the `RVC3` conversion.
 | `pot_target_device` | `Literal["VPU", "ANY"]` | The target device for the post-training optimization. Defaults to `"VPU"`.     |
 
 **RVC4 Parameters**
+
 Parameters specific to the `RVC4` conversion.
 
 | argument                       | type         | description                                                  |
@@ -119,6 +122,7 @@ Parameters specific to the `RVC4` conversion.
 | `htp_socs`                     | `list[str]?` | The list of HTP SoCs to use.                                 |
 
 **Hailo Parameters**
+
 Parameters specific to the `Hailo` conversion.
 
 | argument             | type                           | description                                      |

--- a/modelconverter/hub/README.md
+++ b/modelconverter/hub/README.md
@@ -14,6 +14,19 @@ from modelconverter.hub import convert
 converted_model = convert.RVC2("path/to/model.onnx", api_key=api_key)
 ```
 
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Overview](#overview)
+- [Migration from `blobconverter`](#migration-from-blobconverter)
+  - [Simple Conversion](#simple-conversion)
+  - [Conversion from OpenVINO IR](#conversion-from-openvino-ir)
+  - [Conversion from `tflite`](#conversion-from-tflite)
+  - [RVC3 Conversion](#rvc3-conversion)
+  - [Advanced Parameters](#advanced-parameters)
+  - [`Caffe` Conversion](#caffe-conversion)
+- [CLI Reference](#cli-reference)
+
 ## Overview
 
 The Python API for the conversion is available under the `modelconverter.hub.convert` namespace. Specific conversion functions for individual targets (`RVC2`, `RVC3`, etc.) are accessible from the `convert` namespace under the target name, for example `convert.RVC2`, `convert.Hailo`.

--- a/modelconverter/hub/README.md
+++ b/modelconverter/hub/README.md
@@ -24,11 +24,12 @@ The conversion function takes a number of parameters to specify the model and th
 
 General parameters applicable to all conversion functions.
 
-| argument       | type   | description                                                       |
-| -------------- | ------ | ----------------------------------------------------------------- |
-| `path`         | `str`  | The path to the model file.                                       |
-| `tool_version` | `str?` | The version of the conversion tool.                               |
-| `api_key`      | `str?` | The API key for HubAI. Will take precedence over the environment. |
+| argument           | type                              | description                                                       |
+| ------------------ | --------------------------------- | ----------------------------------------------------------------- |
+| `path`             | `str`                             | The path to the model file.                                       |
+| `tool_version`     | `str?`                            | The version of the conversion tool.                               |
+| `target_precision` | `Literal["FP32", "FP16", "INT8"]` | The precision of the model. Defaults to `"INT8"`.                 |
+| `api_key`          | `str?`                            | The API key for HubAI. Will take precedence over the environment. |
 
 **YOLO Parameters**
 

--- a/modelconverter/hub/README.md
+++ b/modelconverter/hub/README.md
@@ -6,7 +6,13 @@ Besides offline conversion, `modelconverter` can be also used for online convers
 
 In order to use the online conversion, you first need to obtain an API key from [HubAI](https://hub.luxonis.com/ai). You can do this by signing up for a free account and generating an API key in the settings.
 
-Once you have the API key
+Once you have the API key, you can run the conversion using the following code:
+
+```python
+from modelconverter.hub import convert
+
+converted_model = convert.RVC2("path/to/model.onnx", api_key=api_key)
+```
 
 ## Overview
 

--- a/modelconverter/hub/README.md
+++ b/modelconverter/hub/README.md
@@ -40,76 +40,76 @@ General parameters applicable to all conversion functions.
 | argument           | type                              | description                                                       |
 | ------------------ | --------------------------------- | ----------------------------------------------------------------- |
 | `path`             | `str`                             | The path to the model file.                                       |
-| `tool_version`     | `str?`                            | The version of the conversion tool.                               |
+| `tool_version`     | `str \| None`                     | The version of the conversion tool.                               |
 | `target_precision` | `Literal["FP32", "FP16", "INT8"]` | The precision of the model. Defaults to `"INT8"`.                 |
-| `api_key`          | `str?`                            | The API key for HubAI. Will take precedence over the environment. |
+| `api_key`          | `str \| None`                     | The API key for HubAI. Will take precedence over the environment. |
 
 **YOLO Parameters**
 
 These parameters are only relevant if you're converting a YOLO model.
 
-| argument           | type         | description                        |
-| ------------------ | ------------ | ---------------------------------- |
-| `yolo_input_shape` | `list[int]?` | The input shape of the YOLO model. |
-| `yolo_version`     | `str?`       | YOLO version.                      |
-| `yolo_class_names` | `list[str]?` | The class names of the model.      |
+| argument           | type                | description                        |
+| ------------------ | ------------------- | ---------------------------------- |
+| `yolo_input_shape` | `list[int] \| None` | The input shape of the YOLO model. |
+| `yolo_version`     | `str \| None`       | YOLO version.                      |
+| `yolo_class_names` | `list[str] \| None` | The class names of the model.      |
 
 **Model Parameters**
 
 Parameters that specify creation of a new `Model` resource on HubAI.
 
-| argument            | type                                                                                                                                                                                                                                                                        | description                                                                                  |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `model_id`          | `str?`                                                                                                                                                                                                                                                                      | The ID of an already existing model in case you don't want to create a new `Model` resource. |
-| `name`              | `str?`                                                                                                                                                                                                                                                                      | The name of the model. If undefined, it will be the same as the stem of the model file.      |
-| `license_type`      | `Literal["undefined", "MIT", "GNU General Public License v3.0", "GNU Affero General Public License v3.0", "Apache 2.0", "NTU S-Lab 1.0", "Ultralytics Enterprise", "CreativeML Open RAIL-M", "BSD 3-Clause"]`                                                               | The license type of the model.                                                               |
-| `is_public`         | `bool?`                                                                                                                                                                                                                                                                     | Whether the model is public or private.                                                      |
-| `description`       | `str?`                                                                                                                                                                                                                                                                      | The full description of the model.                                                           |
-| `description_short` | `str?`                                                                                                                                                                                                                                                                      | The short description of the model. Defaults to `"<empty>"`                                  |
-| `architecture_id`   | `str?`                                                                                                                                                                                                                                                                      | The architecture ID of the model.                                                            |
-| `tasks`             | `list[Literal["classification", "object_detection", "segmentation", "keypoint_detection", "depth_estimation", "line_detection", "feature_detection", "denoising", "low_light_enhancement", "super_resolution", "regression", "instance_segmentation", "image_embedding"]]?` | The tasks of the model.                                                                      |
-| `links`             | `list[str]?`                                                                                                                                                                                                                                                                | Additional links for the model.                                                              |
-| `is_yolo`           | `bool?`                                                                                                                                                                                                                                                                     | Whether the model is a YOLO model.                                                           |
+| argument            | type                                                                                                                                                                                                                                                                               | description                                                                                  |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `model_id`          | `str \| None`                                                                                                                                                                                                                                                                      | The ID of an already existing model in case you don't want to create a new `Model` resource. |
+| `name`              | `str \| None`                                                                                                                                                                                                                                                                      | The name of the model. If undefined, it will be the same as the stem of the model file.      |
+| `license_type`      | `Literal["undefined", "MIT", "GNU General Public License v3.0", "GNU Affero General Public License v3.0", "Apache 2.0", "NTU S-Lab 1.0", "Ultralytics Enterprise", "CreativeML Open RAIL-M", "BSD 3-Clause"]`                                                                      | The license type of the model.                                                               |
+| `is_public`         | `bool \| None`                                                                                                                                                                                                                                                                     | Whether the model is public or private.                                                      |
+| `description`       | `str \| None`                                                                                                                                                                                                                                                                      | The full description of the model.                                                           |
+| `description_short` | `str \| None`                                                                                                                                                                                                                                                                      | The short description of the model. Defaults to `"<empty>"`                                  |
+| `architecture_id`   | `str \| None`                                                                                                                                                                                                                                                                      | The architecture ID of the model.                                                            |
+| `tasks`             | `list[Literal["classification", "object_detection", "segmentation", "keypoint_detection", "depth_estimation", "line_detection", "feature_detection", "denoising", "low_light_enhancement", "super_resolution", "regression", "instance_segmentation", "image_embedding"]] \| None` | The tasks of the model.                                                                      |
+| `links`             | `list[str] \| None`                                                                                                                                                                                                                                                                | Additional links for the model.                                                              |
+| `is_yolo`           | `bool \| None`                                                                                                                                                                                                                                                                     | Whether the model is a YOLO model.                                                           |
 
 **Model Variant Parameters**
 
 Parameters that specify creation of a new `ModelVersion` resource on HubAI.
 
-| argument              | type         | description                                                                                    |
-| --------------------- | ------------ | ---------------------------------------------------------------------------------------------- |
-| `model_id`            | `str?`       | The ID of the model. Use in case you want to add another variant to an already existing model. |
-| `version`             | `str?`       | The version number of the variant. If undefined, an auto-incremented version is used.          |
-| `variant_description` | `str?`       | The full description of the variant.                                                           |
-| `repository_url`      | `str?`       | A URL of a related repository.                                                                 |
-| `commit_hash`         | `str?`       | A commit hash of the related repository.                                                       |
-| `domain`              | `str?`       | The domain of the variant.                                                                     |
-| `tags`                | `list[str]?` | The tags of the variant.                                                                       |
+| argument              | type                | description                                                                                    |
+| --------------------- | ------------------- | ---------------------------------------------------------------------------------------------- |
+| `model_id`            | `str \| None`       | The ID of the model. Use in case you want to add another variant to an already existing model. |
+| `version`             | `str \| None`       | The version number of the variant. If undefined, an auto-incremented version is used.          |
+| `variant_description` | `str \| None`       | The full description of the variant.                                                           |
+| `repository_url`      | `str \| None`       | A URL of a related repository.                                                                 |
+| `commit_hash`         | `str \| None`       | A commit hash of the related repository.                                                       |
+| `domain`              | `str \| None`       | The domain of the variant.                                                                     |
+| `tags`                | `list[str] \| None` | The tags of the variant.                                                                       |
 
 **Model Instance Parameters**
 
 Parameters that specify creation of a new `ModelInstance` resource on HubAI.
 
-| argument               | type                                                                       | description                                                                                                              |
-| ---------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `variant_id`           | `str`                                                                      | The ID of the associated variant. Use in case you want to add a new model instance to an already existing model variant. |
-| `parent_id`            | `str?`                                                                     | Unique identifier of the parent `ModelInstance`.                                                                         |
-| `model_precision_type` | `str?`                                                                     | The precision type of the model.                                                                                         |
-| `quantization_data`    | `Literal["driving", "food", "general", "indoors", "random", "warehouse"]?` | The domain of data used to quantize this `ModelInstance`.                                                                |
-| `tags`                 | `list[str]?`                                                               | Tags associated with this instance.                                                                                      |
-| `input_shape`          | `list[int]?`                                                               | The input shape of the model.                                                                                            |
-| `is_deployable`        | `bool?`                                                                    | Whether the model is deployable.                                                                                         |
+| argument               | type                                                                              | description                                                                                                              |
+| ---------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `variant_id`           | `str`                                                                             | The ID of the associated variant. Use in case you want to add a new model instance to an already existing model variant. |
+| `parent_id`            | `str \| None`                                                                     | Unique identifier of the parent `ModelInstance`.                                                                         |
+| `model_precision_type` | `str \| None`                                                                     | The precision type of the model.                                                                                         |
+| `quantization_data`    | `Literal["driving", "food", "general", "indoors", "random", "warehouse"] \| None` | The domain of data used to quantize this `ModelInstance`.                                                                |
+| `tags`                 | `list[str] \| None`                                                               | Tags associated with this instance.                                                                                      |
+| `input_shape`          | `list[int] \| None`                                                               | The input shape of the model.                                                                                            |
+| `is_deployable`        | `bool \| None`                                                                    | Whether the model is deployable.                                                                                         |
 
 **RVC2 Parameters**
 
 Parameters specific to the `RVC2` conversion.
 
-| argument            | type         | description                                                                    |
-| ------------------- | ------------ | ------------------------------------------------------------------------------ |
-| `mo_args`           | `list[str]?` | The arguments to pass to the model optimizer.                                  |
-| `compile_tool_args` | `list[str]?` | The arguments to pass to the BLOB compiler.                                    |
-| `compress_to_fp16`  | `bool`       | Whether to compress the model's weights to FP16 precision. Defaults to `True`. |
-| `number_of_shaves`  | `int`        | The number of shaves to use. Defaults to `8`.                                  |
-| `superblob`         | `bool`       | Whether to create a superblob. Defaults to `True`.                             |
+| argument            | type                | description                                                                    |
+| ------------------- | ------------------- | ------------------------------------------------------------------------------ |
+| `mo_args`           | `list[str] \| None` | The arguments to pass to the model optimizer.                                  |
+| `compile_tool_args` | `list[str] \| None` | The arguments to pass to the BLOB compiler.                                    |
+| `compress_to_fp16`  | `bool`              | Whether to compress the model's weights to FP16 precision. Defaults to `True`. |
+| `number_of_shaves`  | `int`               | The number of shaves to use. Defaults to `8`.                                  |
+| `superblob`         | `bool`              | Whether to create a superblob. Defaults to `True`.                             |
 
 **RVC3 Parameters**
 
@@ -117,8 +117,8 @@ Parameters specific to the `RVC3` conversion.
 
 | argument            | type                    | description                                                                    |
 | ------------------- | ----------------------- | ------------------------------------------------------------------------------ |
-| `mo_args`           | `list[str]?`            | The arguments to pass to the model optimizer.                                  |
-| `compile_tool_args` | `list[str]?`            | The arguments to pass to the BLOB compiler.                                    |
+| `mo_args`           | `list[str] \| None`     | The arguments to pass to the model optimizer.                                  |
+| `compile_tool_args` | `list[str] \| None`     | The arguments to pass to the BLOB compiler.                                    |
 | `compress_to_fp16`  | `bool`                  | Whether to compress the model's weights to FP16 precision. Defaults to `True`. |
 | `pot_target_device` | `Literal["VPU", "ANY"]` | The target device for the post-training optimization. Defaults to `"VPU"`.     |
 
@@ -126,14 +126,14 @@ Parameters specific to the `RVC3` conversion.
 
 Parameters specific to the `RVC4` conversion.
 
-| argument                       | type         | description                                                  |
-| ------------------------------ | ------------ | ------------------------------------------------------------ |
-| `snpe_onnx_to_dlc_args`        | `list[str]?` | The arguments to pass to the `snpe-onnx-to-dlc` tool.        |
-| `snpe_dlc_quant_args`          | `list[str]?` | The arguments to pass to the `snpe-dlc-quant` tool.          |
-| `snpe_dlc_graph_prepare_args`  | `list[str]?` | The arguments to pass to the `snpe-dlc-graph-prepare` tool.  |
-| `use_per_channel_quantization` | `bool`       | Whether to use per-channel quantization. Defaults to `True`. |
-| `use_per_row_quantization`     | `bool`       | Whether to use per-row quantization. Defaults to `False`.    |
-| `htp_socs`                     | `list[str]?` | The list of HTP SoCs to use.                                 |
+| argument                       | type                | description                                                  |
+| ------------------------------ | ------------------- | ------------------------------------------------------------ |
+| `snpe_onnx_to_dlc_args`        | `list[str] \| None` | The arguments to pass to the `snpe-onnx-to-dlc` tool.        |
+| `snpe_dlc_quant_args`          | `list[str] \| None` | The arguments to pass to the `snpe-dlc-quant` tool.          |
+| `snpe_dlc_graph_prepare_args`  | `list[str] \| None` | The arguments to pass to the `snpe-dlc-graph-prepare` tool.  |
+| `use_per_channel_quantization` | `bool`              | Whether to use per-channel quantization. Defaults to `True`. |
+| `use_per_row_quantization`     | `bool`              | Whether to use per-row quantization. Defaults to `False`.    |
+| `htp_socs`                     | `list[str] \| None` | The list of HTP SoCs to use.                                 |
 
 **Hailo Parameters**
 
@@ -144,7 +144,7 @@ Parameters specific to the `Hailo` conversion.
 | `optimization_level` | `Literal[-100, 0, 1, 2, 3, 4]` | The optimization level to use.                   |
 | `compression_level`  | `Literal[0, 1, 2, 3, 4, 5]`    | The compression level to use.                    |
 | `batch_size`         | `int`                          | The batch size to use for quantization.          |
-| `alls`               | `list[str]?`                   | The list of additional `alls` parameters to use. |
+| `alls`               | `list[str] \| None`            | The list of additional `alls` parameters to use. |
 
 ## Migration from `blobconverter`
 

--- a/modelconverter/hub/README.md
+++ b/modelconverter/hub/README.md
@@ -1,6 +1,126 @@
 # Online Conversion
 
-Besides offline conversion, `modelconverter` can be also used for online conversion of models using [HubAI](https://hub.luxonis.com/ai).
+Besides offline conversion, `modelconverter` can be also used for online conversion which is powered by [HubAI](https://hub.luxonis.com/ai).
+
+## Quick Start
+
+In order to use the online conversion, you first need to obtain an API key from [HubAI](https://hub.luxonis.com/ai). You can do this by signing up for a free account and generating an API key in the settings.
+
+Once you have the API key
+
+## Overview
+
+The Python API for the conversion is available under the `modelconverter.hub.convert` namespace. Specific conversion functions for individual targets (`RVC2`, `RVC3`, etc.) are accessible from the `convert` namespace under the target name, for example `convert.RVC2`, `convert.Hailo`.
+
+The conversion function takes a number of parameters to specify the model and the conversion options:
+
+**General Parameters**
+
+General parameters applicable to all conversion functions.
+
+| argument       | type   | description                                                       |
+| -------------- | ------ | ----------------------------------------------------------------- |
+| `path`         | `str`  | The path to the model file.                                       |
+| `tool_version` | `str?` | The version of the conversion tool.                               |
+| `api_key`      | `str?` | The API key for HubAI. Will take precedence over the environment. |
+
+**YOLO Parameters**
+
+These parameters are only relevant if you're converting a YOLO model.
+
+| argument           | type         | description                        |
+| ------------------ | ------------ | ---------------------------------- |
+| `yolo_input_shape` | `list[int]?` | The input shape of the YOLO model. |
+| `yolo_version`     | `str?`       | YOLO version.                      |
+| `yolo_class_names` | `list[str]?` | The class names of the model.      |
+
+**Model Parameters**
+
+Parameters that specify creation of a new `Model` resource on HubAI.
+
+| argument            | type                                                                                                                                                                                                          | description                                                                                  |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `model_id`          | `str?`                                                                                                                                                                                                        | The ID of an already existing model in case you don't want to create a new `Model` resource. |
+| `name`              | `str?`                                                                                                                                                                                                        | The name of the model. If undefined, it will be the same as the stem of the model file.      |
+| `license_type`      | `Literal["undefined", "MIT", "GNU General Public License v3.0", "GNU Affero General Public License v3.0", "Apache 2.0", "NTU S-Lab 1.0", "Ultralytics Enterprise", "CreativeML Open RAIL-M", "BSD 3-Clause"]` | The license type of the model.                                                               |
+| `is_public`         | `bool?`                                                                                                                                                                                                       | Whether the model is public or private.                                                      |
+| `description`       | `str?`                                                                                                                                                                                                        | The full description of the model.                                                           |
+| `description_short` | `str?`                                                                                                                                                                                                        | The short description of the model. Defaults to `"<empty>"`                                  |
+| `architecture_id`   | `str?`                                                                                                                                                                                                        | The architecture ID of the model.                                                            |
+| `tasks`             | `list[str]?`                                                                                                                                                                                                  | The tasks of the model.                                                                      |
+| `links`             | `list[str]?`                                                                                                                                                                                                  | Additional links for the model.                                                              |
+| `is_yolo`           | `bool?`                                                                                                                                                                                                       | Whether the model is a YOLO model.                                                           |
+
+**Model Variant Parameters**
+
+Parameters that specify creation of a new `ModelVersion` resource on HubAI.
+
+| argument              | type         | description                                                                                    |
+| --------------------- | ------------ | ---------------------------------------------------------------------------------------------- |
+| `model_id`            | `str?`       | The ID of the model. Use in case you want to add another variant to an already existing model. |
+| `version`             | `str?`       | The version number of the variant. If undefined, an auto-incremented version is used.          |
+| `variant_description` | `str?`       | The full description of the variant.                                                           |
+| `repository_url`      | `str?`       | A URL of a related repository.                                                                 |
+| `commit_hash`         | `str?`       | A commit hash of the related repository.                                                       |
+| `domain`              | `str?`       | The domain of the variant.                                                                     |
+| `tags`                | `list[str]?` | The tags of the variant.                                                                       |
+
+**Model Instance Parameters**
+
+Parameters that specify creation of a new `ModelInstance` resource on HubAI.
+
+| argument               | type         | description                                                                                                              |
+| ---------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `variant_id`           | `str`        | The ID of the associated variant. Use in case you want to add a new model instance to an already existing model variant. |
+| `parent_id`            | `str?`       | Unique identifier of the parent `ModelInstance`.                                                                         |
+| `model_precision_type` | `str?`       | The precision type of the model.                                                                                         |
+| `quantization_data`    | `str?`       | The domain of data used to quantize this `ModelInstance`.                                                                |
+| `tags`                 | `list[str]?` | Tags associated with this instance.                                                                                      |
+| `input_shape`          | `list[int]?` | The input shape of the model.                                                                                            |
+| `is_deployable`        | `bool?`      | Whether the model is deployable.                                                                                         |
+
+**RVC2 Parameters**
+Parameters specific to the `RVC2` conversion.
+
+| argument            | type         | description                                                                    |
+| ------------------- | ------------ | ------------------------------------------------------------------------------ |
+| `mo_args`           | `list[str]?` | The arguments to pass to the model optimizer.                                  |
+| `compile_tool_args` | `list[str]?` | The arguments to pass to the BLOB compiler.                                    |
+| `compress_to_fp16`  | `bool`       | Whether to compress the model's weights to FP16 precision. Defaults to `True`. |
+| `number_of_shaves`  | `int`        | The number of shaves to use. Defaults to `8`.                                  |
+| `superblob`         | `bool`       | Whether to create a superblob. Defaults to `True`.                             |
+
+**RVC3 Parameters**
+Parameters specific to the `RVC3` conversion.
+
+| argument            | type                    | description                                                                    |
+| ------------------- | ----------------------- | ------------------------------------------------------------------------------ |
+| `mo_args`           | `list[str]?`            | The arguments to pass to the model optimizer.                                  |
+| `compile_tool_args` | `list[str]?`            | The arguments to pass to the BLOB compiler.                                    |
+| `compress_to_fp16`  | `bool`                  | Whether to compress the model's weights to FP16 precision. Defaults to `True`. |
+| `pot_target_device` | `Literal["VPU", "ANY"]` | The target device for the post-training optimization. Defaults to `"VPU"`.     |
+
+**RVC4 Parameters**
+Parameters specific to the `RVC4` conversion.
+
+| argument                       | type         | description                                                  |
+| ------------------------------ | ------------ | ------------------------------------------------------------ |
+| `snpe_onnx_to_dlc_args`        | `list[str]?` | The arguments to pass to the `snpe-onnx-to-dlc` tool.        |
+| `snpe_dlc_quant_args`          | `list[str]?` | The arguments to pass to the `snpe-dlc-quant` tool.          |
+| `snpe_dlc_graph_prepare_args`  | `list[str]?` | The arguments to pass to the `snpe-dlc-graph-prepare` tool.  |
+| `use_per_channel_quantization` | `bool`       | Whether to use per-channel quantization. Defaults to `True`. |
+| `use_per_row_quantization`     | `bool`       | Whether to use per-row quantization. Defaults to `False`.    |
+| `htp_socs`                     | `list[str]?` | The list of HTP SoCs to use.                                 |
+
+**Hailo Parameters**
+Parameters specific to the `Hailo` conversion.
+
+| argument             | type                           | description                                      |
+| -------------------- | ------------------------------ | ------------------------------------------------ |
+| `optimization_level` | `Literal[-100, 0, 1, 2, 3, 4]` | The optimization level to use.                   |
+| `compression_level`  | `Literal[0, 1, 2, 3, 4, 5]`    | The compression level to use.                    |
+| `batch_size`         | `int`                          | The batch size to use for quantization.          |
+| `alls`               | `list[str]?`                   | The list of additional `alls` parameters to use. |
 
 ## Migration from `blobconverter`
 

--- a/modelconverter/hub/README.md
+++ b/modelconverter/hub/README.md
@@ -137,6 +137,10 @@ Parameters specific to the `Hailo` conversion.
 
 [BlobConverter](https://pypi.org/project/blobconverter/) is our previous library for converting models to the BLOB format usable with `RVC2` and `RVC3` devices. This library is being replaced by `modelconverter`, which eventually become the only supported way of converting models in the future.
 
+`blobconverter` is still available and can be used for conversion, but we recommend using `modelconverter` for new projects. The API of `modelconverter` is similar to that of `blobconverter`, but there are some differences in the parameters and the way the conversion is done.
+
+`blobconverter` offers several functions for converting models from different frameworks, such as `from_onnx`, `from_openvino`, and `from_tf`. These functions are now replaced by the `convert.RVC2` (or `convert.RVC3`) function in `modelconverter`, which takes a single argument `path` that specifies the path to the model file.
+
 The following table shows the mapping between the parameters of `blobconverter` and `modelconverter`. The parameters are grouped by their purpose. The first column shows the parameters of `blobconverter`, the second column shows the equivalent parameters in `modelconverter`, and the third column contains additional notes.
 
 | `blobconverter`    | `modelconverter`    | Notes                                                                                                     |

--- a/modelconverter/hub/__init__.py
+++ b/modelconverter/hub/__init__.py
@@ -1,3 +1,3 @@
-from .__main__ import convert
+from . import convert
 
 __all__ = ["convert"]

--- a/modelconverter/hub/__init__.py
+++ b/modelconverter/hub/__init__.py
@@ -1,3 +1,3 @@
-from . import convert
+from .convert import convert
 
 __all__ = ["convert"]

--- a/modelconverter/hub/__main__.py
+++ b/modelconverter/hub/__main__.py
@@ -209,6 +209,7 @@ def model_create(
     architecture_id: str | None = None,
     tasks: list[Task] | None = None,
     links: list[str] | None = None,
+    is_yolo: bool = False,
     silent: bool = False,
 ) -> dict[str, Any]:
     """Creates a new model resource.
@@ -231,6 +232,8 @@ def model_create(
         List of tasks this model supports.
     links : list[str] | None
         List of links to related resources.
+    is_yolo : bool
+        Whether the model is a YOLO model.
     silent : bool
         Whether to print the model information after creation.
     """
@@ -243,6 +246,7 @@ def model_create(
         "architecture_id": architecture_id,
         "tasks": tasks or [],
         "links": links or [],
+        "is_yolo": is_yolo,
     }
     try:
         res = Request.post("models", json=data)
@@ -734,6 +738,7 @@ def convert(
     architecture_id: str | None = None,
     tasks: list[Task] | None = None,
     links: list[str] | None = None,
+    is_yolo: bool = False,
     model_id: str | None = None,
     version: str | None = None,
     repository_url: str | None = None,
@@ -773,6 +778,8 @@ def convert(
         List of tasks this model supports.
     links : list[str], optional
         List of links to related resources.
+    is_yolo : bool, optional
+        Whether the model is a YOLO model.
     model_id : str, optional
         ID of an existing Model resource. If specified, this model will be used instead of creating a new one.
     version : str, optional
@@ -855,6 +862,7 @@ def convert(
                 architecture_id=architecture_id,
                 tasks=tasks or [],
                 links=links or [],
+                is_yolo=is_yolo,
                 silent=True,
             )["id"]
         except ValueError:

--- a/modelconverter/hub/__main__.py
+++ b/modelconverter/hub/__main__.py
@@ -891,6 +891,7 @@ def convert(
         silent=True,
     )["id"]
 
+    # TODO: IR support
     if path is not None and is_nn_archive(path):
         upload(path, instance_id)
     else:

--- a/modelconverter/hub/convert.py
+++ b/modelconverter/hub/convert.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+from typing import Literal
+
+from luxonis_ml.typing import Kwargs, PathType
+
+from modelconverter.utils.types import PotDevice, Target
+
+from .__main__ import convert as cli_convert
+
+
+def _combine_opts(
+    target: Target, target_kwargs: Kwargs, opts: list[str] | Kwargs | None
+) -> list[str]:
+    opts = opts or []
+    if isinstance(opts, dict):
+        opts_list = []
+        for key, value in opts.items():
+            opts_list.extend([key, value])
+    else:
+        opts_list = opts
+
+    for key, value in target_kwargs.items():
+        opts_list.extend([f"{target.value}.{key}", value])
+
+    return opts_list
+
+
+def RVC2(
+    path: PathType,
+    mo_args: list[str] | None = None,
+    compile_tool_args: list[str] | None = None,
+    compress_to_fp16: bool = True,
+    number_of_shaves: int = 8,
+    superblob: bool = True,
+    opts: Kwargs | list[str] | None = None,
+    **hub_kwargs,
+) -> Path:
+    return cli_convert(
+        Target.RVC2,
+        _combine_opts(
+            Target.RVC2,
+            {
+                "mo_args": mo_args or [],
+                "compile_tool_args": compile_tool_args or [],
+                "compress_to_fp16": compress_to_fp16,
+                "number_of_shaves": number_of_shaves,
+                "superblob": superblob,
+            },
+            opts,
+        ),
+        path=str(path),
+        **hub_kwargs,
+    )
+
+
+def RVC3(
+    path: PathType,
+    mo_args: list[str] | None = None,
+    compile_tool_args: list[str] | None = None,
+    compress_to_fp16: bool = True,
+    pot_target_device: PotDevice | Literal["VPU", "ANY"] = PotDevice.VPU,
+    opts: Kwargs | list[str] | None = None,
+    **hub_kwargs,
+) -> Path:
+    if not isinstance(pot_target_device, PotDevice):
+        pot_target_device = PotDevice(pot_target_device)
+    return cli_convert(
+        Target.RVC3,
+        _combine_opts(
+            Target.RVC3,
+            {
+                "mo_args": mo_args or [],
+                "compile_tool_args": compile_tool_args or [],
+                "compress_to_fp16": compress_to_fp16,
+                "pot_target_device": pot_target_device.value,
+            },
+            opts,
+        ),
+        path=str(path),
+        **hub_kwargs,
+    )
+
+
+def RVC4(
+    path: PathType,
+    snpe_onnx_to_dlc_args: list[str] | None = None,
+    snpe_dlc_quant_args: list[str] | None = None,
+    snpe_dlc_graph_prepare_args: list[str] | None = None,
+    usu_per_channel_quantization: bool = True,
+    use_per_row_quantization: bool = False,
+    htp_socs: list[
+        Literal["sm8350", "sm8450", "sm8550", "sm8650", "qcs6490", "qcs8550"]
+    ]
+    | None = None,
+    opts: Kwargs | list[str] | None = None,
+    **hub_kwargs,
+) -> Path:
+    htp_socs = htp_socs or ["sm8550"]
+    return cli_convert(
+        Target.RVC4,
+        _combine_opts(
+            Target.RVC4,
+            {
+                "snpe_onnx_to_dlc_args": snpe_onnx_to_dlc_args or [],
+                "snpe_dlc_quant_args": snpe_dlc_quant_args or [],
+                "snpe_dlc_graph_prepare_args": snpe_dlc_graph_prepare_args
+                or [],
+                "usu_per_channel_quantization": usu_per_channel_quantization
+                or [],
+                "use_per_row_quantization": use_per_row_quantization,
+                "htp_socs": htp_socs,
+            },
+            opts,
+        ),
+        path=str(path),
+        **hub_kwargs,
+    )
+
+
+def Hailo(
+    path: PathType,
+    optimization_level: Literal[-100, 0, 1, 2, 3, 4] = 2,
+    compression_level: Literal[0, 1, 2, 3, 4, 5] = 2,
+    batch_size: int = 8,
+    alls: list[str] | None = None,
+    opts: Kwargs | list[str] | None = None,
+    **hub_kwargs,
+) -> Path:
+    return cli_convert(
+        Target.HAILO,
+        _combine_opts(
+            Target.HAILO,
+            {
+                "optimization_level": optimization_level,
+                "compression_level": compression_level,
+                "batch_size": batch_size,
+                "alls": alls or [],
+            },
+            opts,
+        ),
+        path=str(path),
+        **hub_kwargs,
+    )

--- a/modelconverter/hub/convert.py
+++ b/modelconverter/hub/convert.py
@@ -8,6 +8,226 @@ from modelconverter.utils.types import PotDevice, Target
 from .__main__ import convert as cli_convert
 
 
+class convert:
+    """Namespace for all conversion methods.
+
+    Specific conversion functions for individual targets are
+    available as static methods under the names `RVC2`, `RVC3`, `RVC4`, and `Hailo`.
+    """
+
+    __call__ = staticmethod(cli_convert)
+
+    @staticmethod
+    def RVC2(
+        path: PathType,
+        mo_args: list[str] | None = None,
+        compile_tool_args: list[str] | None = None,
+        compress_to_fp16: bool = True,
+        number_of_shaves: int = 8,
+        superblob: bool = True,
+        opts: Kwargs | list[str] | None = None,
+        **hub_kwargs,
+    ) -> Path:
+        """Convert a model to RVC2 format.
+
+        Parameters
+        ----------
+        path : PathType
+            Path to the model file to be converted.
+        mo_args : list[str] | None, optional
+            Additional arguments for the Model Optimizer (MO).
+        compile_tool_args : list[str] | None, optional
+            Additional arguments for the compile tool.
+        compress_to_fp16 : bool, default True
+            Whether to compress the model's weights to FP16.
+        number_of_shaves : int, default 8
+            Number of shaves to use for the conversion.
+        superblob : bool, default True
+            Whether to create a superblob for the model.
+        opts : dict[str, Any] | list[str] | None, optional
+            Additional options for the conversion. Can be used
+            to override configuration values.
+        **hub_kwargs
+            Additional keyword arguments to be passed to the
+            online conversion.
+        """
+        return cli_convert(
+            Target.RVC2,
+            _combine_opts(
+                Target.RVC2,
+                {
+                    "mo_args": mo_args or [],
+                    "compile_tool_args": compile_tool_args or [],
+                    "compress_to_fp16": compress_to_fp16,
+                    "number_of_shaves": number_of_shaves,
+                    "superblob": superblob,
+                },
+                opts,
+            ),
+            path=str(path),
+            **hub_kwargs,
+        )
+
+    @staticmethod
+    def RVC3(
+        path: PathType,
+        mo_args: list[str] | None = None,
+        compile_tool_args: list[str] | None = None,
+        compress_to_fp16: bool = True,
+        pot_target_device: PotDevice | Literal["VPU", "ANY"] = PotDevice.VPU,
+        opts: Kwargs | list[str] | None = None,
+        **hub_kwargs,
+    ) -> Path:
+        """Convert a model to RVC3 format.
+
+        Parameters
+        ----------
+        path : PathType
+            Path to the model file to be converted.
+        mo_args : list[str] | None, optional
+            Additional arguments for the Model Optimizer (MO).
+        compile_tool_args : list[str] | None, optional
+            Additional arguments for the compile tool.
+        compress_to_fp16 : bool, default True
+            Whether to compress the model's weights to FP16.
+        pot_target_device : PotDevice | Literal["VPU", "ANY"], default PotDevice.VPU
+            Target device for POT quantization.
+        opts : dict[str, Any] | list[str] | None, optional
+            Additional options for the conversion. Can be used
+            to override configuration values.
+        **hub_kwargs
+            Additional keyword arguments to be passed to the
+            online conversion.
+        """
+        if not isinstance(pot_target_device, PotDevice):
+            pot_target_device = PotDevice(pot_target_device)
+        return cli_convert(
+            Target.RVC3,
+            _combine_opts(
+                Target.RVC3,
+                {
+                    "mo_args": mo_args or [],
+                    "compile_tool_args": compile_tool_args or [],
+                    "compress_to_fp16": compress_to_fp16,
+                    "pot_target_device": pot_target_device.value,
+                },
+                opts,
+            ),
+            path=str(path),
+            **hub_kwargs,
+        )
+
+    @staticmethod
+    def RVC4(
+        path: PathType,
+        snpe_onnx_to_dlc_args: list[str] | None = None,
+        snpe_dlc_quant_args: list[str] | None = None,
+        snpe_dlc_graph_prepare_args: list[str] | None = None,
+        use_per_channel_quantization: bool = True,
+        use_per_row_quantization: bool = False,
+        htp_socs: list[
+            Literal[
+                "sm8350", "sm8450", "sm8550", "sm8650", "qcs6490", "qcs8550"
+            ]
+        ]
+        | None = None,
+        opts: Kwargs | list[str] | None = None,
+        **hub_kwargs,
+    ) -> Path:
+        """Convert a model to RVC4 format.
+
+        Parameters
+        ----------
+        path : PathType
+            Path to the model file to be converted.
+        snpe_onnx_to_dlc_args : list[str] | None, optional
+            Additional arguments for the SNPE ONNX to DLC conversion.
+        snpe_dlc_quant_args : list[str] | None, optional
+            Additional arguments for the SNPE DLC quantization.
+        snpe_dlc_graph_prepare_args : list[str] | None, optional
+            Additional arguments for the SNPE DLC graph preparation.
+        use_per_channel_quantization : bool, default True
+            Whether to use per-channel quantization.
+        use_per_row_quantization : bool, default False
+            Whether to use per-row quantization.
+        htp_socs : list[str] | None, optional
+            List of HTP SoCs for the final DLC graph.
+        opts : dict[str, Any] | list[str] | None, optional
+            Additional options for the conversion. Can be used
+            to override configuration values.
+        **hub_kwargs
+            Additional keyword arguments to be passed to the
+            online conversion.
+        """
+        htp_socs = htp_socs or ["sm8550"]
+        return cli_convert(
+            Target.RVC4,
+            _combine_opts(
+                Target.RVC4,
+                {
+                    "snpe_onnx_to_dlc_args": snpe_onnx_to_dlc_args or [],
+                    "snpe_dlc_quant_args": snpe_dlc_quant_args or [],
+                    "snpe_dlc_graph_prepare_args": snpe_dlc_graph_prepare_args
+                    or [],
+                    "usu_per_channel_quantization": use_per_channel_quantization
+                    or [],
+                    "use_per_row_quantization": use_per_row_quantization,
+                    "htp_socs": htp_socs,
+                },
+                opts,
+            ),
+            path=str(path),
+            **hub_kwargs,
+        )
+
+    @staticmethod
+    def Hailo(
+        path: PathType,
+        optimization_level: Literal[-100, 0, 1, 2, 3, 4] = 2,
+        compression_level: Literal[0, 1, 2, 3, 4, 5] = 2,
+        batch_size: int = 8,
+        alls: list[str] | None = None,
+        opts: Kwargs | list[str] | None = None,
+        **hub_kwargs,
+    ) -> Path:
+        """Convert a model to Hailo format.
+
+        Parameters
+        ----------
+        path : PathType
+            Path to the model file to be converted.
+        optimization_level : int, default 2
+            Optimization level for the conversion.
+        compression_level : int, default 2
+            Compression level for the conversion.
+        batch_size : int, default 8
+            Batch size for the conversion.
+        alls : list[str] | None, optional
+            List of `alls` parameters for the conversion.
+        opts : dict[str, Any] | list[str] | None, optional
+            Additional options for the conversion. Can be used
+            to override configuration values.
+        **hub_kwargs
+            Additional keyword arguments to be passed to the
+            online conversion.
+        """
+        return cli_convert(
+            Target.HAILO,
+            _combine_opts(
+                Target.HAILO,
+                {
+                    "optimization_level": optimization_level,
+                    "compression_level": compression_level,
+                    "batch_size": batch_size,
+                    "alls": alls or [],
+                },
+                opts,
+            ),
+            path=str(path),
+            **hub_kwargs,
+        )
+
+
 def _combine_opts(
     target: Target, target_kwargs: Kwargs, opts: list[str] | Kwargs | None
 ) -> list[str]:
@@ -23,121 +243,3 @@ def _combine_opts(
         opts_list.extend([f"{target.value}.{key}", value])
 
     return opts_list
-
-
-def RVC2(
-    path: PathType,
-    mo_args: list[str] | None = None,
-    compile_tool_args: list[str] | None = None,
-    compress_to_fp16: bool = True,
-    number_of_shaves: int = 8,
-    superblob: bool = True,
-    opts: Kwargs | list[str] | None = None,
-    **hub_kwargs,
-) -> Path:
-    return cli_convert(
-        Target.RVC2,
-        _combine_opts(
-            Target.RVC2,
-            {
-                "mo_args": mo_args or [],
-                "compile_tool_args": compile_tool_args or [],
-                "compress_to_fp16": compress_to_fp16,
-                "number_of_shaves": number_of_shaves,
-                "superblob": superblob,
-            },
-            opts,
-        ),
-        path=str(path),
-        **hub_kwargs,
-    )
-
-
-def RVC3(
-    path: PathType,
-    mo_args: list[str] | None = None,
-    compile_tool_args: list[str] | None = None,
-    compress_to_fp16: bool = True,
-    pot_target_device: PotDevice | Literal["VPU", "ANY"] = PotDevice.VPU,
-    opts: Kwargs | list[str] | None = None,
-    **hub_kwargs,
-) -> Path:
-    if not isinstance(pot_target_device, PotDevice):
-        pot_target_device = PotDevice(pot_target_device)
-    return cli_convert(
-        Target.RVC3,
-        _combine_opts(
-            Target.RVC3,
-            {
-                "mo_args": mo_args or [],
-                "compile_tool_args": compile_tool_args or [],
-                "compress_to_fp16": compress_to_fp16,
-                "pot_target_device": pot_target_device.value,
-            },
-            opts,
-        ),
-        path=str(path),
-        **hub_kwargs,
-    )
-
-
-def RVC4(
-    path: PathType,
-    snpe_onnx_to_dlc_args: list[str] | None = None,
-    snpe_dlc_quant_args: list[str] | None = None,
-    snpe_dlc_graph_prepare_args: list[str] | None = None,
-    usu_per_channel_quantization: bool = True,
-    use_per_row_quantization: bool = False,
-    htp_socs: list[
-        Literal["sm8350", "sm8450", "sm8550", "sm8650", "qcs6490", "qcs8550"]
-    ]
-    | None = None,
-    opts: Kwargs | list[str] | None = None,
-    **hub_kwargs,
-) -> Path:
-    htp_socs = htp_socs or ["sm8550"]
-    return cli_convert(
-        Target.RVC4,
-        _combine_opts(
-            Target.RVC4,
-            {
-                "snpe_onnx_to_dlc_args": snpe_onnx_to_dlc_args or [],
-                "snpe_dlc_quant_args": snpe_dlc_quant_args or [],
-                "snpe_dlc_graph_prepare_args": snpe_dlc_graph_prepare_args
-                or [],
-                "usu_per_channel_quantization": usu_per_channel_quantization
-                or [],
-                "use_per_row_quantization": use_per_row_quantization,
-                "htp_socs": htp_socs,
-            },
-            opts,
-        ),
-        path=str(path),
-        **hub_kwargs,
-    )
-
-
-def Hailo(
-    path: PathType,
-    optimization_level: Literal[-100, 0, 1, 2, 3, 4] = 2,
-    compression_level: Literal[0, 1, 2, 3, 4, 5] = 2,
-    batch_size: int = 8,
-    alls: list[str] | None = None,
-    opts: Kwargs | list[str] | None = None,
-    **hub_kwargs,
-) -> Path:
-    return cli_convert(
-        Target.HAILO,
-        _combine_opts(
-            Target.HAILO,
-            {
-                "optimization_level": optimization_level,
-                "compression_level": compression_level,
-                "batch_size": batch_size,
-                "alls": alls or [],
-            },
-            opts,
-        ),
-        path=str(path),
-        **hub_kwargs,
-    )


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Adds more in-depth documetation for online conversion and for migration from `blobconverter. 

Additionally adds an easier-to-use Python API for the online conversion.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Added docs
- Added some extra arguments to `convert`
  - `api_key`
  - `is_yolo`
  - `variant_tags`
- New module `modelconverter.hub.convert` with a `convert` namespace, which contains specific conversion functions for individual targets (`convert.RVC2`, `convert.Hailo`, etc.)
  - More sensible to use than `convert(Target.RVC2, ...) 

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable