### PR TITLE
Fix: NN Archive precision

### DIFF
--- a/modelconverter/packages/rvc2/exporter.py
+++ b/modelconverter/packages/rvc2/exporter.py
@@ -234,7 +234,8 @@ class RVC2Exporter(Exporter):
         self._inference_model_path = xml_path
         args = self.compile_tool_args
         self._add_args(args, ["-d", self.device])
-        self._add_args(args, ["-ip", "U8"])
+        if "-iop" not in args:
+            self._add_args(args, ["-ip", "U8"])
 
         args += ["-m", xml_path]
 

--- a/modelconverter/packages/rvc3/exporter.py
+++ b/modelconverter/packages/rvc3/exporter.py
@@ -47,7 +47,8 @@ class RVC3Exporter(RVC2Exporter):
         self._inference_model_path = xml_path
         args = self.compile_tool_args
         self._add_args(args, ["-d", self.device])
-        self._add_args(args, ["-ip", "U8"])
+        if "-iop" not in args:
+            self._add_args(args, ["-ip", "U8"])
 
         if not self._disable_calibration:
             if len(self.inputs) > 1:

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -27,6 +27,7 @@ from modelconverter.utils.types import (
     InputFileType,
     PotDevice,
     ResizeMethod,
+    Target,
 )
 
 NAMED_VALUES = {
@@ -300,6 +301,17 @@ class SingleStageConfig(CustomBaseModel):
     rvc2: RVC2Config = RVC2Config()
     rvc3: RVC3Config = RVC3Config()
     rvc4: RVC4Config = RVC4Config()
+
+    def get_target_config(self, target: Target) -> TargetConfig:
+        """Returns the target configuration for the given target."""
+        if target == Target.HAILO:
+            return self.hailo
+        if target == Target.RVC2:
+            return self.rvc2
+        if target == Target.RVC3:
+            return self.rvc3
+        if target == Target.RVC4:
+            return self.rvc4
 
     @model_validator(mode="before")
     @classmethod

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -441,6 +441,10 @@ def _get_io_dtype(
     *,
     mode: Literal["input", "output"],
 ) -> str:
+    if mode == "input":
+        dtypes = metadata.input_dtypes
+    else:
+        dtypes = metadata.output_dtypes
     if target in {Target.RVC2, Target.RVC3}:
         compile_tool_args: list[str] = getattr(cfg, "compile_tool_args", [])
         assert isinstance(cfg, BlobBaseConfig)
@@ -461,9 +465,9 @@ def _get_io_dtype(
         elif mode == "output" and "-op" in compile_tool_args:
             idx = compile_tool_args.index("-op")
         else:
-            return metadata.input_dtypes[name].as_nn_archive_dtype()
+            return dtypes[name].as_nn_archive_dtype()
 
         blob_dtype = compile_tool_args[idx + 1].upper()
         return DataType.from_ir_ie_dtype(blob_dtype).as_nn_archive_dtype()
 
-    return metadata.input_dtypes[name].as_nn_archive_dtype()
+    return dtypes[name].as_nn_archive_dtype()

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -206,6 +206,8 @@ def modelconverter_config_to_nn(
 
     cfg = config.stages[main_stage_key]
     target_cfg = cfg.get_target_config(target)
+
+    # TODO: This might be more complicated for Hailo
     if target_cfg.disable_calibration:
         precision = DataType.FLOAT32
     elif getattr(target_cfg, "compress_to_fp16", False):

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -444,8 +444,18 @@ def _get_io_dtype(
     if target in {Target.RVC2, Target.RVC3}:
         compile_tool_args: list[str] = getattr(cfg, "compile_tool_args", [])
         assert isinstance(cfg, BlobBaseConfig)
+        # -iop is in a form of "-iop <name>:<dtype>"
         if "-iop" in compile_tool_args:
-            idx = compile_tool_args.index("-iop")
+            for i in range(len(compile_tool_args) - 1):
+                if compile_tool_args[i] == "-iop":
+                    value = compile_tool_args[i + 1]
+                    n, d = value.split(":")
+                    if n == name:
+                        blob_dtype = d.upper()
+                        return DataType.from_ir_ie_dtype(
+                            blob_dtype
+                        ).as_nn_archive_dtype()
+
         elif mode == "input" and "-ip" in compile_tool_args:
             idx = compile_tool_args.index("-ip")
         elif mode == "output" and "-op" in compile_tool_args:

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -247,7 +247,9 @@ def modelconverter_config_to_nn(
                 "name": inp.name,
                 "shape": new_shape,
                 "layout": layout,
-                "dtype": model_metadata.input_dtypes[inp.name].value,
+                "dtype": model_metadata.input_dtypes[
+                    inp.name
+                ].as_nn_archive_dtype(),
                 "input_type": "image",
                 "preprocessing": {
                     "mean": [0 for _ in inp.mean_values]
@@ -286,7 +288,9 @@ def modelconverter_config_to_nn(
                 "name": out.name,
                 "shape": new_shape,
                 "layout": layout,
-                "dtype": model_metadata.output_dtypes[out.name].value,
+                "dtype": model_metadata.output_dtypes[
+                    out.name
+                ].as_nn_archive_dtype(),
             }
         )
 

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -444,17 +444,17 @@ def _get_io_dtype(
     if target in {Target.RVC2, Target.RVC3}:
         compile_tool_args: list[str] = getattr(cfg, "compile_tool_args", [])
         assert isinstance(cfg, BlobBaseConfig)
-        # -iop is in a form of "-iop <name>:<dtype>"
+        # -iop is in a form of '-iop "<name1>:<dtype>,<name2>:<dtype2>"'
         if "-iop" in compile_tool_args:
-            for i in range(len(compile_tool_args) - 1):
-                if compile_tool_args[i] == "-iop":
-                    value = compile_tool_args[i + 1]
-                    n, d = value.split(":")
-                    if n == name:
-                        blob_dtype = d.upper()
-                        return DataType.from_ir_ie_dtype(
-                            blob_dtype
-                        ).as_nn_archive_dtype()
+            idx = compile_tool_args.index("-iop")
+            for value in compile_tool_args[idx + 1].split(","):
+                value = value.strip()
+                n, d = value.split(":")
+                if n == name:
+                    blob_dtype = d.upper()
+                    return DataType.from_ir_ie_dtype(
+                        blob_dtype
+                    ).as_nn_archive_dtype()
 
         elif mode == "input" and "-ip" in compile_tool_args:
             idx = compile_tool_args.index("-ip")

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -244,7 +244,7 @@ def modelconverter_config_to_nn(
         dai_type += type
         dai_type += "i" if layout == "NHWC" else "p"
         if target in {Target.RVC2, Target.RVC3}:
-            dtype = "int8"
+            dtype = "uint8"
         else:
             dtype = model_metadata.input_dtypes[inp.name].as_nn_archive_dtype()
 
@@ -288,7 +288,7 @@ def modelconverter_config_to_nn(
             layout = make_default_layout(new_shape)
 
         if target in {Target.RVC2, Target.RVC3}:
-            dtype = "int8"
+            dtype = "uint8"
         else:
             dtype = model_metadata.output_dtypes[
                 out.name

--- a/modelconverter/utils/types.py
+++ b/modelconverter/utils/types.py
@@ -203,6 +203,13 @@ class DataType(Enum):
     def as_snpe_dtype(self) -> str:
         return self.value
 
+    def as_nn_archive_dtype(self) -> str:
+        if self.value.startswith("ufxp"):
+            return self.value.replace("ufxp", "uint")
+        if self.value.startswith("fxp"):
+            return self.value.replace("fxp", "int")
+        return self.value
+
 
 class ResizeMethod(Enum):
     CROP = "CROP"

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -26,6 +26,7 @@ from modelconverter.utils.types import (
     InputFileType,
     PotDevice,
     ResizeMethod,
+    Target,
 )
 
 DATA_DIR = Path("tests/data/test_utils/test_config")
@@ -943,6 +944,7 @@ def test_output_nn_config_from_yaml(
         preprocessing,
         "dummy_model",
         DATA_DIR / "dummy_model.onnx",
+        Target.RVC4,
     )
 
     input_0_preprocessing = nn_config.model.inputs[0].preprocessing
@@ -1149,6 +1151,7 @@ def test_output_nn_config_from_nn_archive(
         preprocessing,
         main_stage,
         DATA_DIR / "dummy_model.onnx",
+        Target.RVC4,
     )
 
     input_0_preprocessing = nn_config.model.inputs[0].preprocessing


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes incorrectly set `precision` and `dtype` fields when converting to an NN Archive.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable