### PR TITLE
Option to disable `rich` logging

### DIFF
--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -127,7 +127,10 @@ def convert(
 
         output_path = get_output_dir_name(target, cfg.name, output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
-        setup_logging(file=str(output_path / "modelconverter.log"))
+        setup_logging(
+            file=str(output_path / "modelconverter.log"),
+            use_rich=cfg.rich_logging,
+        )
         if is_multistage:
             exporter = MultiStageExporter(
                 target=target, config=cfg, output_dir=output_path
@@ -228,11 +231,13 @@ def infer(
 
     if path is not None:
         config = path
-    setup_logging(file="modelconverter.log")
-    logger.info("Starting inference")
     with catch_exceptions():
         mult_cfg, _, _ = get_configs(str(config), opts)
         cfg = mult_cfg.get_stage_config(stage)
+        setup_logging(
+            file="modelconverter.log", use_rich=mult_cfg.rich_logging
+        )
+        logger.info("Starting inference")
         get_inferer(
             target, model_path, input_path, Path(output_dir), cfg
         ).run()

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -472,6 +472,7 @@ class SingleStageConfig(CustomBaseModel):
 class Config(LuxonisConfig):
     stages: Annotated[dict[str, SingleStageConfig], Field(min_length=1)]
     name: str
+    rich_logging: bool = True
 
     def get_stage_config(self, stage: str | None) -> SingleStageConfig:
         if stage is None:
@@ -492,9 +493,11 @@ class Config(LuxonisConfig):
     def _validate_stages(cls, data: dict[str, Any]) -> dict[str, Any]:
         if "stages" not in data:
             name = data.pop("name", "default_stage")
+            rich_logging = data.pop("rich_logging", True)
             data = {
-                "stages": {name: data},
                 "name": name,
+                "rich_logging": rich_logging,
+                "stages": {name: data},
             }
         else:
             extra = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Pillow
 gcsfs
-luxonis-ml[data,nn_archive]==0.7.1
+luxonis-ml[data,nn_archive]==0.7.2
 onnx>=1.17.0
 onnxruntime
 onnxsim

--- a/shared_with_container/configs/defaults.yaml
+++ b/shared_with_container/configs/defaults.yaml
@@ -2,6 +2,9 @@
 # Name of the model. Will be the stem of the input model if undefined.
 name: ~
 
+# Whether to enable rich formatting for the log messages.
+rich_logging: true
+
 # List of stages for multistage models. Doesn't have to be provided
 # for single-stage models.
 stages:

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -280,6 +280,7 @@ def load_and_compare(
         name = expected["input_model"].stem
         expected = {
             "name": name,
+            "rich_logging": True,
             "stages": {name: expected},
         }
     assert config == expected


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Makes the logs cleaner for debugging

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Added new config field `rich_logging` which is set to `true` by default. When set to `false`, the logging module will not use the `RichHandler`.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable