### PR TITLE
Fix a conversion error when a certain optimization applied before an Erf operation.

### DIFF
--- a/modelconverter/packages/base_exporter.py
+++ b/modelconverter/packages/base_exporter.py
@@ -189,6 +189,7 @@ class Exporter(ABC):
         imgs = read_calib_dir(path)
         if not imgs:
             exit_with(FileNotFoundError(f"No images found in {path}"))
+        imgs = sorted(imgs, key=lambda x: x.name)
         if max_images >= 0:
             logger.info(
                 f"Using [{max_images}/{len(imgs)}] images for calibration."

--- a/modelconverter/packages/rvc4/exporter.py
+++ b/modelconverter/packages/rvc4/exporter.py
@@ -162,7 +162,7 @@ class RVC4Exporter(Exporter):
             f"Quantization finished in {time.time() - start_time:.2f} seconds"
         )
 
-        if not self.keep_raw_images:
+        if not self.keep_raw_images and self.raw_img_dir.exists():
             shutil.rmtree(self.raw_img_dir)
             self.input_list_path.unlink()
 

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -554,6 +554,16 @@ class ONNXModifier:
 
         for node in self.onnx_gs.nodes:
             if node.op == source_node:
+                next_nodes = [
+                    n
+                    for n in self.onnx_gs.nodes
+                    if node.outputs[0] in n.inputs
+                ]
+                if any(n.op == "Erf" for n in next_nodes):
+                    logger.warning(
+                        f"Skipping `substitute_node_by_type ({source_node} -> {target_node})` optimization for node {node.name} with op {node.op} because it is followed by an Erf node."
+                    )
+                    continue
                 constant = self.get_constant_value(node, constant_map)
                 if constant is not None:
                     _, const_idx = constant

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -559,6 +559,7 @@ class ONNXModifier:
                     for n in self.onnx_gs.nodes
                     if node.outputs[0] in n.inputs
                 ]
+                # Skip optimization for nodes followed by Erf operations due to conversion compatibility issues with SNPE 2.32.6.
                 if any(n.op == "Erf" for n in next_nodes):
                     logger.warning(
                         f"Skipping `substitute_node_by_type ({source_node} -> {target_node})` optimization for node {node.name} with op {node.op} because it is followed by an Erf node."


### PR DESCRIPTION
## Purpose

- When the substitute_node_by_type (Div -> Mul) optimization is applied and an `Erf` op follows that creates an issue during the conversion of the onnx to dlc at the `snpe-onnx-to-dlc` command. This issue is not captured and does not affect the model at the onnx level.
- Sort the calibration images by name, which is necessary when working with multi-input modes, to keep all the inputs aligned.
- Check if the directory exists before deleting the raw images (some edge cases tries to delete the folder that does not exist producing an error)

## Specification
None / not applicable

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
None / not applicable