### PR TITLE
ONNX Split node compatibility

### DIFF
--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -84,6 +84,7 @@ def onnx_attach_normalization_to_inputs(
                 inputs=[last_output],
                 outputs=split_names,
                 axis=1 if layout == "NCHW" else 3,
+                num_outputs=3,
                 name=f"split_{input_name}",
             )
             new_nodes.append(split_node)

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -7,12 +7,19 @@ import onnx
 import onnx_graphsurgeon as gs
 import onnxruntime as ort
 from loguru import logger
-from onnx import checker, helper
+from onnx import TensorProto, checker, helper
 from onnxsim import simplify
 
 from modelconverter.utils.config import InputConfig
 
 from .exceptions import ONNXException
+
+
+def get_opset_version(model: onnx.ModelProto) -> int:
+    for imp in model.opset_import:
+        if imp.domain == "":
+            return imp.version
+    raise ONNXException("No opset version found in the ONNX model.")
 
 
 def onnx_attach_normalization_to_inputs(
@@ -78,22 +85,42 @@ def onnx_attach_normalization_to_inputs(
 
         # 1. Reverse channels if needed
         if cfg.encoding_mismatch:
+            opset = get_opset_version(model)
             split_names = [f"split_{i}_{input_name}" for i in range(3)]
-            split_node = helper.make_node(
-                "Split",
-                inputs=[last_output],
-                outputs=split_names,
-                axis=1 if layout == "NCHW" else 3,
-                num_outputs=n_channels,
-                name=f"split_{input_name}",
-            )
+            axis = 1 if layout == "NCHW" else 3
+
+            if opset < 13:
+                split_node = helper.make_node(
+                    "Split",
+                    inputs=[last_output],
+                    outputs=split_names,
+                    axis=axis,
+                    split=[1] * n_channels,
+                    name=f"split_{input_name}",
+                )
+            else:
+                split_lengths_name = f"split_{input_name}_lengths"
+                split_lengths_tensor = helper.make_tensor(
+                    name=split_lengths_name,
+                    data_type=TensorProto.INT64,
+                    dims=[n_channels],
+                    vals=[1] * n_channels,
+                )
+                new_initializers.append(split_lengths_tensor)
+                split_node = helper.make_node(
+                    "Split",
+                    inputs=[last_output, split_lengths_name],
+                    outputs=split_names,
+                    axis=axis,
+                    name=f"split_{input_name}",
+                )
             new_nodes.append(split_node)
 
             concat_node = helper.make_node(
                 "Concat",
                 inputs=split_names[::-1],
                 outputs=[f"normalized_{input_name}"],
-                axis=1 if layout == "NCHW" else 3,
+                axis=axis,
                 name=f"concat_{input_name}",
             )
             new_nodes.append(concat_node)

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -84,7 +84,7 @@ def onnx_attach_normalization_to_inputs(
                 inputs=[last_output],
                 outputs=split_names,
                 axis=1 if layout == "NCHW" else 3,
-                num_outputs=3,
+                num_outputs=n_channels,
                 name=f"split_{input_name}",
             )
             new_nodes.append(split_node)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Pillow
 gcsfs
 luxonis-ml[data,nn_archive]==0.7.1
-onnx>=1.17.0
+onnx>=1.18.0
 onnxruntime
 onnxsim
 s3fs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Pillow
 gcsfs
 luxonis-ml[data,nn_archive]==0.7.1
-onnx>=1.18.0
+onnx>=1.17.0
 onnxruntime
 onnxsim
 s3fs


### PR DESCRIPTION
## Purpose
During the creation of a custom [Split](https://onnx.ai/onnx/operators/onnx__Split.html) onnx node the newer ONNX versions (>=1.18.0) require `either input ‘split’ or the attribute ‘num_outputs’ should be specified`. Since we are adding such node on the modified ONNX model graph, we need to make sure the respective change is made during the creation of the Split node.

## Specification
Based on the opset version we add the split as input or attribute:
- opset < 13: split is added as an attribute
- opset >= 13: split is added as an input

## Dependencies & Potential Impact
Affects the modification of all the ONNX models during the conversion process.

## Deployment Plan
None / not applicable

## Testing & Validation
None / not applicable