### PR TITLE
Fix: Expand analyzer input types and add logger

### DIFF
--- a/docker/rvc4/Dockerfile
+++ b/docker/rvc4/Dockerfile
@@ -16,8 +16,8 @@ RUN <<EOF
         libc++-dev      \
         ffmpeg          \
         libcurl4        \
-        libncurses5     \
-        llvm-14-runtime \
+        libncurses6     \
+        llvm-19-runtime \
         git
 
 EOF

--- a/docker/rvc4/Dockerfile
+++ b/docker/rvc4/Dockerfile
@@ -78,8 +78,6 @@ COPY --link --from=base \
     /usr/lib/x86_64-linux-gnu/librtmp.so.1 \
     /usr/lib/x86_64-linux-gnu/libssh2.so.1 \
     /usr/lib/x86_64-linux-gnu/libpsl.so.5 \
-    /usr/lib/x86_64-linux-gnu/libldap-2.5.so.0 \
-    /usr/lib/x86_64-linux-gnu/liblber-2.5.so.0 \
     /usr/lib/x86_64-linux-gnu/libbrotlidec.so.1 \
     /usr/lib/x86_64-linux-gnu/libsasl2.so.2 \
     /usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1 \
@@ -97,13 +95,9 @@ COPY --link --from=base \
     /usr/lib/x86_64-linux-gnu/libc++abi.so.1 \
     /usr/lib/x86_64-linux-gnu/libunwind.so.1 \
     /usr/lib/x86_64-linux-gnu/libatomic.so.1 \
-    /usr/lib/x86_64-linux-gnu/libtinfo.so.5 \
-    /usr/lib/x86_64-linux-gnu/libLLVM-19.so.1 \
     /usr/lib/x86_64-linux-gnu/libedit.so.2 \
     /usr/lib/x86_64-linux-gnu/libz3.so.4 \
     /usr/lib/x86_64-linux-gnu/libxml2.so.2 \
-    /usr/lib/x86_64-linux-gnu/libicuuc.so.72 \
-    /usr/lib/x86_64-linux-gnu/libicudata.so.72 \
     /usr/lib/
 
 

--- a/docker/rvc4/Dockerfile
+++ b/docker/rvc4/Dockerfile
@@ -98,7 +98,7 @@ COPY --link --from=base \
     /usr/lib/x86_64-linux-gnu/libunwind.so.1 \
     /usr/lib/x86_64-linux-gnu/libatomic.so.1 \
     /usr/lib/x86_64-linux-gnu/libtinfo.so.5 \
-    /usr/lib/x86_64-linux-gnu/libLLVM-14.so.1 \
+    /usr/lib/x86_64-linux-gnu/libLLVM-19.so.1 \
     /usr/lib/x86_64-linux-gnu/libedit.so.2 \
     /usr/lib/x86_64-linux-gnu/libz3.so.4 \
     /usr/lib/x86_64-linux-gnu/libxml2.so.2 \

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -369,9 +369,12 @@ def benchmark(
 @app.meta.command(group=device_commands)
 def analyze(
     *,
+    device_id: str | None = None,
     dlc_model_path: str,
     onnx_model_path: str,
-    image_dirs: Annotated[list[str], Parameter(negative_iterable=[], consume_multiple=True)],
+    image_dirs: Annotated[
+        list[str], Parameter(negative_iterable=[], consume_multiple=True)
+    ],
     analyze_outputs: bool = True,
     analyze_cycles: bool = True,
 ) -> None:
@@ -412,7 +415,9 @@ def analyze(
                 for i in range(0, len(image_dirs), 2)
             }
 
-        analyzer = get_analyzer(Target.RVC4, dlc_model_path, image_dirs_dict)
+        analyzer = get_analyzer(
+            Target.RVC4, device_id, dlc_model_path, image_dirs_dict
+        )
         if analyze_outputs:
             logger.info("Analyzing layer outputs")
             analyzer.analyze_layer_outputs(

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -365,7 +365,6 @@ def benchmark(
     get_benchmark(target, model_path).run(full=full, save=save, **kwargs)
 
 
-# TODO: Specify device ID in case more than one device is connected
 @app.meta.command(group=device_commands)
 def analyze(
     *,
@@ -385,6 +384,8 @@ def analyze(
 
     Parameters
     ----------
+    device_id : str | None
+        The ID of the device to run the analysis on. If not provided, the first listed device will be used.
     dlc_model_path : str
         The path to the DLC model file.
 

--- a/modelconverter/packages/base_analyze.py
+++ b/modelconverter/packages/base_analyze.py
@@ -88,6 +88,7 @@ class Analyzer(ABC):
         ln = ln.replace("/", "_")
         ln = ln.replace("_output_0", "")
         ln = ln.replace("(cycles)", "")
+
         return ln.strip("_")
 
     def _get_output_sizes(self) -> dict[str, list[int]]:

--- a/modelconverter/packages/rvc4/analyze.py
+++ b/modelconverter/packages/rvc4/analyze.py
@@ -251,7 +251,7 @@ class RVC4Analyzer(Analyzer):
                 "max_abs_diff",
                 "MSE",
                 "cos_sim",
-                "max_absolute_percentage_error",
+                "mean_absolute_percentage_error",
             ],
             orient="row",
         )
@@ -260,16 +260,16 @@ class RVC4Analyzer(Analyzer):
                 pl.col("max_abs_diff").mean().alias("max_abs_diff"),
                 pl.col("MSE").mean().alias("MSE"),
                 pl.col("cos_sim").mean().alias("cos_sim"),
-                pl.col("max_absolute_percentage_error")
+                pl.col("mean_absolute_percentage_error")
                 .mean()
-                .alias("max_absolute_percentage_error"),
+                .alias("mean_absolute_percentage_error"),
             ]
         )
         grouped_df = grouped_df.with_columns(
             pl.col("max_abs_diff").round(6),
             pl.col("MSE").round(6),
             pl.col("cos_sim").round(6),
-            pl.col("max_absolute_percentage_error").round(4),
+            pl.col("mean_absolute_percentage_error").round(4),
         )
 
         layer_mapping = {name: idx for idx, name in enumerate(layer_names)}

--- a/modelconverter/packages/rvc4/analyze.py
+++ b/modelconverter/packages/rvc4/analyze.py
@@ -9,6 +9,7 @@ import onnx
 import onnx.onnx_pb
 import onnxruntime as rt
 import polars as pl
+from loguru import logger
 from PIL import Image
 
 from modelconverter.packages.base_analyze import Analyzer
@@ -16,9 +17,16 @@ from modelconverter.utils import AdbHandler, constants, subprocess_run
 
 
 class RVC4Analyzer(Analyzer):
-    def __init__(self, dlc_model_path: str, image_dirs: dict[str, str]):
+    def __init__(
+        self,
+        device_id: str | None,
+        dlc_model_path: str,
+        image_dirs: dict[str, str],
+    ):
         super().__init__(dlc_model_path, image_dirs)
-        self.adb = AdbHandler()
+        self.adb = AdbHandler(device_id)
+
+        self.device_id = device_id
 
     def analyze_layer_outputs(self, onnx_model_path: Path) -> None:
         input_matcher = self._prepare_input_matcher()
@@ -66,6 +74,7 @@ class RVC4Analyzer(Analyzer):
     def _prepare_raw_inputs(
         self, input_matcher: dict[str, dict[str, str]], type: type = np.uint8
     ) -> dict[str, str]:
+        logger.info("Preparing raw inputs for RVC4 analysis.")
         self.adb.shell(f"rm -rf /data/local/tmp/{self.model_name}")
         self.adb.shell(f"mkdir -p /data/local/tmp/{self.model_name}/inputs")
 
@@ -75,23 +84,30 @@ class RVC4Analyzer(Analyzer):
             input_row = ""
             dlc_matcher[i] = "Result_" + str(i)
             for input_name, img_path in input_dict.items():
-                if not img_path.endswith((".png", ".jpg")):
+                if not img_path.endswith((".png", ".jpg", ".npy")):
                     continue
                 img_name = Path(img_path).stem
-                width_height = self.input_sizes[input_name][1:3][::-1]
-                image = self._resize_image(img_path, width_height)
-                image = image.astype(type)
-                raw_image = cast(np.ndarray, image).astype(type)
+                if img_path.endswith(
+                    ".npy"
+                ):  # expects numpy array to already be in correct format
+                    raw_image = cast(np.ndarray, np.load(img_path)).astype(
+                        type
+                    )
+                else:
+                    width_height = self.input_sizes[input_name][1:3][::-1]
+                    image = self._resize_image(img_path, width_height)
+                    image = image.astype(type)
+                    raw_image = cast(np.ndarray, image).astype(type)
 
                 with tempfile.NamedTemporaryFile() as f:
                     raw_image.tofile(f)
                     self.adb.push(
                         f.name,
-                        f"/data/local/tmp/{self.model_name}/inputs/{img_name}.raw",
+                        f"/data/local/tmp/{self.model_name}/inputs/{input_name}_{img_name}.raw",
                     )
                     f.close()
 
-                input_row += f"{input_name}:=/data/local/tmp/{self.model_name}/inputs/{img_name}.raw "
+                input_row += f"{input_name}:=/data/local/tmp/{self.model_name}/inputs/{input_name}_{img_name}.raw "
             input_list += input_row
             input_list += "\n"
 
@@ -102,7 +118,9 @@ class RVC4Analyzer(Analyzer):
                 f.name, f"/data/local/tmp/{self.model_name}/input_list.txt"
             )
             f.close()
-
+        logger.info(
+            f"Raw inputs pushed to device at /data/local/tmp/{self.model_name}/input_list.txt"
+        )
         return dlc_matcher
 
     def _add_outputs_to_all_layers(self, onnx_file_path: str) -> Path:
@@ -130,12 +148,42 @@ class RVC4Analyzer(Analyzer):
 
         return Path(all_output_name)
 
+    def transpose_to_match(
+        self, src: np.ndarray, target_shape: tuple[int, ...]
+    ) -> np.ndarray:
+        if src.shape == target_shape:
+            return src
+
+        candidates = {
+            2: [(1, 0)],
+            3: [
+                (0, 2, 1),  # N W C <-> N C W
+            ],
+            4: [
+                (0, 3, 1, 2),  # NHWC -> NCHW
+                (0, 2, 3, 1),  # NCHW -> NHWC
+                (0, 1, 3, 2),  # N C H W -> N C W H
+                (0, 3, 2, 1),  # N H W C -> N W H C
+            ],
+            5: [
+                (0, 4, 1, 2, 3),  # NDHWC -> NCDHW
+                (0, 2, 3, 4, 1),  # NCDHW -> NDHWC
+            ],
+        }
+
+        for perm in candidates.get(src.ndim, []):
+            if tuple(np.array(src.shape)[list(perm)]) == target_shape:
+                return np.transpose(src, perm)
+
+        raise ValueError(f"Cannot align shapes: {src.shape} -> {target_shape}")
+
     def _compare_to_onnx(
         self,
         onnx_model_path: str,
         input_matcher: dict[str, dict[str, str]],
         dlc_matcher: dict[str, Path],
     ) -> None:
+        logger.info("Comparing ONNX and DLC layer outputs.")
         onnx_all_layers = self._add_outputs_to_all_layers(str(onnx_model_path))
         session = rt.InferenceSession(onnx_all_layers)
         output_names = [layer.name for layer in session.get_outputs()]
@@ -144,21 +192,27 @@ class RVC4Analyzer(Analyzer):
 
         statistics = []
         onnx_input_shapes = {}
+        logger.info("Inferencing ONNX model.")
         for input_metadata in session.get_inputs():
             onnx_input_shapes[input_metadata.name] = input_metadata.shape
 
         for i, input_dict in input_matcher.items():
             onnx_input_dict = {}
             for input_name, img_path in input_dict.items():
-                if not img_path.endswith((".png", ".jpg")):
+                if not img_path.endswith((".png", ".jpg", ".npy")):
                     continue
 
-                shape = onnx_input_shapes[input_name][2:][::-1]
-                image = self._resize_image(img_path, shape)
-                image = np.transpose(
-                    image, [2, 0, 1]
-                )  # NCHW format is assumed by default and resize returns HWC
-                image = np.expand_dims(image, axis=0).astype(np.float32)
+                if img_path.endswith(
+                    ".npy"
+                ):  # expects numpy array to already be in correct format
+                    image = np.load(img_path)
+                else:
+                    shape = onnx_input_shapes[input_name][2:][::-1]
+                    image = self._resize_image(img_path, shape)
+                    image = np.transpose(
+                        image, [2, 0, 1]
+                    )  # NCHW format is assumed by default and resize returns HWC
+                    image = np.expand_dims(image, axis=0).astype(np.float32)
 
                 onnx_input_dict[input_name] = image
 
@@ -166,6 +220,7 @@ class RVC4Analyzer(Analyzer):
 
             dlc_output_path = dlc_matcher[i]
 
+            logger.info("Calculating statistics for ONNX and DLC outputs.")
             for layer_name, onnx_layer_output in zip(
                 layer_names, outputs, strict=True
             ):
@@ -179,10 +234,9 @@ class RVC4Analyzer(Analyzer):
                 dlc_layer_output = np.frombuffer(raw_data, dtype=np.float32)
                 dlc_layer_output = dlc_layer_output.reshape(dlc_layer_size)
 
-                if dlc_layer_output.shape != onnx_layer_output.shape:
-                    dlc_layer_output = np.transpose(
-                        dlc_layer_output, [0, 3, 1, 2]
-                    )
+                dlc_layer_output = self.transpose_to_match(
+                    dlc_layer_output, onnx_layer_output.shape
+                )
 
                 layer_stats = self._calculate_statistics(
                     onnx_layer_output, dlc_layer_output
@@ -192,7 +246,13 @@ class RVC4Analyzer(Analyzer):
         output_dir = f"{constants.OUTPUTS_DIR!s}/analysis/{self.model_name}"
         stats_df = pl.DataFrame(
             statistics,
-            schema=["layer_name", "max_abs_diff", "MSE", "cos_sim"],
+            schema=[
+                "layer_name",
+                "max_abs_diff",
+                "MSE",
+                "cos_sim",
+                "max_absolute_percentage_error",
+            ],
             orient="row",
         )
         grouped_df = stats_df.group_by("layer_name").agg(
@@ -200,7 +260,16 @@ class RVC4Analyzer(Analyzer):
                 pl.col("max_abs_diff").mean().alias("max_abs_diff"),
                 pl.col("MSE").mean().alias("MSE"),
                 pl.col("cos_sim").mean().alias("cos_sim"),
+                pl.col("max_absolute_percentage_error")
+                .mean()
+                .alias("max_absolute_percentage_error"),
             ]
+        )
+        grouped_df = grouped_df.with_columns(
+            pl.col("max_abs_diff").round(6),
+            pl.col("MSE").round(6),
+            pl.col("cos_sim").round(6),
+            pl.col("max_absolute_percentage_error").round(4),
         )
 
         layer_mapping = {name: idx for idx, name in enumerate(layer_names)}
@@ -214,6 +283,9 @@ class RVC4Analyzer(Analyzer):
 
         grouped_df = grouped_df.drop("order")
         grouped_df.write_csv(f"{output_dir}/layer_comparison.csv")
+        logger.info(
+            f"Layer comparison results saved to {output_dir}/layer_comparison.csv"
+        )
         Path(onnx_all_layers).unlink()
 
     def _calculate_statistics(
@@ -221,51 +293,84 @@ class RVC4Analyzer(Analyzer):
     ) -> list:
         max_abs_diff = np.max(np.abs(onnx_output - dlc_output))
         mse = np.mean((onnx_output - dlc_output) ** 2)
+
         cosine_sim = np.dot(onnx_output.flatten(), dlc_output.flatten()) / (
             np.linalg.norm(onnx_output.flatten())
             * np.linalg.norm(dlc_output.flatten())
         )
+        mean_ape = np.mean(
+            np.abs((onnx_output - dlc_output) / (onnx_output + 1e-8))
+        )
+        logger.debug(
+            f"Max absolute difference: {max_abs_diff}, MSE: {mse}, Cosine similarity: {cosine_sim}, Mean absolute percentage error: {mean_ape}"
+        )
 
-        return [max_abs_diff, mse, cosine_sim]
+        return [max_abs_diff, mse, cosine_sim, mean_ape]
 
     def _run_dlc(self, command: str) -> str:
-        self.adb.push(
-            str(self.dlc_model_path),
-            f"/data/local/tmp/{self.model_name}/{self.model_name}.dlc",
-        )
-        self.adb.shell(f"rm -rf /data/local/tmp/{self.model_name}/output")
-        self.adb.shell(f"cd /data/local/tmp/{self.model_name} && {command}")
+        logger.info("Inferencing DLC model on device.")
+        try:
+            self.adb.push(
+                str(self.dlc_model_path),
+                f"/data/local/tmp/{self.model_name}/{self.model_name}.dlc",
+            )
+            self.adb.shell(f"rm -rf /data/local/tmp/{self.model_name}/output")
+            self.adb.shell(
+                f"cd /data/local/tmp/{self.model_name} && {command}"
+            )
 
-        target_dir = constants.OUTPUTS_DIR / "analysis" / self.model_name
-        if (target_dir / "output").exists():
-            shutil.rmtree(target_dir / "output")
+            target_dir = constants.OUTPUTS_DIR / "analysis" / self.model_name
+            if (target_dir / "output").exists():
+                shutil.rmtree(target_dir / "output")
 
-        target_dir.mkdir(parents=True, exist_ok=True)
-        self.adb.pull(
-            f"/data/local/tmp/{self.model_name}/output", f"{target_dir}/output"
-        )
+            target_dir.mkdir(parents=True, exist_ok=True)
+            self.adb.pull(
+                f"/data/local/tmp/{self.model_name}/output",
+                f"{target_dir}/output",
+            )
+            logger.info(
+                f"Raw outputs pulled from device to {target_dir}/output"
+            )
+        except Exception as e:
+            logger.error(f"Error during DLC inference: {e}")
+            raise RuntimeError(
+                f"Failed to run DLC model with command: {command}"
+            ) from e
 
         return f"{target_dir}/output"
 
     def _flatten_dlc_outputs(self, dlc_matcher: dict[str, Path]) -> None:
+        logger.info("Flattening SNPE results.")
         for result_path in dlc_matcher.values():
-            # TODO: replace with `iterdir`
-            for root, _, files in os.walk(result_path):
-                for file in files:
-                    relative_path = os.path.relpath(root, result_path)
-                    new_file_name = (
-                        relative_path.replace(os.sep, "_") + f"_{file}"
-                    )
-                    new_file_name = new_file_name.strip(".raw")
-                    new_file_name = self._replace_bad_layer_names(
-                        [new_file_name]
-                    )[0]
+            root = Path(result_path)
 
-                    source_path = str(Path(root, file))
-                    if source_path not in f"{result_path}/{new_file_name}.raw":
-                        shutil.copy(
-                            source_path, f"{result_path}/{new_file_name}.raw"
-                        )
+            def walk(dir_path: Path, *, base: Path) -> None:
+                for entry in dir_path.iterdir():
+                    if entry.is_dir():
+                        walk(entry, base=base)
+
+                    if not entry.is_file():
+                        continue
+
+                    relative_path = entry.parent.relative_to(base)
+                    prefix = (
+                        "_".join(relative_path.parts) if relative_path else ""
+                    )
+                    new_file_name = (
+                        f"{prefix}_{entry.stem}" if prefix else entry.stem
+                    )
+                    new_file_name = self._replace_bad_layer_name(
+                        str(new_file_name)
+                    )
+
+                    dest = base / f"{new_file_name}.raw"
+                    if dest.exists() and entry.samefile(dest):
+                        continue
+
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(entry, dest)
+
+            walk(result_path, base=root)
 
             with os.scandir(result_path) as entries:
                 for entry in entries:
@@ -277,6 +382,7 @@ class RVC4Analyzer(Analyzer):
         input_matcher = self._prepare_input_matcher()
         _ = self._prepare_raw_inputs(input_matcher)
 
+        logger.info("Running DLC model to analyze layer cycles.")
         output_dir = self._run_dlc(
             f"snpe-net-run --container {self.model_name}.dlc --input_list input_list.txt --use_dsp --use_native_input_files --use_native_output_files --perf_profile balanced --userbuffer_tf8"
         )
@@ -302,7 +408,6 @@ class RVC4Analyzer(Analyzer):
 
     def _process_diagview_csv(self, csv_path: str) -> None:
         df = pl.read_csv(csv_path)
-        df = df.drop_nans()
         df = df.drop_nulls()
         layer_stats = df.group_by("Layer Id").agg(
             pl.col("Time").mean().round(0).cast(int).alias("time_mean"),
@@ -324,6 +429,12 @@ class RVC4Analyzer(Analyzer):
             pl.col("time_mean")
             .mul(1 / total_time)
             .alias("Percentage_of_Total_Time"),
+        )
+
+        layer_stats = layer_stats.with_columns(
+            pl.col("Percentage_of_Total_Time")
+            .round(6)
+            .alias("Percentage_of_Total_Time")
         )
 
         layer_stats = layer_stats.sort("layer_id")

--- a/modelconverter/utils/adb_handler.py
+++ b/modelconverter/utils/adb_handler.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 
 from loguru import logger
@@ -8,6 +9,7 @@ class AdbHandler:
     def __init__(
         self, device_id: str | None = None, silent: bool = True
     ) -> None:
+        device_id = self._check_adb_connection(device_id)
         self.device_args = ["-s", device_id] if device_id else []
         self.silent = silent
 
@@ -49,3 +51,29 @@ class AdbHandler:
 
     def push(self, src: PathType, dst: PathType) -> tuple[int, str, str]:
         return self._adb_run("push", src, dst)
+
+    def _check_adb_connection(self, device_id: str | None) -> str:
+        result = subprocess.run(
+            "adb devices", check=False, capture_output=True
+        )
+        if result.returncode == 0:
+            pattern = re.compile(r"^(\w+)\s+device$", re.MULTILINE)
+            devices = pattern.findall(result.stdout.decode())
+        else:
+            raise RuntimeError("Unable to verify device ID")
+
+        if device_id is None:
+            if len(devices) == 0:
+                raise RuntimeError("No devices connected")
+            logger.warning(
+                "No device ID specified, using the first connected "
+                f"device: {devices[0]}"
+            )
+            return devices[0]
+        if device_id not in devices:
+            raise ValueError(
+                f"Device ID '{device_id}' not found in connected devices: {devices}"
+            )
+        logger.info(f"Using device ID: {device_id}")
+
+        return device_id

--- a/modelconverter/utils/adb_handler.py
+++ b/modelconverter/utils/adb_handler.py
@@ -54,7 +54,7 @@ class AdbHandler:
 
     def _check_adb_connection(self, device_id: str | None) -> str:
         result = subprocess.run(
-            "adb devices", check=False, capture_output=True
+            ["adb", "devices"], check=False, capture_output=True
         )
         if result.returncode == 0:
             pattern = re.compile(r"^(\w+)\s+device$", re.MULTILINE)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
This PR expands analyzer to accept npy input types, adds a logger and fixes issues regarding output name checking and comparison.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Changes: 
- Add logger to analyze tool
- Option to specify adb device id instead of the tool automatically picking the first one.
- add support for `.npy` input file types ( tool assumes all preprocessing has been applied and that the npy files are in FP32 format)
- Instead of a hardcoded single transformation option from NCHW -> NHWC, added all possible transformations from 2 dims to 5 dims ( `transpose_to_match` method)
- added `mean_absolute_percentage_error` metric, round all metrics to 6 decimal places
- Improved layer name sanitation due to problems with `strip` method.
-
## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->


## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Tested with YOLOE model and some images.  