### PR TITLE
CLI: `--command` argument in `modelconverter shell`

### DIFF
--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -231,7 +231,12 @@ def infer(
 
 
 @app.command(group=docker_commands)
-def shell(target: Target, /) -> None:
+def shell(
+    target: Target,
+    /,
+    *,
+    command: Annotated[str | None, Parameter(name=["-c", "--command"])] = None,
+) -> None:
     """Boots up a shell inside a docker container for the specified
     target platform.
 
@@ -239,8 +244,14 @@ def shell(target: Target, /) -> None:
     ----------
     target : Target
         The target platform.
+    command : str
+        The command to run in the shell. If not provided, a bash shell is started.
+        If you want to run a command with arguments, use quotes around the command.
     """
-    os.execle("/bin/bash", "bash", os.environ)
+    args = ["bash"]
+    if command is not None:
+        args.extend(["-c", command])
+    os.execle("/bin/bash", *args, os.environ)
 
 
 @app.meta.command(group=device_commands)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Adds an option to run a command in the shell inside the docker image instead of first booting into the shell and running the command manually.

**Example**
```bash
modelconverter shell rvc4 -c "snpe-dlc-info -i path/to/model.dlc -s shared_with_container/model_info.csv"
```
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Added `command` argument to `modelconverter shell` in `__main__.py`

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable