### PR TITLE
Pin onnx version to 1.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Pillow
 gcsfs
 luxonis-ml[data,nn_archive]==0.8.0
-onnx>=1.17.0
+onnx==1.17.0
 onnxruntime
 onnxsim
 s3fs


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
In `onnx==1.18` the mapping constants were removed ([commit link](https://github.com/onnx/onnx/commit/4ebc37b3f8c2867868758d59f40e8dd5a467e914))

To avoid the following error, we can now restrict onnx version to 1.17 and address it in the future.
`AttributeError: module 'onnx' has no attribute 'mapping' `

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Pin onnx version to 1.17.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable