### PR TITLE
Fix: Skip random calibration data when calibration is disabled

### DIFF
--- a/modelconverter/packages/base_exporter.py
+++ b/modelconverter/packages/base_exporter.py
@@ -85,7 +85,7 @@ class Exporter(ABC):
             logger.warning("Calibration has been disabled.")
             logger.warning("The quantization step will be skipped.")
 
-        if self.target != Target.RVC2:
+        if self.target != Target.RVC2 and not self._disable_calibration:
             self._prepare_random_calibration_data()
 
     @property

--- a/modelconverter/packages/base_exporter.py
+++ b/modelconverter/packages/base_exporter.py
@@ -81,7 +81,7 @@ class Exporter(ABC):
             self.config, self.target.name.lower()
         ).disable_calibration
 
-        if self._disable_calibration:
+        if self.target != Target.RVC2 and self._disable_calibration:
             logger.warning("Calibration has been disabled.")
             logger.warning("The quantization step will be skipped.")
 
@@ -176,8 +176,6 @@ class Exporter(ABC):
     def _prepare_random_calibration_data(self) -> None:
         for name, inp in self.inputs.items():
             calib = inp.calibration
-            if calib is None:
-                continue
             if not isinstance(calib, RandomCalibrationConfig):
                 continue
             logger.warning(


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Removes confusing log about preparation of random calibration data when calibration is disabled.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable