### PR TITLE
Added `--build-arg` to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,14 @@ docker build -f docker/$TARGET/Dockerfile \
              -t luxonis/modelconverter-$TARGET:latest .
 ```
 
+If you want to build the image with a different version of the underlying conversion tools than is the default one, you also need to pass the `--build-arg` flag with the desired version. For example, to build the `RVC2` image with ` 2021.4.0`, use:
+
+```bash
+docker build -f docker/rvc2/Dockerfile \
+             -t luxonis/modelconverter-rvc2:latest \
+             --build-arg VERSION=2021.4.0 .
+```
+
 #### GPU Support
 
 To enable GPU acceleration for `hailo` conversion, install the [Nvidia Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker).


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Updates the README with instructions on how to manually build the docker images with non-default versions of packages. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable