### PR TITLE
Fix: CLI overrides for `input.encoding` fields

### DIFF
--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -156,7 +156,9 @@ def process_nn_archive(
                 "data_type": inp.dtype.value,
                 "mean_values": mean,
                 "scale_values": scale,
-                "encoding": encoding,
+                "encoding": encoding
+                if isinstance(encoding, dict)
+                else {"from": encoding, "to": encoding},
             }
         )
 
@@ -180,7 +182,7 @@ def process_nn_archive(
                 "input_model": str(input_model_path),
                 "inputs": [],
                 "outputs": [],
-                "encoding": "NONE",
+                "encoding": {"from": "NONE", "to": "NONE"},
             }
             stages[input_model_path.stem] = head_stage_config
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes an error when user provided CLI parameters for the `input.encoding` field.
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable