### PR TITLE
RVC4: Simpler support for setting the optimization level.

### DIFF
--- a/modelconverter/packages/rvc4/exporter.py
+++ b/modelconverter/packages/rvc4/exporter.py
@@ -45,6 +45,7 @@ class RVC4Exporter(Exporter):
             rvc4_cfg.use_per_channel_quantization
         )
         self.use_per_row_quantization = rvc4_cfg.use_per_row_quantization
+        self.optimization_level = rvc4_cfg.optimization_level
         self.keep_raw_images = rvc4_cfg.keep_raw_images
         if "--htp_socs" in self.snpe_dlc_graph_prepare:
             i = self.snpe_dlc_graph_prepare.index("--htp_socs")
@@ -108,6 +109,9 @@ class RVC4Exporter(Exporter):
         self._add_args(
             args,
             ["--set_output_tensors", ",".join(name for name in self.outputs)],
+        )
+        self._add_args(
+            args, ["--optimization_level", str(self.optimization_level)]
         )
         self._add_args(args, ["--htp_socs", ",".join(self.htp_socs)])
         if self.compress_to_fp16:

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -269,6 +269,7 @@ class RVC4Config(TargetConfig):
     keep_raw_images: bool = False
     use_per_channel_quantization: bool = True
     use_per_row_quantization: bool = False
+    optimization_level: Literal[1, 2, 3] = 2
     htp_socs: list[
         Literal["sm8350", "sm8450", "sm8550", "sm8650", "qcs6490", "qcs8550"]
     ] = ["sm8550"]

--- a/shared_with_container/configs/defaults.yaml
+++ b/shared_with_container/configs/defaults.yaml
@@ -211,3 +211,6 @@ stages:
       # to `snpe-dlc-graph-prepare`, and the `qcs8550` platform
       # to the `htp_socs` list.
       compress_to_fp16: False
+
+      # Optimization level for the DLC graph preparation. The available levels are: 1, 2, and 3. Higher optimization levels incur longer offline prepare time but yields more optimal graph and hence faster execution time for most graphs.
+      optimization_level: 2

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -65,6 +65,7 @@ DEFAULT_TARGET_CONFIGS = {
         "use_per_channel_quantization": True,
         "use_per_row_quantization": False,
         "compress_to_fp16": False,
+        "optimization_level": 2,
     },
     "hailo": {
         "optimization_level": 2,


### PR DESCRIPTION
## Purpose
Makes it easier to set the optimization level used for the DLC graph preparation on RVC4.

## Specification
- Added new configuration field `rvc4.optimization_level` which will set the respective flag to snpe-dlc-graph-prepare as regards the optimization level used for the DLC graph preparation.

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
None / not applicable