### PR TITLE
RVC4: Support for JSON quantization overrides

### DIFF
--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -127,7 +127,7 @@ def convert(
 
     with catch_exceptions():
         init_dirs()
-        cfg, archive_cfg, _main_stage = get_configs(path, opts)
+        cfg, archive_cfg, _main_stage = get_configs(target, path, opts)
         main_stage = main_stage or _main_stage
         is_multistage = len(cfg.stages) > 1
         if is_multistage and main_stage is None:
@@ -264,7 +264,7 @@ def infer(
     if path is not None:
         config = path
     with catch_exceptions():
-        mult_cfg, _, _ = get_configs(str(config), opts)
+        mult_cfg, _, _ = get_configs(target, str(config), opts)
         cfg = mult_cfg.get_stage_config(stage)
         setup_logging(
             file="modelconverter.log", use_rich=mult_cfg.rich_logging

--- a/modelconverter/cli/utils.py
+++ b/modelconverter/cli/utils.py
@@ -72,7 +72,9 @@ def init_dirs() -> None:
 
 
 def get_configs(
-    path: str | None, opts: list[str] | dict[str, Any] | None = None
+    target: Target,
+    path: str | None,
+    opts: list[str] | dict[str, Any] | None = None,
 ) -> tuple[Config, NNArchiveConfig | None, str | None]:
     """Sets up the configuration.
 
@@ -99,7 +101,7 @@ def get_configs(
     if path is not None:
         path_ = resolve_path(path, MISC_DIR)
         if path_.is_dir() or is_nn_archive(path_):
-            return process_nn_archive(path_, overrides)
+            return process_nn_archive(target, path_, overrides)
     cfg = Config.get_config(path, overrides)
 
     main_stage_key = None

--- a/modelconverter/packages/rvc4/exporter.py
+++ b/modelconverter/packages/rvc4/exporter.py
@@ -40,7 +40,7 @@ class RVC4Exporter(Exporter):
         super().__init__(config=config, output_dir=output_dir)
 
         rvc4_cfg = config.rvc4
-        self.custom_quantization_overrides = rvc4_cfg.quantization_overrides
+        self.encodings = rvc4_cfg.encodings
         self.snpe_onnx_to_dlc = rvc4_cfg.snpe_onnx_to_dlc_args
         self.snpe_dlc_quant = rvc4_cfg.snpe_dlc_quant_args
         self.snpe_dlc_graph_prepare = rvc4_cfg.snpe_dlc_graph_prepare_args
@@ -187,7 +187,7 @@ class RVC4Exporter(Exporter):
             args.append("--override_params")
         elif self.quantization_mode == QuantizationMode.INT8_16_MIX:
             self._add_args(args, ["--act_bitwidth", "16"])
-        elif self.custom_quantization_overrides is not None:
+        elif self.encodings is not None:
             args.append("--override_params")
 
         start_time = time.time()
@@ -275,8 +275,8 @@ class RVC4Exporter(Exporter):
         return self.input_list_path
 
     def generate_io_encodings(self) -> Path:
-        if self.custom_quantization_overrides is not None:
-            encodings_dict = self.custom_quantization_overrides.model_dump(
+        if self.encodings is not None:
+            encodings_dict = self.encodings.model_dump(
                 mode="json", exclude_none=True
             )
         else:
@@ -355,16 +355,13 @@ class RVC4Exporter(Exporter):
 
         if self.quantization_mode == QuantizationMode.FP16_STD:
             self._add_args(args, ["--float_bitwidth", "16"])
-        elif self.quantization_mode in [
-            QuantizationMode.INT8_16_MIX,
-            QuantizationMode.INT8_16_MIX_ACC,
         elif (
             self.quantization_mode
             in [
                 QuantizationMode.INT8_16_MIX,
                 QuantizationMode.INT8_16_MIX_ACC,
             ]
-            or self.custom_quantization_overrides is not None
+            or self.encodings is not None
         ):
             io_encodings_file = self.generate_io_encodings()
             self._add_args(

--- a/modelconverter/packages/rvc4/exporter.py
+++ b/modelconverter/packages/rvc4/exporter.py
@@ -296,7 +296,7 @@ class RVC4Exporter(Exporter):
                 encodings_dict["activation_encodings"][name] = [
                     {"bitwidth": 8, "dtype": "int"}
                 ]
-        encodings_path = self.intermediate_outputs_dir / "io_encodings.json"
+        encodings_path = self.intermediate_outputs_dir / "encodings.json"
         with open(encodings_path, "w") as encodings_file:
             json.dump(encodings_dict, encodings_file, indent=4)
         return encodings_path

--- a/modelconverter/packages/rvc4/exporter.py
+++ b/modelconverter/packages/rvc4/exporter.py
@@ -357,7 +357,14 @@ class RVC4Exporter(Exporter):
         elif self.quantization_mode in [
             QuantizationMode.INT8_16_MIX,
             QuantizationMode.INT8_16_MIX_ACC,
-        ]:
+        elif (
+            self.quantization_mode
+            in [
+                QuantizationMode.INT8_16_MIX,
+                QuantizationMode.INT8_16_MIX_ACC,
+            ]
+            or self.custom_quantization_overrides is not None
+        ):
             io_encodings_file = self.generate_io_encodings()
             self._add_args(
                 args,

--- a/modelconverter/packages/rvc4/exporter.py
+++ b/modelconverter/packages/rvc4/exporter.py
@@ -40,6 +40,7 @@ class RVC4Exporter(Exporter):
         super().__init__(config=config, output_dir=output_dir)
 
         rvc4_cfg = config.rvc4
+        self.custom_quantization_overrides = rvc4_cfg.quantization_overrides
         self.snpe_onnx_to_dlc = rvc4_cfg.snpe_onnx_to_dlc_args
         self.snpe_dlc_quant = rvc4_cfg.snpe_dlc_quant_args
         self.snpe_dlc_graph_prepare = rvc4_cfg.snpe_dlc_graph_prepare_args
@@ -273,19 +274,27 @@ class RVC4Exporter(Exporter):
         return self.input_list_path
 
     def generate_io_encodings(self) -> Path:
-        encodings_dict = {"activation_encodings": {}, "param_encodings": {}}
-        if not (list(self.inputs.keys()) and list(self.outputs.keys())):
-            logger.warning(
-                "Cannot generate I/O encodings as inputs or outputs are not defined. The resulting DLC may not be compatible with DAI."
+        if self.custom_quantization_overrides is not None:
+            encodings_dict = self.custom_quantization_overrides.model_dump(
+                mode="json"
             )
-        for name in (
-            list(self.inputs.keys())
-            + list(self.outputs.keys())
-            + self.extra_quant_tensors
-        ):
-            encodings_dict["activation_encodings"][name] = [
-                {"bitwidth": 8, "dtype": "int"}
-            ]
+        else:
+            encodings_dict = {
+                "activation_encodings": {},
+                "param_encodings": {},
+            }
+            if not (list(self.inputs.keys()) and list(self.outputs.keys())):
+                logger.warning(
+                    "Cannot generate I/O encodings as inputs or outputs are not defined. The resulting DLC may not be compatible with DAI."
+                )
+            for name in (
+                list(self.inputs.keys())
+                + list(self.outputs.keys())
+                + self.extra_quant_tensors
+            ):
+                encodings_dict["activation_encodings"][name] = [
+                    {"bitwidth": 8, "dtype": "int"}
+                ]
         encodings_path = self.intermediate_outputs_dir / "io_encodings.json"
         with open(encodings_path, "w") as encodings_file:
             json.dump(encodings_dict, encodings_file, indent=4)

--- a/modelconverter/packages/rvc4/exporter.py
+++ b/modelconverter/packages/rvc4/exporter.py
@@ -187,6 +187,7 @@ class RVC4Exporter(Exporter):
             args.append("--override_params")
         elif self.quantization_mode == QuantizationMode.INT8_16_MIX:
             self._add_args(args, ["--act_bitwidth", "16"])
+        elif self.custom_quantization_overrides is not None:
             args.append("--override_params")
 
         start_time = time.time()

--- a/modelconverter/packages/rvc4/exporter.py
+++ b/modelconverter/packages/rvc4/exporter.py
@@ -276,7 +276,7 @@ class RVC4Exporter(Exporter):
     def generate_io_encodings(self) -> Path:
         if self.custom_quantization_overrides is not None:
             encodings_dict = self.custom_quantization_overrides.model_dump(
-                mode="json"
+                mode="json", exclude_none=True
             )
         else:
             encodings_dict = {

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -278,7 +278,7 @@ class QuantizationOverridesItem(BaseModelExtraForbid):
         return str(value)
 
 
-class QuantizationOverrides(BaseModelExtraForbid):
+class Encodings(BaseModelExtraForbid):
     activation_encodings: dict[str, list[QuantizationOverridesItem]]
     param_encodings: dict[str, list[QuantizationOverridesItem]]
 
@@ -295,21 +295,37 @@ class RVC4Config(TargetConfig):
     htp_socs: list[
         Literal["sm8350", "sm8450", "sm8550", "sm8650", "qcs6490", "qcs8550"]
     ] = ["sm8550"]
-    quantization_overrides: QuantizationOverrides | None = None
+    encodings: Encodings | None = None
 
-    @field_validator("quantization_overrides", mode="before")
+    @model_validator(mode="after")
+    def validate_quantization_overrides(self) -> Self:
+        if "--quantization_overrides" in self.snpe_onnx_to_dlc_args:
+            if self.encodings:
+                raise ValueError(
+                    "Cannot specify both `--quantization_overrides`"
+                    "in `rvc4.snpe_onnx_to_dlc_args` and "
+                    "`rvc4.encodings` at the same time."
+                )
+            qo_index = self.snpe_onnx_to_dlc_args.index(
+                "--quantization_overrides"
+            )
+            self.snpe_onnx_to_dlc_args.pop(qo_index)
+            encodings_json = self.snpe_onnx_to_dlc_args.pop(qo_index)
+            with open(encodings_json) as f:
+                self.encodings = Encodings.model_validate_json(json.load(f))
+        return self
+
+    @field_validator("encodings", mode="before")
     @staticmethod
-    def validate_quantization_overrides(
-        value: Any,
-    ) -> QuantizationOverrides | None:
+    def validate_encodings(value: Any) -> Encodings | None:
         if value is None:
             return None
 
         if isinstance(value, str):
             value_path = resolve_path(value, MISC_DIR)
-            return QuantizationOverrides(**json.loads(value_path.read_text()))
+            return Encodings(**json.loads(value_path.read_text()))
 
-        return QuantizationOverrides(**value)
+        return Encodings(**value)
 
     @model_validator(mode="after")
     def _validate_fp16(self) -> Self:

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -8,11 +8,17 @@ from loguru import logger
 from luxonis_ml.typing import BaseModelExtraForbid, PathType
 from luxonis_ml.utils import LuxonisConfig
 from onnx import TypeProto
-from pydantic import Field, PositiveInt, field_validator, model_validator
+from pydantic import (
+    Field,
+    PositiveInt,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 from typing_extensions import Self
 
 from modelconverter.utils.calibration_data import download_calibration_data
-from modelconverter.utils.constants import MODELS_DIR
+from modelconverter.utils.constants import MISC_DIR, MODELS_DIR
 from modelconverter.utils.filesystem_utils import resolve_path
 from modelconverter.utils.layout import make_default_layout
 from modelconverter.utils.metadata import Metadata, get_metadata
@@ -256,11 +262,20 @@ class RVC3Config(BlobBaseConfig):
 
 
 class QuantizationOverridesItem(BaseModelExtraForbid):
-    bitwidth: int
-    max: float
-    min: float
+    bitwidth: Annotated[int, Field(ge=4, le=32)] | None = None
+    is_symmetric: bool | None = None
+    dtype: Literal["int", "float"] | None = None
+    max: float | None = None
+    min: float | None = None
     offset: int | None = None
     scale: float | None = None
+
+    @field_serializer("is_symmetric", when_used="json")
+    @staticmethod
+    def serialize_is_symmetric(value: bool | None) -> str | None:
+        if value is None:
+            return None
+        return str(value)
 
 
 class QuantizationOverrides(BaseModelExtraForbid):
@@ -291,7 +306,7 @@ class RVC4Config(TargetConfig):
             return None
 
         if isinstance(value, str):
-            value_path = resolve_path(value, MODELS_DIR)
+            value_path = resolve_path(value, MISC_DIR)
             return QuantizationOverrides(**json.loads(value_path.read_text()))
 
         return QuantizationOverrides(**value)

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -1,20 +1,14 @@
+import json
 from itertools import chain
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
 
 import onnx
 from loguru import logger
-from luxonis_ml.typing import PathType
+from luxonis_ml.typing import BaseModelExtraForbid, PathType
 from luxonis_ml.utils import LuxonisConfig
 from onnx import TypeProto
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    PositiveInt,
-    field_validator,
-    model_validator,
-)
+from pydantic import Field, PositiveInt, field_validator, model_validator
 from typing_extensions import Self
 
 from modelconverter.utils.calibration_data import download_calibration_data
@@ -40,11 +34,7 @@ NAMED_VALUES = {
 }
 
 
-class CustomBaseModel(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-
-class LinkCalibrationConfig(CustomBaseModel):
+class LinkCalibrationConfig(BaseModelExtraForbid):
     stage: str
     output: str | None = None
     script: str | None = None
@@ -68,7 +58,7 @@ class LinkCalibrationConfig(CustomBaseModel):
         return script
 
 
-class ImageCalibrationConfig(CustomBaseModel):
+class ImageCalibrationConfig(BaseModelExtraForbid):
     path: Path
     max_images: int = -1
     resize_method: ResizeMethod = ResizeMethod.RESIZE
@@ -81,7 +71,7 @@ class ImageCalibrationConfig(CustomBaseModel):
         return download_calibration_data(str(value))
 
 
-class RandomCalibrationConfig(CustomBaseModel):
+class RandomCalibrationConfig(BaseModelExtraForbid):
     max_images: int = 20
     min_value: float = 0.0
     max_value: float = 255.0
@@ -90,7 +80,7 @@ class RandomCalibrationConfig(CustomBaseModel):
     data_type: DataType = DataType.FLOAT32
 
 
-class OutputConfig(CustomBaseModel):
+class OutputConfig(BaseModelExtraForbid):
     name: str
     shape: list[int] | None = None
     layout: str | None = None
@@ -123,7 +113,7 @@ class OutputConfig(CustomBaseModel):
         return self
 
 
-class EncodingConfig(CustomBaseModel):
+class EncodingConfig(BaseModelExtraForbid):
     from_: Annotated[
         Encoding, Field(alias="from", serialization_alias="from")
     ] = Encoding.RGB
@@ -225,7 +215,7 @@ class InputConfig(OutputConfig):
         return value
 
 
-class TargetConfig(CustomBaseModel):
+class TargetConfig(BaseModelExtraForbid):
     disable_calibration: bool = False
 
 
@@ -265,6 +255,19 @@ class RVC3Config(BlobBaseConfig):
     pot_target_device: PotDevice = PotDevice.VPU
 
 
+class QuantizationOverridesItem(BaseModelExtraForbid):
+    bitwidth: int
+    max: float
+    min: float
+    offset: int | None = None
+    scale: float | None = None
+
+
+class QuantizationOverrides(BaseModelExtraForbid):
+    activation_encodings: dict[str, list[QuantizationOverridesItem]]
+    parameter_encodings: dict[str, list[QuantizationOverridesItem]]
+
+
 class RVC4Config(TargetConfig):
     snpe_onnx_to_dlc_args: list[str] = []
     snpe_dlc_quant_args: list[str] = []
@@ -277,6 +280,21 @@ class RVC4Config(TargetConfig):
     htp_socs: list[
         Literal["sm8350", "sm8450", "sm8550", "sm8650", "qcs6490", "qcs8550"]
     ] = ["sm8550"]
+    quantization_overrides: QuantizationOverrides | None = None
+
+    @field_validator("quantization_overrides", mode="before")
+    @staticmethod
+    def validate_quantization_overrides(
+        value: Any,
+    ) -> QuantizationOverrides | None:
+        if value is None:
+            return None
+
+        if isinstance(value, str):
+            value_path = resolve_path(value, MODELS_DIR)
+            return QuantizationOverrides(**json.loads(value_path.read_text()))
+
+        return QuantizationOverrides(**value)
 
     @model_validator(mode="after")
     def _validate_fp16(self) -> Self:
@@ -286,7 +304,7 @@ class RVC4Config(TargetConfig):
         return self
 
 
-class SingleStageConfig(CustomBaseModel):
+class SingleStageConfig(BaseModelExtraForbid):
     input_model: Path
     input_bin: Path | None = None
     input_file_type: InputFileType

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -262,7 +262,7 @@ class RVC3Config(BlobBaseConfig):
 
 
 class QuantizationOverridesItem(BaseModelExtraForbid):
-    bitwidth: Annotated[int, Field(ge=4, le=32)] | None = None
+    bitwidth: Annotated[int, Literal[4, 8, 16, 32]] | None = None
     is_symmetric: bool | None = None
     dtype: Literal["int", "float"] | None = None
     max: float | None = None
@@ -280,7 +280,7 @@ class QuantizationOverridesItem(BaseModelExtraForbid):
 
 class QuantizationOverrides(BaseModelExtraForbid):
     activation_encodings: dict[str, list[QuantizationOverridesItem]]
-    parameter_encodings: dict[str, list[QuantizationOverridesItem]]
+    param_encodings: dict[str, list[QuantizationOverridesItem]]
 
 
 class RVC4Config(TargetConfig):

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -36,7 +36,7 @@ def get_archive_input(cfg: NNArchiveConfig, name: str) -> NNArchiveInput:
 
 
 def process_nn_archive(
-    path: Path, overrides: dict[str, Any] | None
+    target: Target, path: Path, overrides: dict[str, Any] | None
 ) -> tuple[Config, NNArchiveConfig, str]:
     """Extracts the archive from tar and parses its config.
 
@@ -86,6 +86,15 @@ def process_nn_archive(
         "inputs": [],
         "outputs": [],
     }
+
+    if (
+        target is Target.RVC4
+        and (p := untar_path / "encondings.json").exists()
+    ):
+        logger.info("Using custom `encodings.json` from the NN Archive.")
+        main_stage_config["rvc4"] = {
+            "encodings": json.loads(p.read_text()),
+        }
 
     for inp in archive_config.model.inputs:
         reverse = inp.preprocessing.reverse_channels

--- a/shared_with_container/configs/defaults.yaml
+++ b/shared_with_container/configs/defaults.yaml
@@ -221,3 +221,12 @@ stages:
 
       # Pre-defined quantization modes for the RVC4 exporter. Pre-defined modes (except CUSTOM) will override any user-provided SNPE arguments via `snpe_onnx_to_dlc_args`, `snpe_dlc_quant_args`, and `snpe_dlc_graph_prepare_args`. The available quantization modes are: INT8_STANDARD, INT8_ACCURACY_FOCUSED, INT8_INT16_MIXED, FP16_STANDARD, and CUSTOM.
       quantization_mode: INT8_STANDARD
+
+      # Custom quantization overrides for the RVC4 exporter. The
+      # format is specified as a dictionary with two mandatory
+      # fields: `activation_encodings` and `param_encodings`.
+      # Each field is a list of dictionaries specifying the
+      # quantization encodings for the activations and parameters,
+      # respectively.
+      # The dictionaries in the lists must follow the AIMET specification.
+      quantization_overrides: ~

--- a/shared_with_container/configs/defaults.yaml
+++ b/shared_with_container/configs/defaults.yaml
@@ -229,4 +229,4 @@ stages:
       # quantization encodings for the activations and parameters,
       # respectively.
       # The dictionaries in the lists must follow the AIMET specification.
-      quantization_overrides: ~
+      encodings: ~

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -1147,7 +1147,7 @@ def test_output_nn_config_from_nn_archive(
             )
         shutil.copy(tar_path, nn_archive_path)
     config, archive_cfg, main_stage = process_nn_archive(
-        nn_archive_path, overrides=None
+        Target.RVC4, nn_archive_path, overrides=None
     )
     preprocessing = {}
     if nn_preprocess:
@@ -1335,7 +1335,9 @@ def test_encoding_nn_archive(
                 create_json(keys=keys, values=values), arcname="config.json"
             )
         shutil.copy(tar_path, nn_archive_path)
-    config, _, _ = process_nn_archive(nn_archive_path, overrides=None)
+    config, _, _ = process_nn_archive(
+        Target.RVC4, nn_archive_path, overrides=None
+    )
     assert config.get("stages.dummy_model.inputs.0.encoding") == expected
 
 

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -68,7 +68,7 @@ DEFAULT_TARGET_CONFIGS = {
         "use_per_row_quantization": False,
         "quantization_mode": QuantizationMode.INT8_STD,
         "optimization_level": 2,
-        "quantization_overrides": None,
+        "encodings": None,
     },
     "hailo": {
         "force_onnx_names": True,

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -68,6 +68,7 @@ DEFAULT_TARGET_CONFIGS = {
         "use_per_row_quantization": False,
         "quantization_mode": QuantizationMode.INT8_STD,
         "optimization_level": 2,
+        "quantization_overrides": None,
     },
     "hailo": {
         "force_onnx_names": True,


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Allows users to specify custom quantization overrides using `rvc4.encodings` field.


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Added `rvc4.encodings` to the configuration specs.
  - Can be either a dictionary or a path to a JSON file

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable