### PR TITLE
Fix: issue when saving benchmark results to csv

### DIFF
--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -314,7 +314,6 @@ def benchmark(
         Literal[
             "low_balanced",
             "balanced",
-            "default",
             "high_performance",
             "sustained_high_performance",
             "burst",
@@ -325,7 +324,7 @@ def benchmark(
             "system_settings",
         ],
         Parameter(group="RVC4"),
-    ] = "default",
+    ] = "balanced",
     runtime: Annotated[Literal["dsp", "cpu"], Parameter(group="RVC4")] = "dsp",
     num_images: Annotated[int, Parameter(group="RVC4")] = 1000,
     device_ip: Annotated[str | None, Parameter(group="RVC4")] = None,

--- a/modelconverter/packages/base_benchmark.py
+++ b/modelconverter/packages/base_benchmark.py
@@ -178,6 +178,14 @@ class Benchmark(ABC):
                 for configuration, result in results
             ]
         )
+
+        # Split nested power list into two CSV-friendly columns
+        if "power" in df.columns and isinstance(df.schema["power"], pl.List):
+            df = df.with_columns(
+                power_system=pl.col("power").list.get(0),
+                power_processor=pl.col("power").list.get(1),
+            ).drop("power")
+
         file = f"{self.model_name}_benchmark_results.csv"
         df.write_csv(file)
         logger.info(f"Benchmark results saved to {file}.")

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -376,6 +376,9 @@ class RVC4Benchmark(Benchmark):
             f"--output_dir /data/modelconverter/{self.model_name}/outputs "
             f"--perf_profile {profile} "
             "--cpu_fallback true "
+            f"--{runtime} "
+            f"--perf_profile {profile} "
+            "--cpu_fallback true "
             f"--{runtime}"
         )
         pattern = re.compile(r"(\d+\.\d+) infs/sec")

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -263,7 +263,7 @@ class RVC4Benchmark(Benchmark):
         device_ip, device_adb_id = get_device_info(
             configuration.get("device_ip"), configuration.get("device_id")
         )
-        if power_benchmark or dsp_benchmark:
+        if power_benchmark or dsp_benchmark or not dai_benchmark:
             self.adb = AdbHandler(device_adb_id)
 
         configuration["device_ip"] = device_ip

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -30,7 +30,6 @@ from modelconverter.utils import (
 PROFILES: Final[list[str]] = [
     "low_balanced",
     "balanced",
-    "default",
     "high_performance",
     "sustained_high_performance",
     "burst",
@@ -63,7 +62,7 @@ class RVC4Benchmark(Benchmark):
         num_messages: The number of messages to use for inference (dai-benchmark only).
         """
         return {
-            "profile": "default",
+            "profile": "balanced",
             "runtime": "dsp",
             "num_images": 1000,
             "dai_benchmark": True,
@@ -77,7 +76,11 @@ class RVC4Benchmark(Benchmark):
 
     @property
     def all_configurations(self) -> list[Configuration]:
-        return [{"profile": profile} for profile in PROFILES]
+        return [
+            {"profile": profile, "num_threads": threads}
+            for profile in PROFILES
+            for threads in [1, 2]
+        ]
 
     def _get_input_sizes(
         self, model_path: str | Path | None = None


### PR DESCRIPTION
## Purpose
Fix an issue where the results could not be properly saved on CSV due to the newly introduced `power` field. 

## Specification

- Added a fix to split the list of `power` results into `power_system` and `power_processor` before saving to CSV.
- Removed the deprecated "default" RVC4 profile and replaced it with the "balanced" one which is the same.
- Added "num_threads" in the creation of all_configurations for the RVC4 case.

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
None / not applicable