### PR TITLE
Saving DLC Info on Export

### DIFF
--- a/modelconverter/packages/rvc4/exporter.py
+++ b/modelconverter/packages/rvc4/exporter.py
@@ -17,6 +17,7 @@ from modelconverter.utils.config import (
     ImageCalibrationConfig,
     SingleStageConfig,
 )
+from modelconverter.utils.subprocess import subprocess_run
 from modelconverter.utils.types import (
     DataType,
     Encoding,
@@ -113,6 +114,16 @@ class RVC4Exporter(Exporter):
         )
         logger.info("Offline graph preparation finished.")
         self._inference_model_path = out_dlc_path
+        subprocess_run(
+            [
+                "snpe-dlc-info",
+                "-i",
+                out_dlc_path,
+                "-s",
+                self.output_dir / "info.csv",
+            ],
+            silent=True,
+        )
         return out_dlc_path
 
     def calibrate(self, dlc_path: Path) -> Path:

--- a/modelconverter/utils/metadata.py
+++ b/modelconverter/utils/metadata.py
@@ -20,11 +20,11 @@ class Metadata:
 
 def get_metadata(model_path: Path) -> Metadata:
     suffix = model_path.suffix
-    if suffix == ".dlc":
+    if suffix in {".dlc", ".csv"}:
         return _get_metadata_dlc(model_path)
     if suffix == ".onnx":
         return _get_metadata_onnx(model_path)
-    if suffix in [".xml", ".bin"]:
+    if suffix in {".xml", ".bin"}:
         if suffix == ".xml":
             xml_path = model_path
             bin_path = model_path.with_suffix(".bin")
@@ -32,7 +32,7 @@ def get_metadata(model_path: Path) -> Metadata:
             bin_path = model_path
             xml_path = model_path.with_suffix(".xml")
         return _get_metadata_ir(bin_path, xml_path)
-    if suffix in [".hef", ".har"]:
+    if suffix in {".hef", ".har"}:
         return _get_metadata_hailo(model_path)
     if suffix == ".tflite":
         return _get_metadata_tflite(model_path)

--- a/modelconverter/utils/metadata.py
+++ b/modelconverter/utils/metadata.py
@@ -39,13 +39,16 @@ def get_metadata(model_path: Path) -> Metadata:
     raise ValueError(f"Unsupported model format: {suffix}")
 
 
-def _get_metadata_dlc(model_path: Path) -> Metadata:
+def _get_metadata_dlc(path: Path) -> Metadata:
     import polars as pl
 
-    csv_path = Path("info.csv")
-    subprocess_run(
-        ["snpe-dlc-info", "-i", model_path, "-s", csv_path], silent=True
-    )
+    if path.suffix == ".csv":
+        csv_path = path
+    else:
+        csv_path = Path("info.csv")
+        subprocess_run(
+            ["snpe-dlc-info", "-i", path, "-s", csv_path], silent=True
+        )
     content = csv_path.read_text()
 
     metadata = {}


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Saving the CSV info about converted DLC makes it easier to inspect input/output metadata later. 


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Modelconverter now automatically runs `snpe-dlc-info` at the end of the conversion and saves the resulting CSV to the output directory.
- `get_metadata` now accepts DLC info CSV as well as the DLC file

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable