### PR TITLE
Hailo: Fix for failing build of `dali` libraries

### DIFF
--- a/docker/hailo/Dockerfile
+++ b/docker/hailo/Dockerfile
@@ -20,14 +20,9 @@ RUN <<EOF
 
     pip install --upgrade pip --no-cache-dir
     pip install -r requirements.txt --no-cache-dir
-    pip install --extra-index-url \
+    pip install -U --extra-index-url \
         https://developer.download.nvidia.com/compute/redist \
-        nvidia-dali-cuda120 --no-cache-dir
-    pip install --extra-index-url \
-        https://developer.download.nvidia.com/compute/redist \
-        nvidia-dali-tf-plugin-cuda120 --no-cache-dir
-    pip uninstall protobuf -y
-    pip install protobuf==3.20.3 --no-cache-dir
+        -r requirements-hailo.txt --no-cache-dir
 
 EOF
 

--- a/modelconverter/packages/hailo/requirements.txt
+++ b/modelconverter/packages/hailo/requirements.txt
@@ -1,0 +1,3 @@
+nvidia-dali-cuda120==1.49.0
+nvidia-dali-tf-plugin-cuda120==1.49.0
+protobuf==3.20.3


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes an issue with a failing build of nvidia-dali python libraries.
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Restricted `dali` libraries to version `v1.49.0`

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable