### PR TITLE
Benchmarking for a specific time duration

### DIFF
--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -285,6 +285,9 @@ def benchmark(
     full: bool = False,
     save: bool = False,
     repetitions: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 10,
+    benchmark_time: Annotated[
+        int | None, Parameter(group=["RVC2", "RVC4"])
+    ] = None,
     num_threads: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 2,
     num_messages: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 50,
     requests: Annotated[int, Parameter(group="RVC3")] = 1,
@@ -324,6 +327,8 @@ def benchmark(
 
     repetitions : int
         The number of repetitions to perform. Only relevant for DAI benchmark.
+    benchmark_time : int | None
+        The duration in seconds for time-based benchmarking (overrides repetitions).
     num_threads : int
         The number of threads to use for inference. Only relevant for DAI benchmark.
     num_messages : int
@@ -347,6 +352,7 @@ def benchmark(
     if target in {Target.RVC2, Target.RVC4}:
         kwargs = {
             "repetitions": repetitions,
+            "benchmark_time": benchmark_time,
             "num_threads": num_threads,
             "num_messages": num_messages,
         }

--- a/modelconverter/packages/base_benchmark.py
+++ b/modelconverter/packages/base_benchmark.py
@@ -161,6 +161,20 @@ class Benchmark(ABC):
             (configuration, self.benchmark(configuration))
             for configuration in configurations
         ]
+
+        # Clean up configuration keys: keep either benchmark_time or repetitions
+        for configuration, _ in results:
+            if configuration.get("benchmark_time"):
+                items = list(configuration.items())
+                configuration.clear()
+                for k, v in items:
+                    if k == "benchmark_time":
+                        configuration["benchmark_time (s)"] = v
+                    elif k != "repetitions":
+                        configuration[k] = v
+            else:
+                configuration.pop("benchmark_time", None)
+
         self.print_results(results)
         if save:
             self.save_results(results)

--- a/modelconverter/packages/rvc2/benchmark.py
+++ b/modelconverter/packages/rvc2/benchmark.py
@@ -1,8 +1,9 @@
+import time
 from pathlib import Path
 
 import depthai as dai
 import numpy as np
-from rich.progress import Progress
+from rich.progress import Progress, TextColumn
 
 from modelconverter.packages.base_benchmark import (
     Benchmark,
@@ -16,10 +17,17 @@ class RVC2Benchmark(Benchmark):
     @property
     def default_configuration(self) -> Configuration:
         """
-        repetitions: The number of repetitions to perform.
+        repetitions: The number of repetitions to perform (ignored if benchmark_time is set).
+        benchmark_time: Duration in seconds for time-based benchmarking (overrides repetitions).
+        num_messages: The number of messages to send for benchmarking.
         num_threads: The number of threads to use for inference.
         """
-        return {"repetitions": 10, "num_messages": 50, "num_threads": 2}
+        return {
+            "repetitions": 10,
+            "benchmark_time": None,
+            "num_messages": 50,
+            "num_threads": 2,
+        }
 
     @property
     def all_configurations(self) -> list[Configuration]:
@@ -34,6 +42,7 @@ class RVC2Benchmark(Benchmark):
         repetitions: int,
         num_messages: int,
         num_threads: int,
+        benchmark_time: int | None = None,
     ) -> BenchmarkResult:
         device = dai.Device()
         if device.getPlatform() != dai.Platform.RVC2:
@@ -82,10 +91,23 @@ class RVC2Benchmark(Benchmark):
             )
             inputData.addTensor(name, img)
 
-        with dai.Pipeline(device) as pipeline, Progress() as progress:
-            repet_task = progress.add_task(
-                "[magenta]Repetition", total=repetitions
-            )
+        with dai.Pipeline(device) as pipeline:
+            if benchmark_time:
+
+                def format_time(seconds: float) -> str:
+                    mins = int(seconds // 60)
+                    secs = int(seconds % 60)
+                    return f"{mins:02d}:{secs:02d}"
+
+                progress = Progress(TextColumn("{task.description}"))
+                progress_task = progress.add_task("", total=benchmark_time)
+            else:
+                progress = Progress()
+                progress_task = progress.add_task(
+                    "[magenta]Repetition", total=repetitions
+                )
+
+            progress.start()
 
             benchmarkOut = pipeline.create(dai.node.BenchmarkOut)
             benchmarkOut.setRunOnHost(False)
@@ -117,19 +139,47 @@ class RVC2Benchmark(Benchmark):
             rep = 0
             fps_list = []
             avg_latency_list = []
-            while pipeline.isRunning() and rep < repetitions:
-                benchmarkReport = outputQueue.get()
-                if not isinstance(benchmarkReport, dai.BenchmarkReport):
-                    raise TypeError(
-                        f"Expected BenchmarkReport, got {type(benchmarkReport)}"
-                    )
-                fps = benchmarkReport.fps
-                avg_latency = benchmarkReport.averageLatency * 1000
 
-                fps_list.append(fps)
-                avg_latency_list.append(avg_latency)
-                progress.update(repet_task, advance=1)
-                rep += 1
+            if benchmark_time:
+                start_time = time.time()
+                while (
+                    pipeline.isRunning()
+                    and (time.time() - start_time) < benchmark_time
+                ):
+                    benchmarkReport = outputQueue.get()
+                    if not isinstance(benchmarkReport, dai.BenchmarkReport):
+                        raise TypeError(
+                            f"Expected BenchmarkReport, got {type(benchmarkReport)}"
+                        )
+                    fps = benchmarkReport.fps
+                    avg_latency = benchmarkReport.averageLatency * 1000
+
+                    fps_list.append(fps)
+                    avg_latency_list.append(avg_latency)
+
+                    elapsed = time.time() - start_time
+                    capped_elapsed = min(elapsed, benchmark_time)
+                    elapsed_str = format_time(capped_elapsed)
+                    total_str = format_time(benchmark_time)
+                    progress.update(
+                        progress_task,
+                        description=f"[magenta]Time Elapsed (mm:ss) [cyan]{elapsed_str} / {total_str}",
+                    )
+            else:
+                while pipeline.isRunning() and rep < repetitions:
+                    benchmarkReport = outputQueue.get()
+                    if not isinstance(benchmarkReport, dai.BenchmarkReport):
+                        raise TypeError(
+                            f"Expected BenchmarkReport, got {type(benchmarkReport)}"
+                        )
+                    fps = benchmarkReport.fps
+                    avg_latency = benchmarkReport.averageLatency * 1000
+
+                    fps_list.append(fps)
+                    avg_latency_list.append(avg_latency)
+                    progress.update(progress_task, advance=1)
+                    rep += 1
+            progress.stop()
 
             # Currently, the latency measurement is not supported on RVC2 by the depthai library.
             return BenchmarkResult(float(np.mean(fps_list)), "N/A")

--- a/modelconverter/packages/rvc2/benchmark.py
+++ b/modelconverter/packages/rvc2/benchmark.py
@@ -1,16 +1,14 @@
-import time
 from pathlib import Path
 
 import depthai as dai
 import numpy as np
-from rich.progress import Progress, TextColumn
 
 from modelconverter.packages.base_benchmark import (
     Benchmark,
     BenchmarkResult,
     Configuration,
 )
-from modelconverter.utils import environ
+from modelconverter.utils import create_progress_handler, environ
 
 
 class RVC2Benchmark(Benchmark):
@@ -74,7 +72,7 @@ class RVC2Benchmark(Benchmark):
         inputSizes = []
         inputNames = []
         if isinstance(model_path, str) or str(model_path).endswith(".tar.xz"):
-            modelArhive = dai.NNArchive(str(modelPath))
+            modelArhive = dai.NNArchive(str(modelPath))  # type: ignore[arg-type]
             for input in modelArhive.getConfig().model.inputs:
                 inputSizes.append(input.shape[::-1])
                 inputNames.append(input.name)
@@ -92,23 +90,6 @@ class RVC2Benchmark(Benchmark):
             inputData.addTensor(name, img)
 
         with dai.Pipeline(device) as pipeline:
-            if benchmark_time:
-
-                def format_time(seconds: float) -> str:
-                    mins = int(seconds // 60)
-                    secs = int(seconds % 60)
-                    return f"{mins:02d}:{secs:02d}"
-
-                progress = Progress(TextColumn("{task.description}"))
-                progress_task = progress.add_task("", total=benchmark_time)
-            else:
-                progress = Progress()
-                progress_task = progress.add_task(
-                    "[magenta]Repetition", total=repetitions
-                )
-
-            progress.start()
-
             benchmarkOut = pipeline.create(dai.node.BenchmarkOut)
             benchmarkOut.setRunOnHost(False)
             benchmarkOut.setFps(-1)
@@ -136,50 +117,27 @@ class RVC2Benchmark(Benchmark):
             pipeline.start()
             inputQueue.send(inputData)
 
-            rep = 0
+            progress, on_tick, should_continue = create_progress_handler(
+                benchmark_time, repetitions
+            )
+
             fps_list = []
             avg_latency_list = []
 
-            if benchmark_time:
-                start_time = time.time()
-                while (
-                    pipeline.isRunning()
-                    and (time.time() - start_time) < benchmark_time
-                ):
+            with progress:
+                while pipeline.isRunning() and should_continue():
                     benchmarkReport = outputQueue.get()
                     if not isinstance(benchmarkReport, dai.BenchmarkReport):
                         raise TypeError(
                             f"Expected BenchmarkReport, got {type(benchmarkReport)}"
                         )
-                    fps = benchmarkReport.fps
-                    avg_latency = benchmarkReport.averageLatency * 1000
 
-                    fps_list.append(fps)
-                    avg_latency_list.append(avg_latency)
-
-                    elapsed = time.time() - start_time
-                    capped_elapsed = min(elapsed, benchmark_time)
-                    elapsed_str = format_time(capped_elapsed)
-                    total_str = format_time(benchmark_time)
-                    progress.update(
-                        progress_task,
-                        description=f"[magenta]Time Elapsed (mm:ss) [cyan]{elapsed_str} / {total_str}",
+                    fps_list.append(benchmarkReport.fps)
+                    avg_latency_list.append(
+                        benchmarkReport.averageLatency * 1000
                     )
-            else:
-                while pipeline.isRunning() and rep < repetitions:
-                    benchmarkReport = outputQueue.get()
-                    if not isinstance(benchmarkReport, dai.BenchmarkReport):
-                        raise TypeError(
-                            f"Expected BenchmarkReport, got {type(benchmarkReport)}"
-                        )
-                    fps = benchmarkReport.fps
-                    avg_latency = benchmarkReport.averageLatency * 1000
 
-                    fps_list.append(fps)
-                    avg_latency_list.append(avg_latency)
-                    progress.update(progress_task, advance=1)
-                    rep += 1
-            progress.stop()
+                    on_tick()
 
             # Currently, the latency measurement is not supported on RVC2 by the depthai library.
             return BenchmarkResult(float(np.mean(fps_list)), "N/A")

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -389,7 +389,7 @@ class RVC4Benchmark(Benchmark):
             img = np.random.randint(0, 255, inputSize, np.uint8)
             inputData.addTensor(name, img, dataType=data_type)
 
-        with dai.Pipeline(device) as pipeline, Progress() as progress:
+        with dai.Pipeline(device) as pipeline:
             if benchmark_time:
 
                 def format_time(seconds: float) -> str:

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -42,7 +42,6 @@ RUNTIMES: dict[str, str] = {
 
 
 class RVC4Benchmark(Benchmark):
-    adb = AdbHandler()
     force_cpu: bool = False
 
     @property
@@ -258,6 +257,7 @@ class RVC4Benchmark(Benchmark):
                 "benchmark_time",
             ]:
                 configuration.pop(key, None)
+            self.adb = AdbHandler()
             return self._benchmark_snpe(self.model_path, **configuration)
         finally:
             if not dai_benchmark:

--- a/modelconverter/utils/__init__.py
+++ b/modelconverter/utils/__init__.py
@@ -32,6 +32,7 @@ from .nn_archive import (
     process_nn_archive,
 )
 from .onnx_tools import ONNXModifier, onnx_attach_normalization_to_inputs
+from .progress_handler import create_progress_handler
 from .subprocess import subprocess_run
 
 __all__ = [
@@ -43,6 +44,7 @@ __all__ = [
     "SubprocessException",
     "archive_from_model",
     "check_docker",
+    "create_progress_handler",
     "docker_build",
     "docker_exec",
     "download_calibration_data",

--- a/modelconverter/utils/progress_handler.py
+++ b/modelconverter/utils/progress_handler.py
@@ -1,0 +1,66 @@
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from rich.progress import Progress, TextColumn
+
+
+@dataclass
+class _PBState:
+    use_time: bool
+    total: int
+    start_time: float | None
+    reps_done: int
+    task_id: int
+
+
+def _format_time(seconds: float) -> str:
+    mins, secs = divmod(int(seconds), 60)
+    return f"{mins:02d}:{secs:02d}"
+
+
+def create_progress_handler(
+    benchmark_time: int | None, repetitions: int
+) -> tuple[Progress, Callable[[], None], Callable[[], bool]]:
+    """
+    Returns:
+      progress: Rich Progress instance (context-manage it with `with progress:`)
+      on_tick(): call once per iteration to update the bar
+      should_continue(): loop guard for time/rep modes
+    """
+    use_time = benchmark_time is not None
+    total = int(benchmark_time) if use_time else int(repetitions)
+
+    if use_time:
+        progress = Progress(TextColumn("{task.description}"))
+        task_id = progress.add_task(
+            f"[magenta]Time Elapsed (mm:ss) [cyan]00:00 / {_format_time(total)}",
+            total=total,
+        )
+        state = _PBState(True, total, time.time(), 0, task_id)
+    else:
+        progress = Progress()
+        task_id = progress.add_task("[magenta]Repetition", total=total)
+        state = _PBState(False, total, None, 0, task_id)
+
+    def should_continue() -> bool:
+        if state.use_time:
+            return (time.time() - state.start_time) < state.total  # type: ignore[arg-type]
+        return state.reps_done < state.total
+
+    def on_tick() -> None:
+        if state.use_time:
+            elapsed = min(time.time() - state.start_time, state.total)  # type: ignore[arg-type]
+            progress.update(
+                state.task_id,  # type: ignore[arg-type]
+                completed=int(elapsed),
+                description=(
+                    f"[magenta]Time Elapsed (mm:ss) "
+                    f"[cyan]{_format_time(elapsed)} / {_format_time(state.total)}"
+                ),
+            )
+        else:
+            state.reps_done += 1
+            progress.update(state.task_id, advance=1)  # type: ignore[arg-type]
+
+    return progress, on_tick, should_continue


### PR DESCRIPTION
## Purpose
Add an extra CLI option for RVC2 and RVC4 benchmarking to benchmark for specific time duration instead of a number of repetitions.

## Specification
Added the `--benchmark-time` flag which (if set) overrides the `--repetitions` flag and runs the benchmark (either on RVC2 or on RVC4) for a specific time duration expressed in seconds.

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
None / not applicable