### PR TITLE
Feat/force onnx names hailo

### DIFF
--- a/modelconverter/packages/hailo/exporter.py
+++ b/modelconverter/packages/hailo/exporter.py
@@ -114,6 +114,9 @@ class HailoExporter(Exporter):
         logger.info("Model translated to Hailo IR.")
         har_path = self.input_model.with_suffix(".har")
         runner.save_har(har_path)
+
+        har_path = self._force_onnx_names(har_path)
+
         if self._disable_calibration:
             self._inference_model_path = (
                 self.output_dir / self.model_name
@@ -150,6 +153,110 @@ class HailoExporter(Exporter):
             )
             return sanitized
         return net_name
+
+    def _force_onnx_names(self, har_path: Path) -> Path:
+        runner = ClientRunner(hw_arch=self.hw_arch, har=str(har_path))
+        hn = runner.get_hn()
+        npz = runner.get_params()
+
+        # get old names and onnx names
+        hn_layers = hn["layers"]
+        items = list(hn_layers.items())
+
+        # get layer names
+        map_list = []
+        for i in range(len(items)):
+            if items[i][1]["type"] == "output_layer":
+                # print (items[i][1])
+                layer_name = items[i][1]["input"][0]
+                # Extract the first part of the old name, which is the context name
+                split_name = layer_name.split("/")
+                context_name = split_name[0]
+                orig_layer_name = items[i][1]["original_names"][0]
+                origName = context_name + "/" + orig_layer_name
+                map_list.append(tuple((layer_name, origName)))
+                # print('({0}, {1}), '.format(layer_name, orig_layer_name), end="")
+
+        # map layer names
+        items = list(hn_layers.items())
+        new_items = []
+        npz = dict(npz)  # weights dictionary
+        list_keys = list(npz.keys())
+        for i in range(len(items)):
+            # Iterate through old2newName_map
+            # If layer name matches the name in the list old2newName_map then change name of the layer and in the npz weight dictionay, replace the corresponding layer's key name
+            # If output layer of that layer matches the name in the list old2newName_map then change output layer name
+            # If input layer of that layer matches the name in the list old2newName_map then change input layer name
+            for j in range(len(map_list)):
+                if items[i][0] == map_list[j][0]:
+                    newName = map_list[j][1]
+                    print(
+                        "Layer {0} changed to {1}".format(
+                            map_list[j][0], newName
+                        )
+                    )
+                    # Since tuple is immutable, convert to list first
+                    item_list = list(items[i])
+                    item_list[0] = newName
+                    # print(item_list)
+                    # Convert back to tuple before writing
+                    items[i] = tuple(item_list)
+                    # In the npz weight dictionay, look for any entry whose key contains the corresponding layer's name and replace the key with the new name
+                    for k in range(len(list_keys)):
+                        if map_list[j][0] in list_keys[k]:
+                            old_key_name = list_keys[k]
+                            new_key_name = old_key_name.replace(
+                                map_list[j][0], map_list[j][1]
+                            )
+                            npz[new_key_name] = npz.pop(old_key_name)
+                            print(
+                                "In npz file, replaced {0} with {1}".format(
+                                    old_key_name, new_key_name
+                                )
+                            )
+                    break  # break the 'for j' loop since we have found a name match
+
+                if items[i][1]["output"] != []:
+                    for k in range(len(items[i][1]["output"])):
+                        if items[i][1]["output"][k] == map_list[j][0]:
+                            newName = map_list[j][1]
+                            print(
+                                "Layer {0}: changed the output layer field from {1} to {2}".format(
+                                    items[i][0], map_list[j][0], newName
+                                )
+                            )
+                            items[i][1]["output"][k] = newName
+                            break  # break the 'for j' loop since we have found a name match
+
+                if items[i][1]["input"] != []:
+                    for k in range(len(items[i][1]["input"])):
+                        if items[i][1]["input"][k] == map_list[j][0]:
+                            newName = map_list[j][1]
+                            print(
+                                "Layer {0}: changed the input layer field from {1} to {2}".format(
+                                    items[i][0], map_list[j][0], newName
+                                )
+                            )
+                            items[i][1]["input"][k] = newName
+                            break  # break the 'for j' loop since we have found a name match
+
+            new_items.append(items[i])
+
+        new_layers = dict(new_items)
+        hn["layers"] = new_layers
+
+        # hn_layers = hn['layers']
+        # print(hn_layers.items())
+
+        # configure output layers
+        hn["net_params"]["output_layers_order"] = list(
+            map(dict(map_list).get, hn["net_params"]["output_layers_order"])
+        )
+
+        runner.set_hn(hn)
+        runner.load_params(npz)
+        runner.save_har(har_path)
+        return har_path
 
     def _get_calibration_data(
         self, runner: ClientRunner

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -228,6 +228,7 @@ class TargetConfig(CustomBaseModel):
 
 
 class HailoConfig(TargetConfig):
+    force_onnx_names: bool = True
     optimization_level: Literal[-100, 0, 1, 2, 3, 4] = 2
     compression_level: Literal[0, 1, 2, 3, 4, 5] = 2
     batch_size: int = 8

--- a/shared_with_container/configs/defaults.yaml
+++ b/shared_with_container/configs/defaults.yaml
@@ -117,6 +117,9 @@ stages:
 
     # --- Hailo-Specific Arguments ---
     hailo:
+      # Force onnx names on the final .har and .hef model
+      force_onnx_names: true
+
       # Specifies the optimization level. A number between 0 and 3.
       optimization_level: 2
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Adding parameter `force_onnx_names` so that the input and output names of the exported `.har` and `.hef` are consistent.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable