### PR TITLE
Fix: CLI overrides for NN Archive

### DIFF
--- a/modelconverter/packages/multistage_exporter.py
+++ b/modelconverter/packages/multistage_exporter.py
@@ -36,8 +36,8 @@ class MultiStageExporter:
         logger.info(f"Output directory: {self.output_dir}")
 
         self.exporters = {
-            stage_name: get_exporter(target)(
-                stage_config, self.output_dir / stage_name
+            stage_name: get_exporter(
+                target, stage_config, self.output_dir / stage_name
             )
             for stage_name, stage_config in config.stages.items()
         }


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes incorrect processing of CLI overrides for conversions from NN Archive. Even for single-stage models they needed to specify the specific stage otherwise would get ignored.

Now the CLI overrides work the same for conversions from a config and from an NN Archive.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable