### PR TITLE
Fix: Random calibration data for RVC3

### DIFF
--- a/modelconverter/packages/base_exporter.py
+++ b/modelconverter/packages/base_exporter.py
@@ -5,6 +5,7 @@ from importlib.metadata import version
 from pathlib import Path
 from typing import Any
 
+import cv2
 import numpy as np
 from loguru import logger
 
@@ -225,7 +226,24 @@ class Exporter(ABC):
                 arr = np.clip(arr, calib.min_value, calib.max_value)
 
                 arr = arr.astype(calib.data_type.as_numpy_dtype())
-                np.save(dest / f"{i}.npy", arr)
+                if len(arr.shape) in {2, 3} or (
+                    len(arr.shape) in {3, 4} and arr.shape[0] == 1
+                ):
+                    layout = inp.layout
+                    if arr.shape[0] == 1:
+                        arr = arr.squeeze(0)
+                        if layout is not None:
+                            layout = layout[1:]
+
+                    if layout is not None and "C" in layout:
+                        channel_dim = layout.index("C")
+                        if channel_dim == 0:
+                            arr = arr.transpose(1, 2, 0)
+                    elif arr.shape[0] in [1, 3]:
+                        arr = arr.transpose(1, 2, 0)
+                    cv2.imwrite(str(dest / f"{i}.png"), arr)
+                else:
+                    np.save(dest / f"{i}.npy", arr)
 
             self.inputs[name].calibration = ImageCalibrationConfig(path=dest)
 

--- a/modelconverter/packages/base_exporter.py
+++ b/modelconverter/packages/base_exporter.py
@@ -230,16 +230,16 @@ class Exporter(ABC):
                     len(arr.shape) in {3, 4} and arr.shape[0] == 1
                 ):
                     layout = inp.layout
-                    if arr.shape[0] == 1:
+                    if arr.shape[0] == 1 and len(arr.shape) > 2:
                         arr = arr.squeeze(0)
                         if layout is not None:
                             layout = layout[1:]
 
                     if layout is not None and "C" in layout:
                         channel_dim = layout.index("C")
-                        if channel_dim == 0:
+                        if channel_dim == 0 and len(arr.shape) == 3:
                             arr = arr.transpose(1, 2, 0)
-                    elif arr.shape[0] in [1, 3]:
+                    elif arr.shape[0] in {1, 3}:  # type: ignore
                         arr = arr.transpose(1, 2, 0)
                     cv2.imwrite(str(dest / f"{i}.png"), arr)
                 else:

--- a/modelconverter/packages/rvc3/exporter.py
+++ b/modelconverter/packages/rvc3/exporter.py
@@ -31,6 +31,7 @@ class RVC3Exporter(RVC2Exporter):
         self.mo_args = config.rvc3.mo_args
         self.compile_tool_args = config.rvc3.compile_tool_args
         self.device = "VPUX.3400"
+        self.reverse_input_channels = False
         self._device_specific_buildinfo = {}
 
     def export(self) -> Path:


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes the usage of random calibration data for RVC3.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Random calibration data are saved as images if possible because the POT tool used for RVC3 quantization does not support `.npy` files.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable