### PR TITLE
Removed `pkg_resources`

### DIFF
--- a/modelconverter/__init__.py
+++ b/modelconverter/__init__.py
@@ -1,4 +1,5 @@
-import pkg_resources
+from importlib.metadata import entry_points
+
 from luxonis_ml.utils import PUT_FILE_REGISTRY
 
 from .hub import convert
@@ -10,7 +11,9 @@ __all__ = ["convert"]
 
 def load_put_file_plugins() -> None:
     """Registers any external put file plugins."""
-    for entry_point in pkg_resources.iter_entry_points("put_file_plugins"):
+    eps = entry_points()
+    put_file_plugins = eps.select(group="put_file_plugins")
+    for entry_point in put_file_plugins:
         plugin_class = entry_point.load()
         PUT_FILE_REGISTRY.register_module(module=plugin_class)
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
`pkg_resources` were deprecated and will be removed this year. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- replaced `pkg_resources` with `importlib`

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable