### PR TITLE
Feat/add docker image tag option

### DIFF
--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -574,6 +574,14 @@ def launcher(
             "Available options differ based on the target platform. ",
         ),
     ] = None,
+    full_tag: Annotated[
+        str | None,
+        Parameter(
+            group=docker_parameters,
+            help="Full tag of the docker image to use. "
+            "If provided, it takes precedence over the version parameter. ",
+        ),
+    ] = None,
     memory: Annotated[
         str | None,
         Parameter(
@@ -617,7 +625,9 @@ def launcher(
     target = bound.arguments["target"]
 
     if dev:
-        docker_build(target.value, bare_tag=tag, version=tool_version)
+        docker_build(
+            target.value, bare_tag=tag, version=tool_version, full_tag=full_tag
+        )
 
     docker_exec(
         target.value,
@@ -625,6 +635,7 @@ def launcher(
         bare_tag=tag,
         use_gpu=gpu,
         version=tool_version,
+        full_tag=full_tag,
         memory=memory,
         cpus=cpus,
     )

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -577,6 +577,7 @@ def launcher(
     image: Annotated[
         str | None,
         Parameter(
+            ["image", "docker-image"],
             group=docker_parameters,
             help="Full name of the docker image to use. "
             "If the name includes a tag (e.g. ':latest'), "

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -574,12 +574,14 @@ def launcher(
             "Available options differ based on the target platform. ",
         ),
     ] = None,
-    full_tag: Annotated[
+    image: Annotated[
         str | None,
         Parameter(
             group=docker_parameters,
-            help="Full tag of the docker image to use. "
-            "If provided, it takes precedence over the version parameter. ",
+            help="Full name of the docker image to use. "
+            "If the name includes a tag (e.g. ':latest'), "
+            "it will be used as is and the `--tool-version` "
+            "argument will be ignored.",
         ),
     ] = None,
     memory: Annotated[
@@ -626,7 +628,7 @@ def launcher(
 
     if dev:
         docker_build(
-            target.value, bare_tag=tag, version=tool_version, full_tag=full_tag
+            target.value, bare_tag=tag, version=tool_version, image=image
         )
 
     docker_exec(
@@ -635,7 +637,7 @@ def launcher(
         bare_tag=tag,
         use_gpu=gpu,
         version=tool_version,
-        full_tag=full_tag,
+        image=image,
         memory=memory,
         cpus=cpus,
     )

--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -130,12 +130,13 @@ def docker_build(
     target: Literal["rvc2", "rvc3", "rvc4", "hailo"],
     bare_tag: str,
     version: str | None = None,
+    full_tag: str | None = None,
 ) -> str:
     check_docker()
     if version is None:
         version = get_default_target_version(target)
 
-    tag = f"{version}-{bare_tag}"
+    tag = full_tag or f"{version}-{bare_tag}"
 
     image = f"luxonis/modelconverter-{target}:{tag}"
     args = [
@@ -193,11 +194,12 @@ def get_docker_image(
     target: Literal["rvc2", "rvc3", "rvc4", "hailo"],
     bare_tag: str,
     version: str,
+    full_tag: str | None = None,
 ) -> str:
     check_docker()
 
     client = get_docker_client_from_active_context()
-    tag = f"{version}-{bare_tag}"
+    tag = full_tag or f"{version}-{bare_tag}"
 
     image = f"luxonis/modelconverter-{target}:{tag}"
 
@@ -218,7 +220,7 @@ def get_docker_image(
 
     except Exception:
         logger.error("Failed to pull the image, building it locally...")
-        return docker_build(target, bare_tag, version)
+        return docker_build(target, bare_tag, version, full_tag)
 
 
 def docker_exec(
@@ -227,11 +229,12 @@ def docker_exec(
     bare_tag: str,
     use_gpu: bool,
     version: str | None = None,
+    full_tag: str | None = None,
     memory: str | None = None,
     cpus: float | None = None,
 ) -> None:
     version = version or get_default_target_version(target)
-    image = get_docker_image(target, bare_tag, version)
+    image = get_docker_image(target, bare_tag, version, full_tag)
 
     with tempfile.NamedTemporaryFile(delete=False) as f:
         f.write(


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
It makes it possible for users to pass a specific docker image to the CLI. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Added new `--image/--docker-image` argument to the relevant CLI commands.
- If the image name includes a tag, it will be used as is
- In other cases a tag will be constructed as usually (`{version}-latest`) and used with the user provided image name 

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable