### PR TITLE
Fix: Hailo package versions

### DIFF
--- a/.github/workflows/modelconverter_test.yaml
+++ b/.github/workflows/modelconverter_test.yaml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Docker
-      uses: crazy-max/ghaction-setup-docker@v3
+      uses: crazy-max/ghaction-setup-docker@v4
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/docker/hailo/Dockerfile
+++ b/docker/hailo/Dockerfile
@@ -22,7 +22,8 @@ RUN <<EOF
     pip install -r requirements.txt --no-cache-dir
     pip install -U --extra-index-url \
         https://developer.download.nvidia.com/compute/redist \
-        -r requirements-hailo.txt --no-cache-dir
+        --no-cache-dir --use-pep517 --no-build-isolation \
+        -r requirements-hailo.txt
 
 EOF
 

--- a/modelconverter/packages/hailo/exporter.py
+++ b/modelconverter/packages/hailo/exporter.py
@@ -191,13 +191,13 @@ class HailoExporter(Exporter):
             scale_values = inp.scale_values or [1.0] * values_len
             mean_values = inp.mean_values or [0.0] * values_len
             alls.append(
-                f"normalization_{safe_name} = normalization("
+                f"normalization_{safe_name}=normalization("
                 f"{mean_values},{scale_values},{hn_name})"
             )
 
             if inp.encoding_mismatch:
                 alls.append(
-                    f"bgr_to_rgb_{safe_name} = input_conversion("
+                    f"bgr_to_rgb_{safe_name}=input_conversion("
                     f"{hn_name},bgr_to_rgb)"
                 )
 

--- a/modelconverter/packages/hailo/exporter.py
+++ b/modelconverter/packages/hailo/exporter.py
@@ -191,18 +191,18 @@ class HailoExporter(Exporter):
             scale_values = inp.scale_values or [1.0] * values_len
             mean_values = inp.mean_values or [0.0] * values_len
             alls.append(
-                f"normalization_{safe_name}=normalization("
+                f"normalization_{safe_name} = normalization("
                 f"{mean_values},{scale_values},{hn_name})"
             )
 
             if inp.encoding_mismatch:
                 alls.append(
-                    f"bgr_to_rgb_{safe_name}=input_conversion("
+                    f"bgr_to_rgb_{safe_name} = input_conversion("
                     f"{hn_name},bgr_to_rgb)"
                 )
 
         self._alls = alls
-        return "\n\n".join(alls)
+        return "\n".join(alls)
 
     def exporter_buildinfo(self) -> dict[str, Any]:
         return {

--- a/modelconverter/packages/hailo/exporter.py
+++ b/modelconverter/packages/hailo/exporter.py
@@ -202,7 +202,7 @@ class HailoExporter(Exporter):
                 )
 
         self._alls = alls
-        return "\n".join(alls)
+        return "\n\n".join(alls)
 
     def exporter_buildinfo(self) -> dict[str, Any]:
         return {

--- a/modelconverter/packages/hailo/requirements.txt
+++ b/modelconverter/packages/hailo/requirements.txt
@@ -1,3 +1,5 @@
 nvidia-dali-cuda120==1.49.0
 nvidia-dali-tf-plugin-cuda120==1.49.0
 protobuf==3.20.3
+matplotlib==3.10.6
+pyparsing==2.4.7


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes a failing build and usage of hailo images.

### Issue 1

Failing to build the image because installing the `nvidia-dali-tf-plugin` fails.
The installation was failing because `nvidia-dali-tf-plugin` is using a legacy setup.py bdist_wheel mechanism, which stopped being supported by default in `pip-v25.3`. 

Fixed by adding extra flags to `pip install`.

### Issue 2 

Breaking changes in `pyparsing>=3`. Fixed by pinning to a lower version.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Added `--use-pep517 --no-build-isolation` flags to `pip install` when installing specific hailo requirements. 
- Added `pyparsing==2.4.7` to hailo requirements
- Updated the version of `crazy-max/ghaction-setup-docker`

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable