### PR TITLE
Support arbitrary zip layouts of calibration datasets

### DIFF
--- a/modelconverter/utils/calibration_data.py
+++ b/modelconverter/utils/calibration_data.py
@@ -27,15 +27,32 @@ def read_img_dir(path: Path, max_images: int) -> list[Path]:
     return imgs
 
 
+def _find_content_root(path: Path) -> Path:
+    current = path
+    while True:
+        contents = list(current.iterdir())
+        subdirs = [p for p in contents if p.is_dir()]
+        files = [p for p in contents if p.is_file()]
+
+        if files:
+            return current
+        if len(subdirs) == 1:
+            current = subdirs[0]
+        else:
+            # Multiple subdirectories and no files. Return current and let read_img_dir raise an error
+            return current
+
+
 def _get_from_remote(string: str, dest: Path, max_images: int = -1) -> Path:
     path = download_from_remote(string, dest, max_images)
     if path.suffix == ".zip":
         extracted_path = path.with_suffix("")
         if extracted_path.exists():
             shutil.rmtree(extracted_path)
+        extracted_path.mkdir(parents=True, exist_ok=True)
         with zipfile.ZipFile(path, "r") as zip_ref:
-            zip_ref.extractall(path.parent)
-        return extracted_path
+            zip_ref.extractall(extracted_path)
+        return _find_content_root(extracted_path)
     return path
 
 

--- a/modelconverter/utils/calibration_data.py
+++ b/modelconverter/utils/calibration_data.py
@@ -28,11 +28,18 @@ def read_img_dir(path: Path, max_images: int) -> list[Path]:
 
 
 def _find_content_root(path: Path) -> Path:
+    IGNORE_DIRS = {"__MACOSX"}
+    IGNORE_FILES = {".DS_Store"}
+
     current = path
     while True:
         contents = list(current.iterdir())
-        subdirs = [p for p in contents if p.is_dir()]
-        files = [p for p in contents if p.is_file()]
+        subdirs = [
+            p for p in contents if p.is_dir() and p.name not in IGNORE_DIRS
+        ]
+        files = [
+            p for p in contents if p.is_file() and p.name not in IGNORE_FILES
+        ]
 
         if files:
             return current

--- a/modelconverter/utils/calibration_data.py
+++ b/modelconverter/utils/calibration_data.py
@@ -29,7 +29,7 @@ def read_img_dir(path: Path, max_images: int) -> list[Path]:
 
 def _find_content_root(path: Path) -> Path:
     IGNORE_DIRS = {"__MACOSX"}
-    IGNORE_FILES = {".DS_Store"}
+    IGNORE_FILES = {".DS_Store", "Thumbs.db", "desktop.ini"}
 
     current = path
     while True:

--- a/modelconverter/utils/calibration_data.py
+++ b/modelconverter/utils/calibration_data.py
@@ -28,18 +28,17 @@ def read_img_dir(path: Path, max_images: int) -> list[Path]:
 
 
 def _find_content_root(path: Path) -> Path:
-    IGNORE_DIRS = {"__MACOSX"}
-    IGNORE_FILES = {".DS_Store", "Thumbs.db", "desktop.ini"}
+    ignored_entries = {"__MACOSX", "Thumbs.db", "desktop.ini"}
 
     current = path
     while True:
-        contents = list(current.iterdir())
-        subdirs = [
-            p for p in contents if p.is_dir() and p.name not in IGNORE_DIRS
+        contents = [
+            p
+            for p in current.iterdir()
+            if p.name not in ignored_entries and not p.name.startswith(".")
         ]
-        files = [
-            p for p in contents if p.is_file() and p.name not in IGNORE_FILES
-        ]
+        subdirs = [p for p in contents if p.is_dir()]
+        files = [p for p in contents if p.is_file()]
 
         if files:
             return current


### PR DESCRIPTION
## Purpose
Fix zip extraction in to handle arbitrary archive layouts (non-nested, nested, and double-nested) when downloading calibration data.

## Specification

- Extraction now always targets a dedicated subfolder, preventing loose files from polluting the destination directory in the non-nested case.
- Introduced `_find_content_root`, which walks down the extracted directory tree to the first level containing files, transparently handling any zip layout.

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
Tested with three zip layouts:

- Non-nested (loose .npy files at zip root)
- Nested with matching folder name
- Nested with mismatched folder name