### PR TITLE
Fix: Mean and scale values for non-image inputs in NN Archive

### DIFF
--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -145,18 +145,19 @@ def process_nn_archive(
             if channels and channels == 1:
                 encoding = "GRAY"
 
+        _enc = encoding if isinstance(encoding, str) else encoding["from"]
         mean = inp.preprocessing.mean
         if mean is None:
-            if encoding in {"RGB", "BGR"}:
+            if _enc in {"RGB", "BGR"}:
                 mean = [0, 0, 0]
-            elif encoding == "GRAY":
+            elif _enc == "GRAY":
                 mean = [0]
 
         scale = inp.preprocessing.scale
         if scale is None:
-            if encoding in {"RGB", "BGR"}:
+            if _enc in {"RGB", "BGR"}:
                 scale = [1, 1, 1]
-            elif encoding == "GRAY":
+            elif _enc == "GRAY":
                 scale = [1]
 
         main_stage_config["inputs"].append(

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -145,8 +145,19 @@ def process_nn_archive(
             if channels and channels == 1:
                 encoding = "GRAY"
 
-        mean = inp.preprocessing.mean or [0, 0, 0]
-        scale = inp.preprocessing.scale or [1, 1, 1]
+        mean = inp.preprocessing.mean
+        if mean is None:
+            if encoding in {"RGB", "BGR"}:
+                mean = [0, 0, 0]
+            elif encoding == "GRAY":
+                mean = [0]
+
+        scale = inp.preprocessing.scale
+        if scale is None:
+            if encoding in {"RGB", "BGR"}:
+                scale = [1, 1, 1]
+            elif encoding == "GRAY":
+                scale = [1]
 
         main_stage_config["inputs"].append(
             {


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes incorrectly set mean and scale values for non-image or GRAY inputs when parsing an NN Archive.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable