### PR TITLE
Added auto-download of SNPE if used locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,22 @@ Only the version `2022.3.0` of `OpenVino` is supported for `RVC3`. Follow the sa
 
 **RVC4**
 
-Requires `snpe-<version>.zip` archive to be present in `docker/extra_packages`. You can download different SNPE versions from [here](https://softwarecenter.qualcomm.com/catalog/item/Qualcomm_AI_Runtime_Community). After downloading, rename the archive according to the version number. For example, if you download `version 2.32.6`, rename the file to `snpe-2.32.6.zip` and then place it in the `docker/extra_packages` directory.
+Requires `snpe-<version>.zip` archive to be present in `docker/extra_packages`. When building locally via the CLI, the tool will attempt to download the archive automatically if it is missing, as long as the version you pass matches one of the versions available in the Qualcomm catalog.
+You can also download different SNPE versions manually from [here](https://softwarecenter.qualcomm.com/catalog/item/Qualcomm_AI_Runtime_Community). After downloading, rename the archive according to the version number and place it in the `docker/extra_packages` directory.
+
+Example (auto-download on first build):
+
+```bash
+modelconverter convert rvc4 --tool-version 2.32.6.250402 --path <config_or_archive>
+```
+
+Example (archive is already present, no auto-download):
+
+```bash
+# Place the archive ahead of time:
+# docker/extra_packages/snpe-2.40.0.zip
+modelconverter convert rvc4 --tool-version 2.40.0 --path <config_or_archive>
+```
 
 **HAILO**
 

--- a/README.md
+++ b/README.md
@@ -197,21 +197,21 @@ Only the version `2022.3.0` of `OpenVino` is supported for `RVC3`. Follow the sa
 
 **RVC4**
 
-Requires `snpe-<version>.zip` archive to be present in `docker/extra_packages`. When building locally via the CLI, the tool will attempt to download the archive automatically if it is missing, as long as the version you pass matches one of the versions available in the Qualcomm catalog.
+Requires `snpe-<version>.zip` archive to be present in `docker/extra_packages`. When building locally via the CLI, the tool will attempt to download the archive automatically if it is missing, but only when a **full SNPE build version** is provided (e.g. `2.32.6.250402`) and that version exists in the Qualcomm catalog. If you pass only the short version (e.g. `2.32.6`), the CLI expects either the image or archive to already be present. After the first download though you can use the local image with the short or long version.
 You can also download different SNPE versions manually from [here](https://softwarecenter.qualcomm.com/catalog/item/Qualcomm_AI_Runtime_Community). After downloading, rename the archive according to the version number and place it in the `docker/extra_packages` directory.
 
-Example (auto-download on first build):
+Example (auto-download only on first build, afterwards available as `2.32.6.250402` or `2.32.6` ):
 
 ```bash
 modelconverter convert rvc4 --tool-version 2.32.6.250402 --path <config_or_archive>
 ```
 
-Example (archive is already present, no auto-download):
+Example (short version, assumes archive or image already present):
 
 ```bash
-# Place the archive ahead of time:
-# docker/extra_packages/snpe-2.40.0.zip
-modelconverter convert rvc4 --tool-version 2.40.0 --path <config_or_archive>
+# Place the archive ahead of time (or run the command above beforehand):
+# docker/extra_packages/snpe-2.32.6.zip
+modelconverter convert rvc4 --tool-version 2.32.6 --path <config_or_archive>
 ```
 
 **HAILO**

--- a/modelconverter/cli/utils.py
+++ b/modelconverter/cli/utils.py
@@ -1,38 +1,23 @@
-import re
 import shutil
-import sys
 from contextlib import suppress
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from time import sleep
 from typing import Any, Literal
-from uuid import UUID
 
-import typer
 from loguru import logger
 from luxonis_ml.nn_archive import is_nn_archive
 from luxonis_ml.nn_archive.config import Config as NNArchiveConfig
 from luxonis_ml.nn_archive.config_building_blocks import PreprocessingBlock
 from luxonis_ml.typing import Params
-from packaging.version import Version
 from requests.exceptions import HTTPError
-from rich import print
-from rich.box import ROUNDED
-from rich.console import Console, Group, RenderableType
-from rich.markdown import Markdown
-from rich.panel import Panel
-from rich.pretty import Pretty
-from rich.progress import Progress
-from rich.table import Table
 
-from modelconverter.utils.hub_requests import Request
 from modelconverter.utils import (
     process_nn_archive,
     resolve_path,
     sanitize_net_name,
 )
-from modelconverter.utils.config import Config, SingleStageConfig
+from modelconverter.utils.config import Config
 from modelconverter.utils.constants import (
     CALIBRATION_DIR,
     CONFIGS_DIR,
@@ -40,6 +25,7 @@ from modelconverter.utils.constants import (
     MODELS_DIR,
     OUTPUTS_DIR,
 )
+from modelconverter.utils.hub_requests import Request
 from modelconverter.utils.types import DataType, Encoding, Target
 
 

--- a/modelconverter/packages/hailo/exporter.py
+++ b/modelconverter/packages/hailo/exporter.py
@@ -111,7 +111,7 @@ class HailoExporter(Exporter):
         hn_layers = hn["layers"]
 
         map_list = []
-        for name, layer in hn_layers.items():
+        for layer in hn_layers.values():
             if layer["type"] == "output_layer":
                 input_name = layer["input"][0]
                 context = input_name.split("/")[0]
@@ -142,7 +142,9 @@ class HailoExporter(Exporter):
         npz = updated_npz
 
         outputs = hn["net_params"]["output_layers_order"]
-        hn["net_params"]["output_layers_order"] = [name_map.get(o, o) for o in outputs]
+        hn["net_params"]["output_layers_order"] = [
+            name_map.get(o, o) for o in outputs
+        ]
 
         runner.set_hn(hn)
         runner.load_params(npz)

--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -11,12 +11,12 @@ from urllib.request import Request, urlopen
 
 import psutil
 import yaml
-from docker.utils import parse_repository_tag
 from loguru import logger
 from luxonis_ml.utils import environ
 from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
 
 import docker
+from docker.utils import parse_repository_tag
 
 
 def get_docker_client_from_active_context() -> docker.DockerClient:
@@ -200,8 +200,8 @@ def ensure_snpe_archive(version: str) -> Path:
 def _download_file(url: str, dest: Path) -> None:
     tmp_path: Path | None = None
     try:
-        request = Request(url, headers={"User-Agent": "modelconverter"})
-        with urlopen(request, timeout=30) as response:
+        request = Request(url, headers={"User-Agent": "modelconverter"})  # noqa: S310
+        with urlopen(request, timeout=30) as response:  # noqa: S310
             if getattr(response, "status", 200) >= 400:
                 raise RuntimeError(
                     f"HTTP {response.status} while downloading {url}"


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
When modelconverter is used locally you can specify tool version. For RVC4 specifically you had to previously download the .zip manually from Qualcomm and put it into the correct place. Since Qualcomm now publicly distributes their SDK we can auto-download it from their catalog if the zip is not present locally.
Note: Version must match exactly for auto-download to work (eg. `2.41.0.251128` works but just `2.41.0` won't work)

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable