### PR TITLE
[RVC4 Benchmark] Read inputs info from archive

### DIFF
--- a/modelconverter/packages/base_benchmark.py
+++ b/modelconverter/packages/base_benchmark.py
@@ -2,23 +2,12 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Literal, NamedTuple, TypeAlias
+from typing import Any, TypeAlias
 
 import polars as pl
 from loguru import logger
 
 from modelconverter.utils import is_hubai_available, resolve_path
-
-
-class BenchmarkResult(NamedTuple):
-    """Benchmark result, tuple (FPS, latency in ms, system and processor
-    power in W, dsp utilization)"""
-
-    fps: float
-    latency: float | Literal["N/A"]
-    power: tuple[float | None, float | None] = (None, None)
-    dsp: float | None = None
-
 
 Configuration: TypeAlias = dict[str, Any]
 
@@ -68,7 +57,7 @@ class Benchmark(ABC):
         ]
 
     @abstractmethod
-    def benchmark(self, configuration: Configuration) -> BenchmarkResult:
+    def benchmark(self, configuration: Configuration) -> dict[str, Any]:
         pass
 
     @property
@@ -82,7 +71,7 @@ class Benchmark(ABC):
         pass
 
     def print_results(
-        self, results: list[tuple[Configuration, BenchmarkResult]]
+        self, results: list[tuple[Configuration, dict[str, Any]]]
     ) -> None:
         assert results, "No results to print"
 
@@ -110,7 +99,7 @@ class Benchmark(ABC):
 
     def _base_header(
         self,
-        results: list[tuple[Configuration, BenchmarkResult]],
+        results: list[tuple[Configuration, dict[str, Any]]],
     ) -> list[str]:
         """Shared header cells."""
         return [*results[0][0].keys(), "fps", "latency (ms)"]
@@ -118,7 +107,7 @@ class Benchmark(ABC):
     def _base_row_cells(
         self,
         configuration: Configuration,
-        result: BenchmarkResult,
+        result: dict[str, Any],
     ) -> Iterable[str]:
         """Shared row cells for each result (configuration + fps +
         latency)."""
@@ -126,33 +115,27 @@ class Benchmark(ABC):
         for x in configuration.values():
             yield f"[magenta]{x}"
 
-        # fps
-        fps_color = (
-            "yellow"
-            if 5 < result.fps < 15
-            else "red"
-            if result.fps < 5
-            else "green"
-        )
-        yield f"[{fps_color}]{result.fps:.2f}"
+        fps = result["fps"]
+        fps_color = "yellow" if 5 < fps < 15 else "red" if fps < 5 else "green"
+        yield f"[{fps_color}]{fps:.2f}"
 
-        # latency
-        if isinstance(result.latency, str):
+        latency = result.get("latency", "N/A")
+        if isinstance(latency, str):
             latency_color = "orange3"
-            yield f"[{latency_color}]{result.latency}"
+            yield f"[{latency_color}]{latency}"
         else:
             latency_color = (
                 "yellow"
-                if 50 < result.latency < 100
+                if 50 < latency < 100
                 else "red"
-                if result.latency > 100
+                if latency > 100
                 else "green"
             )
-            yield f"[{latency_color}]{result.latency:.5f}"
+            yield f"[{latency_color}]{latency:.5f}"
 
     def _extra_header(
         self,
-        results: list[tuple[Configuration, BenchmarkResult]],
+        results: list[tuple[Configuration, dict[str, Any]]],
     ) -> list[str]:
         """Columns to append after the base header (default: none)."""
         return []
@@ -160,7 +143,7 @@ class Benchmark(ABC):
     def _extra_row_cells(
         self,
         configuration: Configuration,
-        result: BenchmarkResult,
+        result: dict[str, Any],
     ) -> Iterable[str]:
         """Extra cells to append after the base row cells (default:
 
@@ -169,14 +152,11 @@ class Benchmark(ABC):
         return []
 
     def save_results(
-        self, results: list[tuple[Configuration, BenchmarkResult]]
+        self, results: list[tuple[Configuration, dict[str, Any]]]
     ) -> None:
         assert results, "No results to save"
         df = pl.DataFrame(
-            [
-                {**configuration, **result._asdict()}
-                for configuration, result in results
-            ]
+            [configuration | result for configuration, result in results]
         )
 
         # Split nested power list into two CSV-friendly columns
@@ -207,7 +187,7 @@ class Benchmark(ABC):
                 for config in self.all_configurations  # add only kwarg keys that are not already there to not overwrite
             ]
 
-        results: list[tuple[Configuration, BenchmarkResult]] = [
+        results: list[tuple[Configuration, dict[str, Any]]] = [
             (configuration, self.benchmark(configuration))
             for configuration in configurations
         ]

--- a/modelconverter/packages/rvc2/benchmark.py
+++ b/modelconverter/packages/rvc2/benchmark.py
@@ -1,13 +1,10 @@
 from pathlib import Path
+from typing import Any
 
 import depthai as dai
 import numpy as np
 
-from modelconverter.packages.base_benchmark import (
-    Benchmark,
-    BenchmarkResult,
-    Configuration,
-)
+from modelconverter.packages.base_benchmark import Benchmark, Configuration
 from modelconverter.utils import create_progress_handler, environ
 
 
@@ -31,7 +28,7 @@ class RVC2Benchmark(Benchmark):
     def all_configurations(self) -> list[Configuration]:
         return [{"num_threads": i} for i in [1, 2, 3]]
 
-    def benchmark(self, configuration: Configuration) -> BenchmarkResult:
+    def benchmark(self, configuration: Configuration) -> dict[str, Any]:
         return self._benchmark(self.model_path, **configuration)
 
     @staticmethod
@@ -41,7 +38,7 @@ class RVC2Benchmark(Benchmark):
         num_messages: int,
         num_threads: int,
         benchmark_time: int,
-    ) -> BenchmarkResult:
+    ) -> dict[str, Any]:
         device = dai.Device()
         if device.getPlatform() != dai.Platform.RVC2:
             raise ValueError(
@@ -138,4 +135,7 @@ class RVC2Benchmark(Benchmark):
                     on_tick()
 
             # Currently, the latency measurement is not supported on RVC2 by the depthai library.
-            return BenchmarkResult(float(np.mean(fps_list)), "N/A")
+            return {
+                "fps": float(np.mean(fps_list)),
+                "latency": "N/A",
+            }

--- a/modelconverter/packages/rvc3/benchmark.py
+++ b/modelconverter/packages/rvc3/benchmark.py
@@ -1,16 +1,13 @@
 import sys
 from datetime import datetime, timezone
 from statistics import median
+from typing import Any
 
 from loguru import logger
 from openvino.inference_engine.ie_api import IECore, StatusCode
 from rich.progress import track
 
-from modelconverter.packages.base_benchmark import (
-    Benchmark,
-    BenchmarkResult,
-    Configuration,
-)
+from modelconverter.packages.base_benchmark import Benchmark, Configuration
 
 
 class RVC3Benchmark(Benchmark):
@@ -25,11 +22,11 @@ class RVC3Benchmark(Benchmark):
     def all_configurations(self) -> list[Configuration]:
         return [{"requests": i} for i in range(1, 6)]
 
-    def benchmark(self, configuration: Configuration) -> BenchmarkResult:
+    def benchmark(self, configuration: Configuration) -> dict[str, Any]:
         return self._benchmark(str(self.model_path), **configuration)
 
     @staticmethod
-    def _benchmark(model_path: str, requests: int) -> BenchmarkResult:
+    def _benchmark(model_path: str, requests: int) -> dict[str, Any]:
         ie = IECore()
         exe_network = ie.load_network(
             model_path,
@@ -79,4 +76,4 @@ class RVC3Benchmark(Benchmark):
         times.sort()
         latency = median(times)
         fps = i / total_duration_sec
-        return BenchmarkResult(fps, latency)
+        return {"fps": fps, "latency": latency}

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -5,18 +5,14 @@ import shutil
 import tempfile
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Final
+from typing import Any, Final
 
 import depthai as dai
 import numpy as np
 import polars as pl
 from loguru import logger
 
-from modelconverter.packages.base_benchmark import (
-    Benchmark,
-    BenchmarkResult,
-    Configuration,
-)
+from modelconverter.packages.base_benchmark import Benchmark, Configuration
 from modelconverter.utils import (
     DataType,
     MonitorDSP,
@@ -177,7 +173,7 @@ class RVC4Benchmark(Benchmark):
             spec.data_type.as_numpy_dtype()
         )
 
-    def benchmark(self, configuration: Configuration) -> BenchmarkResult:
+    def benchmark(self, configuration: Configuration) -> dict[str, Any]:
         dai_benchmark = configuration.get("dai_benchmark")
         power_benchmark = configuration.get("power_benchmark")
         dsp_benchmark = configuration.get("dsp_benchmark")
@@ -228,9 +224,9 @@ class RVC4Benchmark(Benchmark):
                 result = self._benchmark_snpe(self.model_path, **configuration)
 
             if self.power_monitor:
-                result = result._replace(power=self.power_monitor.get_stats())
+                result["power"] = self.power_monitor.get_stats()
             if self.dsp_monitor:
-                result = result._replace(dsp=self.dsp_monitor.get_stats())
+                result["dsp"] = self.dsp_monitor.get_stats()
             return result
         finally:
             if self.power_monitor:
@@ -251,7 +247,7 @@ class RVC4Benchmark(Benchmark):
         num_images: int,
         profile: str,
         runtime: str,
-    ) -> BenchmarkResult:
+    ) -> dict[str, Any]:
         runtime = RUNTIMES.get(runtime, "use_dsp")
 
         if isinstance(model_path, str):
@@ -306,7 +302,7 @@ class RVC4Benchmark(Benchmark):
                 f"stdout:\n{stdout}"
             )
         fps = float(match.group(1))
-        return BenchmarkResult(fps=fps, latency="N/A")
+        return {"fps": fps, "latency": "N/A"}
 
     def _benchmark_dai(
         self,
@@ -318,7 +314,7 @@ class RVC4Benchmark(Benchmark):
         num_messages: int,
         benchmark_time: int,
         device_ip: str | None = None,
-    ) -> BenchmarkResult:
+    ) -> dict[str, Any]:
         if device_ip:
             device = dai.Device(dai.DeviceInfo(device_ip))
         else:
@@ -426,11 +422,16 @@ class RVC4Benchmark(Benchmark):
                     on_tick()
 
             # Currently, the latency measurement is only supported on RVC4 when using ImgFrame as the input to the BenchmarkOut which we don't do here.
-            return BenchmarkResult(float(np.mean(fps_list)), "N/A")
+            return {
+                "fps": float(np.mean(fps_list)),
+                "latency": float(np.mean(avg_latency_list))
+                if avg_latency_list
+                else "N/A",
+            }
 
     def _extra_header(
         self,
-        results: list[tuple[Configuration, BenchmarkResult]],
+        results: list[tuple[Configuration, dict[str, Any]]],
     ) -> list[str]:
         heads = []
         if self.power_monitor:
@@ -443,10 +444,10 @@ class RVC4Benchmark(Benchmark):
     def _extra_row_cells(
         self,
         configuration: Configuration,
-        result: BenchmarkResult,
+        result: dict[str, Any],
     ) -> Iterable[str]:
-        power_sys, power_core = result.power
-        dsp = result.dsp
+        power_sys, power_core = result.get("power", (None, None))
+        dsp = result.get("dsp")
 
         if self.power_monitor:
             yield f"{power_sys:.2f}" if power_sys else "[orange3]N/A"

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -355,7 +355,10 @@ class RVC4Benchmark(Benchmark):
         input_specs: list[InputSpec] = []
         if isinstance(model_path, str) or str(model_path).endswith(".tar.xz"):
             model_archive = dai.NNArchive(modelPath)  # type: ignore[arg-type]
-            input_specs = self._get_archive_input_specs(model_archive)
+            if shutil.which("snpe-dlc-info") is not None:
+                input_specs = self._get_dlc_input_specs(modelPath)
+            else:
+                input_specs = self._get_archive_input_specs(model_archive)
 
         inputData = dai.NNData()
         for spec in input_specs:

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -165,6 +165,8 @@ class RVC4Benchmark(Benchmark):
     @staticmethod
     def _create_random_input(spec: InputSpec) -> np.ndarray:
         if spec.data_type is DataType.INT32:
+            # INT inputs are often token/index tensors;
+            # zero keeps synthetic benchmark inputs in a safe range.
             return np.zeros(spec.shape, dtype=np.int32)
         if spec.data_type == DataType.INT8:
             return np.random.randint(-128, 128, size=spec.shape, dtype=np.int8)

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -4,7 +4,6 @@ import re
 import shutil
 import tempfile
 from collections.abc import Iterable
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
 
@@ -19,6 +18,7 @@ from modelconverter.packages.base_benchmark import (
     Configuration,
 )
 from modelconverter.utils import (
+    DataType,
     MonitorDSP,
     MonitorPower,
     create_handler,
@@ -26,6 +26,7 @@ from modelconverter.utils import (
     environ,
     subprocess_run,
 )
+from modelconverter.utils.config import OutputConfig as InputSpec
 
 PROFILES: Final[list[str]] = [
     "low_balanced",
@@ -44,26 +45,6 @@ RUNTIMES: dict[str, str] = {
     "dsp": "use_dsp",
     "cpu": "use_cpu",
 }
-
-DLC_TO_DAI_DATA_TYPE: Final[dict[str, dai.TensorInfo.DataType]] = {
-    "Float_32": dai.TensorInfo.DataType.FP32,
-    "Float_16": dai.TensorInfo.DataType.FP16,
-    "Float_64": dai.TensorInfo.DataType.FP64,
-    "Int_8": dai.TensorInfo.DataType.I8,
-    "Int_32": dai.TensorInfo.DataType.INT,
-    # DAI does not currently expose a 16-bit fixed-point/int tensor type.
-    # Until it does, keep uFxp_16 on the closest supported 16-bit path.
-    "uFxp_16": dai.TensorInfo.DataType.FP16,
-    "uFxp_8": dai.TensorInfo.DataType.U8F,
-}
-
-
-@dataclass(frozen=True)
-class InputSpec:
-    name: str
-    shape: list[int]
-    dlc_dtype: str
-    dai_dtype: dai.TensorInfo.DataType
 
 
 class RVC4Benchmark(Benchmark):
@@ -144,19 +125,12 @@ class RVC4Benchmark(Benchmark):
         )
 
         rows = df.rows(named=True)
-        data_types = [str(row["Type"]) for row in rows]
-        unsupported_types = sorted(set(data_types) - set(DLC_TO_DAI_DATA_TYPE))
-        if unsupported_types:
-            raise ValueError(
-                f"Unsupported data types {unsupported_types}. Expected one of: {sorted(DLC_TO_DAI_DATA_TYPE)}."
-            )
 
         return [
             InputSpec(
                 name=str(row["Input Name"]),
                 shape=list(row["Dimensions"]),
-                dlc_dtype=str(row["Type"]),
-                dai_dtype=DLC_TO_DAI_DATA_TYPE[str(row["Type"])],
+                data_type=DataType.from_dlc_dtype(str(row["Type"])),
             )
             for row in rows
         ]
@@ -189,25 +163,17 @@ class RVC4Benchmark(Benchmark):
             )
 
     @staticmethod
-    def _create_random_input(
-        spec: InputSpec,
-    ) -> np.ndarray:
-        if spec.dai_dtype == dai.TensorInfo.DataType.FP32:
-            return np.random.rand(*spec.shape).astype(np.float32)
-        if spec.dai_dtype == dai.TensorInfo.DataType.FP16:
-            return np.random.rand(*spec.shape).astype(np.float16)
-        if spec.dai_dtype == dai.TensorInfo.DataType.FP64:
-            return np.random.rand(*spec.shape).astype(np.float64)
-        if spec.dai_dtype == dai.TensorInfo.DataType.I8:
-            return np.random.randint(-128, 128, size=spec.shape, dtype=np.int8)
-        if spec.dai_dtype == dai.TensorInfo.DataType.INT:
-            # INT inputs are often token/index tensors; zero keeps synthetic
-            # benchmark inputs in a safe range.
+    def _create_random_input(spec: InputSpec) -> np.ndarray:
+        if spec.data_type is DataType.INT32:
             return np.zeros(spec.shape, dtype=np.int32)
-        if spec.dai_dtype == dai.TensorInfo.DataType.U8F:
+        if spec.data_type == DataType.INT8:
+            return np.random.randint(-128, 128, size=spec.shape, dtype=np.int8)
+        if spec.data_type == DataType.UFXP8:
             return np.random.randint(0, 256, size=spec.shape, dtype=np.uint8)
 
-        raise ValueError(f"Unsupported DAI data type {spec.dai_dtype}.")
+        return np.random.rand(*spec.shape).astype(
+            spec.data_type.as_numpy_dtype()
+        )
 
     def benchmark(self, configuration: Configuration) -> BenchmarkResult:
         dai_benchmark = configuration.get("dai_benchmark")
@@ -389,12 +355,14 @@ class RVC4Benchmark(Benchmark):
         input_specs: list[InputSpec] = []
         if isinstance(model_path, str) or str(model_path).endswith(".tar.xz"):
             model_archive = dai.NNArchive(modelPath)  # type: ignore[arg-type]
-            input_specs = self._get_dlc_input_specs(modelPath)
+            input_specs = self._get_archive_input_specs(model_archive)
 
         inputData = dai.NNData()
         for spec in input_specs:
             input_data = self._create_random_input(spec)
-            inputData.addTensor(spec.name, input_data, dataType=spec.dai_dtype)
+            inputData.addTensor(
+                spec.name, input_data, dataType=spec.data_type.as_dai_dtype()
+            )
 
         with dai.Pipeline(device) as pipeline:
             benchmarkOut = pipeline.create(dai.node.BenchmarkOut)
@@ -480,6 +448,18 @@ class RVC4Benchmark(Benchmark):
             yield f"{power_core:.2f}" if power_core else "[orange3]N/A"
         if self.dsp_monitor:
             yield f"{dsp:.2f}" if dsp else "[orange3]N/A"
+
+    @staticmethod
+    def _get_archive_input_specs(archive: dai.NNArchive) -> list[InputSpec]:
+        cfg = archive.getConfig()
+        return [
+            InputSpec(
+                input.name,
+                input.shape,
+                DataType(input.dtype.name.lower()),
+            )
+            for input in cfg.model.inputs
+        ]
 
 
 def device_id_to_adb_id(device_id: str) -> str:

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -454,9 +454,9 @@ class RVC4Benchmark(Benchmark):
         cfg = archive.getConfig()
         return [
             InputSpec(
-                input.name,
-                input.shape,
-                DataType(input.dtype.name.lower()),
+                name=input.name,
+                shape=input.shape,
+                data_type=DataType(input.dtype.name.lower()),
             )
             for input in cfg.model.inputs
         ]

--- a/modelconverter/utils/types.py
+++ b/modelconverter/utils/types.py
@@ -1,10 +1,14 @@
 from enum import Enum
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from onnx.onnx_pb import TensorProto
 
 __all__ = ["DataType", "Encoding", "PotDevice", "ResizeMethod", "Target"]
+
+if TYPE_CHECKING:
+    import depthai as dai
 
 
 class Layout(Enum):
@@ -66,6 +70,22 @@ class DataType(Enum):
         if dtype not in tensor_types:
             raise ValueError(f"Unsupported TensorFlow data type: `{dtype}`")
         return cls(tensor_types[dtype])
+
+    @classmethod
+    def from_dai_dtype(cls, dtype: "dai.TensorInfo.DataType") -> "DataType":
+        import depthai as dai
+
+        dtype_map = {
+            dai.TensorInfo.DataType.FP16: "float16",
+            dai.TensorInfo.DataType.FP32: "float32",
+            dai.TensorInfo.DataType.FP64: "float64",
+            dai.TensorInfo.DataType.I8: "int8",
+            dai.TensorInfo.DataType.INT: "int32",
+            dai.TensorInfo.DataType.U8F: "ufxp8",
+        }
+        if dtype not in dtype_map:
+            raise ValueError(f"Unsupported DepthAI data type: `{dtype}`")
+        return cls(dtype_map[dtype])
 
     @classmethod
     def from_dlc_dtype(cls, dtype: str) -> "DataType":
@@ -175,38 +195,59 @@ class DataType(Enum):
             raise ValueError(f"Unsupported IR runtime data type: `{dtype}`")
         return cls(dtype_map[dtype])
 
+    def as_dai_dtype(self) -> "dai.TensorInfo.DataType":
+        import depthai as dai
+
+        return self._transform(
+            {
+                "float16": dai.TensorInfo.DataType.FP16,
+                "float32": dai.TensorInfo.DataType.FP32,
+                "float64": dai.TensorInfo.DataType.FP64,
+                "int8": dai.TensorInfo.DataType.I8,
+                "int32": dai.TensorInfo.DataType.INT,
+                "uint8": dai.TensorInfo.DataType.U8F,
+            },
+            "DepthAI",
+        )
+
     def as_numpy_dtype(self) -> np.dtype:
-        return {
-            "bfloat16": np.float32,  # Preserve bfloat16 range better than float16.
-            "float16": np.float16,
-            "float32": np.float32,
-            "float64": np.float64,
-            "int4": np.int8,  # NumPy has no 4-bit signed integer dtype.
-            "int8": np.int8,
-            "int16": np.int16,
-            "int32": np.int32,
-            "int64": np.int64,
-            "uint4": np.uint8,  # NumPy has no 4-bit unsigned integer dtype.
-            "uint8": np.uint8,
-            "uint16": np.uint16,
-            "uint32": np.uint32,
-            "uint64": np.uint64,
-        }[self.value]
+        return self._transform(
+            {
+                "bfloat16": np.float32,  # Preserve bfloat16 range better than float16.
+                "float16": np.float16,
+                "float32": np.float32,
+                "float64": np.float64,
+                "int4": np.int8,  # NumPy has no 4-bit signed integer dtype.
+                "int8": np.int8,
+                "int16": np.int16,
+                "int32": np.int32,
+                "int64": np.int64,
+                "uint4": np.uint8,  # NumPy has no 4-bit unsigned integer dtype.
+                "uint8": np.uint8,
+                "uint16": np.uint16,
+                "uint32": np.uint32,
+                "uint64": np.uint64,
+            },
+            "numpy",
+        )
 
     def as_openvino_dtype(self) -> str:
-        return {
-            "float16": "f16",
-            "float32": "f32",
-            "float64": "f64",
-            "int8": "i8",
-            "int16": "i16",
-            "int32": "i32",
-            "int64": "i64",
-            "uint8": "u8",
-            "uint16": "u16",
-            "uint32": "u32",
-            "uint64": "u64",
-        }[self.value]
+        return self._transform(
+            {
+                "float16": "f16",
+                "float32": "f32",
+                "float64": "f64",
+                "int8": "i8",
+                "int16": "i16",
+                "int32": "i32",
+                "int64": "i64",
+                "uint8": "u8",
+                "uint16": "u16",
+                "uint32": "u32",
+                "uint64": "u64",
+            },
+            "OpenVINO",
+        )
 
     def as_snpe_dtype(self) -> str:
         return self.value
@@ -217,6 +258,13 @@ class DataType(Enum):
         if self.value.startswith("fxp"):
             return self.value.replace("fxp", "int")
         return self.value
+
+    def _transform(self, mapping: dict[str, Any], desc: str) -> Any:
+        if self.value not in mapping:
+            raise ValueError(
+                f"`{self.value}` cannot be transformed to {desc} data type"
+            )
+        return mapping[self.value]
 
 
 class ResizeMethod(Enum):

--- a/modelconverter/utils/types.py
+++ b/modelconverter/utils/types.py
@@ -207,6 +207,11 @@ class DataType(Enum):
                 "int32": dai.TensorInfo.DataType.INT,
                 "uint8": dai.TensorInfo.DataType.U8F,
                 "ufxp8": dai.TensorInfo.DataType.U8F,
+                # DAI does not currently expose a 16-bit
+                # fixed-point/int tensor type.
+                # Until it does, keep uFxp_16 on the closest
+                # supported 16-bit path.
+                "ufxp16": dai.TensorInfo.DataType.FP16,
             },
             "DepthAI",
         )

--- a/modelconverter/utils/types.py
+++ b/modelconverter/utils/types.py
@@ -206,6 +206,7 @@ class DataType(Enum):
                 "int8": dai.TensorInfo.DataType.I8,
                 "int32": dai.TensorInfo.DataType.INT,
                 "uint8": dai.TensorInfo.DataType.U8F,
+                "ufxp8": dai.TensorInfo.DataType.U8F,
             },
             "DepthAI",
         )
@@ -227,6 +228,16 @@ class DataType(Enum):
                 "uint16": np.uint16,
                 "uint32": np.uint32,
                 "uint64": np.uint64,
+                "boolean": np.bool_,
+                "string": np.str_,
+                "ufxp8": np.uint8,  # No fixed-point dtype in NumPy, so use uint8 as a placeholder.
+                "ufxp16": np.uint16,
+                "ufxp32": np.uint32,
+                "ufxp64": np.uint64,
+                "fxp8": np.int8,
+                "fxp16": np.int16,
+                "fxp32": np.int32,
+                "fxp64": np.int64,
             },
             "numpy",
         )


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
DAI RVC4 benchmark can read inputs info from the archive instead of relying on `snpe-dlc-info`. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
