### PR TITLE
Fix automatic RVC4 image build with `--dev` flag

### DIFF
--- a/.github/workflows/hailo_test.yaml
+++ b/.github/workflows/hailo_test.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - requirements.txt
       - 'modelconverter/__init__.py'
       - 'modelconverter/packages/hailo/**'
       - 'modelconverter/packages/base_exporter.py'

--- a/.github/workflows/rvc2_test.yaml
+++ b/.github/workflows/rvc2_test.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - requirements.txt
       - 'modelconverter/__init__.py'
       - 'modelconverter/packages/rvc2/**'
       - 'modelconverter/packages/base_exporter.py'

--- a/.github/workflows/rvc3_test.yaml
+++ b/.github/workflows/rvc3_test.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - requirements.txt
       - 'modelconverter/__init__.py'
       - 'modelconverter/packages/rvc3/**'
       - 'modelconverter/packages/base_exporter.py'

--- a/.github/workflows/rvc4_test.yaml
+++ b/.github/workflows/rvc4_test.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - requirements.txt
       - 'modelconverter/__init__.py'
       - 'modelconverter/packages/rvc4/**'
       - 'modelconverter/packages/base_exporter.py'

--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -153,7 +153,7 @@ def docker_build(
         version = get_default_target_version(target)
 
     tag_version = rvc4_tag_version(version) if target == "rvc4" else version
-    if target == "rvc4":
+    if target == "rvc4" and bare_tag != "dev":
         build_dir = prepare_build_environemnt(target, version)
     else:
         build_dir = Path()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,9 @@
 Pillow
-gcsfs
-luxonis-ml[data,nn_archive]>=0.8.1
+luxonis-ml[data,nn_archive,s3,gcs]>=0.8.2
+cyclopts
 onnx>=1.17.0,<1.19.0
 onnxruntime
 onnxsim
-s3fs==2026.1.0
-s3transfer
-click==8.1.8
-cyclopts
 docker
 keyring
 onnx_graphsurgeon


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes a bug introduced in #202 which caused the build provess to ignore the `--dev` flag.
Additionally updates the requirements to solve resolution issues.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Removed reduntand dependencies from `requirements.txt`
- Added workflow triggers on changed `requirements.txt`

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable