### PR TITLE
Accepting local images with `ghcr.io/` prefix

### DIFF
--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -128,7 +128,7 @@ def get_docker_image(
         docker_image = cast(Image, client.images.pull(f"ghcr.io/{image}", tag))
         docker_image.tag(image, tag)
 
-    except (docker.errors.APIError, docker.errors.DockerException):
+    except Exception:
         logger.error("Failed to pull image, building it locally...")
         docker_build(target, bare_tag, version)
 

--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -117,7 +117,9 @@ def get_docker_image(
     image = f"luxonis/modelconverter-{target}:{tag}"
 
     for docker_image in client.images.list():
-        if {image, f"docker.io/{image}"} & set(docker_image.tags):
+        if {image, f"docker.io/{image}", f"ghcr.io/{image}"} & set(
+            docker_image.tags
+        ):
             return image
 
     logger.warning(f"Image '{image}' not found, pulling latest image...")


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Local images starting with `ghcr.io/` are used instead of ignoring them.
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable