### PR TITLE
Fixed `openvino_telemetry` version

### DIFF
--- a/.github/workflows/hailo_test.yaml
+++ b/.github/workflows/hailo_test.yaml
@@ -11,8 +11,8 @@ on:
       - 'modelconverter/packages/base_exporter.py'
       - 'modelconverter/packages/base_inferer.py'
       - 'tests/test_packages/test_hailo.py'
-      - 'dockerfiles/Dockerfile.hailo'
-      - 'entrypoints/entrypoint_hailo.sh'
+      - 'docker/hailo/Dockerfile'
+      - 'docker/hailo/entrypoint.sh'
       - '.github/workflows/modelconverter_test.yaml'
       - '.github/workflows/hailo_test.yaml'
 

--- a/.github/workflows/rvc2_test.yaml
+++ b/.github/workflows/rvc2_test.yaml
@@ -11,8 +11,8 @@ on:
       - 'modelconverter/packages/base_exporter.py'
       - 'modelconverter/packages/base_inferer.py'
       - 'tests/test_packages/test_rvc2.py'
-      - 'dockerfiles/Dockerfile.rvc2'
-      - 'entrypoints/entrypoint_rvc2.sh'
+      - 'docker/rvc2/Dockerfile'
+      - 'docker/rvc2/entrypoint.sh'
       - '.github/workflows/modelconverter_test.yaml'
       - '.github/workflows/rvc2_test.yaml'
 

--- a/.github/workflows/rvc3_test.yaml
+++ b/.github/workflows/rvc3_test.yaml
@@ -11,8 +11,8 @@ on:
       - 'modelconverter/packages/base_exporter.py'
       - 'modelconverter/packages/base_inferer.py'
       - 'tests/test_packages/test_rvc3.py'
-      - 'dockerfiles/Dockerfile.rvc3'
-      - 'entrypoints/entrypoint_rvc3.sh'
+      - 'docker/rvc3/Dockerfile'
+      - 'docker/rvc3/entrypoint.sh'
       - '.github/workflows/modelconverter_test.yaml'
       - '.github/workflows/rvc3_test.yaml'
 

--- a/.github/workflows/rvc4_test.yaml
+++ b/.github/workflows/rvc4_test.yaml
@@ -11,8 +11,8 @@ on:
       - 'modelconverter/packages/base_exporter.py'
       - 'modelconverter/packages/base_inferer.py'
       - 'tests/test_packages/test_rvc4.py'
-      - 'dockerfiles/Dockerfile.rvc4'
-      - 'entrypoints/entrypoint_rvc4.sh'
+      - 'docker/rvc4/Dockerfile'
+      - 'docker/rvc4/entrypoint.sh'
       - '.github/workflows/modelconverter_test.yaml'
       - '.github/workflows/rvc4_test.yaml'
 

--- a/docker/rvc2/Dockerfile
+++ b/docker/rvc2/Dockerfile
@@ -53,7 +53,11 @@ RUN <<EOF
 
     set -e
 
-    pip install openvino==${VERSION} openvino-dev==${VERSION} tokenizers==0.20.0
+    pip install openvino==${VERSION} \
+        openvino-dev==${VERSION} \
+        openvino-telemetry==2022.3.0 \
+        tokenizers==0.20.0
+
     # ONNX Runtime needs to be installed together with
     # numpy<1.20 to prevent it from installing higher
     # versions of numpy that are incompatible with OpenVINO 2021.4.0

--- a/docker/rvc3/Dockerfile
+++ b/docker/rvc3/Dockerfile
@@ -30,7 +30,11 @@ RUN <<EOF
     mkdir /opt/intel
     tar xvf openvino-2022.3.0.tar.gz -C /opt/intel/ --strip-components 1
 
-    pip install openvino==2022.3.0 openvino-dev==2022.3.0 --no-cache-dir
+    pip install openvino==2022.3.0 \
+        openvino-dev==2022.3.0 \
+        openvino-telemetry==2022.3.0 \
+        --no-cache-dir
+
     pip install /opt/intel/tools/*.whl
 
 EOF


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes a failing `mo` command.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Freezes the `openvino_telemetry` version for RVC3 to `2022.3.0`
- Fixes triggers for CI tests when docker files are updated 

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable