### PR TITLE
Uploading intermediate outputs

### DIFF
--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -33,7 +33,7 @@ from modelconverter.utils import (
     docker_exec,
     in_docker,
     resolve_path,
-    upload_file_to_remote,
+    upload_to_remote,
 )
 from modelconverter.utils.config import SingleStageConfig
 from modelconverter.utils.constants import MODELS_DIR
@@ -193,7 +193,7 @@ def convert(
         if upload_url is not None:
             for model_path in out_models:
                 logger.info(f"Uploading {model_path} to {upload_url}")
-                upload_file_to_remote(
+                upload_to_remote(
                     model_path,
                     upload_url,
                     put_file_plugin,
@@ -211,7 +211,7 @@ def convert(
                 logger.info(
                     f"Uploading intermediate outputs to {intermediate_url}"
                 )
-                upload_file_to_remote(
+                upload_to_remote(
                     exporter.intermediate_outputs_dir,
                     intermediate_url,
                     put_file_plugin,
@@ -503,7 +503,7 @@ def archive(
     ).make_archive()
 
     if protocol != "file":
-        upload_file_to_remote(archive_save_path, save_path, put_file_plugin)
+        upload_to_remote(archive_save_path, save_path, put_file_plugin)
         Path(archive_save_path).unlink()
         logger.info(f"Archive uploaded to {save_path}")
     else:

--- a/modelconverter/utils/__init__.py
+++ b/modelconverter/utils/__init__.py
@@ -18,7 +18,7 @@ from .filesystem_utils import (
     download_from_remote,
     get_protocol,
     resolve_path,
-    upload_file_to_remote,
+    upload_to_remote,
 )
 from .general import sanitize_net_name
 from .hubai_utils import is_hubai_available
@@ -65,5 +65,5 @@ __all__ = [
     "resolve_path",
     "sanitize_net_name",
     "subprocess_run",
-    "upload_file_to_remote",
+    "upload_to_remote",
 ]

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -296,6 +296,7 @@ class SingleStageConfig(CustomBaseModel):
     disable_onnx_simplification: bool = False
     disable_onnx_optimization: bool = False
     output_remote_url: str | None = None
+    intermediate_outputs_remote_url: str | None = None
     put_file_plugin: str | None = None
 
     hailo: HailoConfig = HailoConfig()

--- a/modelconverter/utils/filesystem_utils.py
+++ b/modelconverter/utils/filesystem_utils.py
@@ -53,17 +53,21 @@ def download_from_remote(
     return local_path
 
 
-def upload_file_to_remote(
+def upload_to_remote(
     local_path: Path | str,
     url: str,
     put_file_plugin: str | None = None,
 ) -> None:
     """Uploads a file to remote bucket storage."""
 
+    local_path = Path(local_path)
     absolute_path, remote_path = LuxonisFileSystem.split_full_path(url)
     fs = LuxonisFileSystem(absolute_path, put_file_plugin=put_file_plugin)
 
-    fs.put_file(str(local_path), remote_path)
+    if local_path.is_dir():
+        fs.put_dir(local_path, remote_path)
+    else:
+        fs.put_file(local_path, remote_path)
 
 
 def get_protocol(url: str) -> str:

--- a/shared_with_container/configs/defaults.yaml
+++ b/shared_with_container/configs/defaults.yaml
@@ -82,6 +82,9 @@ stages:
     # Remote path where to upload the compiled model. Optional.
     output_remote_url: ~
 
+    # Remote path where to upload the intermediate outputs.
+    intermediate_outputs_remote_url: ~
+
     # Keep the intermediate files created during the compilation.
     keep_intermediate_outputs: true
 

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -92,6 +92,7 @@ DEFAULT_GENERAL_CONFIG = {
     "disable_onnx_simplification": False,
     "disable_onnx_optimization": False,
     "output_remote_url": None,
+    "intermediate_outputs_remote_url": None,
     "put_file_plugin": None,
     "input_bin": None,
     "input_file_type": InputFileType.ONNX,

--- a/tests/test_utils/test_filesystem.py
+++ b/tests/test_utils/test_filesystem.py
@@ -7,7 +7,7 @@ import pytest
 
 from modelconverter.utils.filesystem_utils import (
     download_from_remote,
-    upload_file_to_remote,
+    upload_to_remote,
 )
 
 S3_BASE_URL = "s3://luxonis-test-bucket/modelconverter-test/test_data/test_utils/test_s3_tools/"
@@ -48,9 +48,7 @@ def setup_remote_tests():
 
 @skip_if_no_remote_credentials
 def test_dir():
-    upload_file_to_remote(
-        LOCAL_FILE_IN_DIR_PATH, f"{S3_DIR_URL}/file_in_dir.txt"
-    )
+    upload_to_remote(LOCAL_FILE_IN_DIR_PATH, f"{S3_DIR_URL}/file_in_dir.txt")
     download_from_remote(S3_DIR_URL, S3_LOCAL_ROOT)
     assert S3_LOCAL_FILE_IN_DIR_PATH.exists()
     assert sorted(path.name for path in S3_LOCAL_DIR_PATH.iterdir()) == sorted(
@@ -62,7 +60,7 @@ def test_dir():
 
 @skip_if_no_remote_credentials
 def test_file():
-    upload_file_to_remote(LOCAL_FILE_PATH, S3_FILE_URL)
+    upload_to_remote(LOCAL_FILE_PATH, S3_FILE_URL)
     download_from_remote(S3_FILE_URL, S3_LOCAL_ROOT)
     assert S3_LOCAL_FILE_PATH.exists()
     assert S3_LOCAL_FILE_PATH.read_text() == LOCAL_FILE_PATH.read_text()


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Makes it possible to upload intermediate outputs to a remote URL.
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Added field `intermediate_outputs_remote_url` to the config. 

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable