### PR TITLE
RVC4: Simpler support for FP16 export

### DIFF
--- a/modelconverter/packages/rvc4/exporter.py
+++ b/modelconverter/packages/rvc4/exporter.py
@@ -37,6 +37,7 @@ class RVC4Exporter(Exporter):
         super().__init__(config=config, output_dir=output_dir)
 
         rvc4_cfg = config.rvc4
+        self.compress_to_fp16 = rvc4_cfg.compress_to_fp16
         self.snpe_onnx_to_dlc = rvc4_cfg.snpe_onnx_to_dlc_args
         self.snpe_dlc_quant = rvc4_cfg.snpe_dlc_quant_args
         self.snpe_dlc_graph_prepare = rvc4_cfg.snpe_dlc_graph_prepare_args
@@ -109,6 +110,8 @@ class RVC4Exporter(Exporter):
             ["--set_output_tensors", ",".join(name for name in self.outputs)],
         )
         self._add_args(args, ["--htp_socs", ",".join(self.htp_socs)])
+        if self.compress_to_fp16:
+            self._add_args(args, ["--use_float_io"])
         self._subprocess_run(
             ["snpe-dlc-graph-prepare", *args], meta_name="graph_prepare"
         )
@@ -285,6 +288,9 @@ class RVC4Exporter(Exporter):
                         f"Layout '{layout}' not supported by snpe for input '{name}'. "
                         "Proceeding wihtout specifying layout."
                     )
+
+        if self.compress_to_fp16:
+            self._add_args(args, ["--float_bitwidth", "16"])
 
         if self.is_tflite:
             command = "snpe-tflite-to-dlc"

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -276,9 +276,6 @@ class RVC4Config(TargetConfig):
     def _validate_fp16(self) -> Self:
         if not self.compress_to_fp16:
             return self
-        logger.warning(
-            "FP16 compression is enabled. Calibration will be skipped."
-        )
         self.disable_calibration = True
         if "qcs8550" not in self.htp_socs:
             self.htp_socs.append("qcs8550")

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -261,6 +261,7 @@ class RVC3Config(BlobBaseConfig):
 
 
 class RVC4Config(TargetConfig):
+    compress_to_fp16: bool = False
     snpe_onnx_to_dlc_args: list[str] = []
     snpe_dlc_quant_args: list[str] = []
     snpe_dlc_graph_prepare_args: list[str] = []
@@ -270,6 +271,18 @@ class RVC4Config(TargetConfig):
     htp_socs: list[
         Literal["sm8350", "sm8450", "sm8550", "sm8650", "qcs6490", "qcs8550"]
     ] = ["sm8550"]
+
+    @model_validator(mode="after")
+    def _validate_fp16(self) -> Self:
+        if not self.compress_to_fp16:
+            return self
+        logger.warning(
+            "FP16 compression is enabled. Calibration will be skipped."
+        )
+        self.disable_calibration = True
+        if "qcs8550" not in self.htp_socs:
+            self.htp_socs.append("qcs8550")
+        return self
 
 
 class SingleStageConfig(CustomBaseModel):

--- a/shared_with_container/configs/defaults.yaml
+++ b/shared_with_container/configs/defaults.yaml
@@ -198,3 +198,13 @@ stages:
 
       # Enables row wise quantization of Matmul and FullyConnected ops.
       use_per_row_quantization: False
+
+      # List of platforms to pre-compute the DLC graph for.
+      htp_socs: ["sm8550"]
+
+      # Configures conversion to float16 precision. This will
+      # disable the calibration, add the `--float_bitwidth 16`
+      # flag to `snpe-onnx-to-dlc`,  the `--use_float_io` flag
+      # to `snpe-dlc-graph-prepare`, and the `qcs8550` platform
+      # to the `htp_socs` list.
+      compress_to_fp16: False

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -63,6 +63,7 @@ DEFAULT_TARGET_CONFIGS = {
         "disable_calibration": False,
         "use_per_channel_quantization": True,
         "use_per_row_quantization": False,
+        "compress_to_fp16": False,
     },
     "hailo": {
         "optimization_level": 2,


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Makes it easier to convert RVC4 models to FP16 precision.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Added new configuration field `rvc4.compress_to_fp16` which will automatically add the required flags to `snpe-onnx-to-dlc` and `snpe-dlc-graph-prepare`

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable