### PR TITLE
Changed benchmark result to `dict`

### DIFF
--- a/modelconverter/packages/base_benchmark.py
+++ b/modelconverter/packages/base_benchmark.py
@@ -2,23 +2,12 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Literal, NamedTuple, TypeAlias
+from typing import Any, TypeAlias
 
 import polars as pl
 from loguru import logger
 
 from modelconverter.utils import is_hubai_available, resolve_path
-
-
-class BenchmarkResult(NamedTuple):
-    """Benchmark result, tuple (FPS, latency in ms, system and processor
-    power in W, dsp utilization)"""
-
-    fps: float
-    latency: float | Literal["N/A"]
-    power: tuple[float | None, float | None] = (None, None)
-    dsp: float | None = None
-
 
 Configuration: TypeAlias = dict[str, Any]
 
@@ -68,7 +57,7 @@ class Benchmark(ABC):
         ]
 
     @abstractmethod
-    def benchmark(self, configuration: Configuration) -> BenchmarkResult:
+    def benchmark(self, configuration: Configuration) -> dict[str, Any]:
         pass
 
     @property
@@ -82,7 +71,7 @@ class Benchmark(ABC):
         pass
 
     def print_results(
-        self, results: list[tuple[Configuration, BenchmarkResult]]
+        self, results: list[tuple[Configuration, dict[str, Any]]]
     ) -> None:
         assert results, "No results to print"
 
@@ -110,7 +99,7 @@ class Benchmark(ABC):
 
     def _base_header(
         self,
-        results: list[tuple[Configuration, BenchmarkResult]],
+        results: list[tuple[Configuration, dict[str, Any]]],
     ) -> list[str]:
         """Shared header cells."""
         return [*results[0][0].keys(), "fps", "latency (ms)"]
@@ -118,7 +107,7 @@ class Benchmark(ABC):
     def _base_row_cells(
         self,
         configuration: Configuration,
-        result: BenchmarkResult,
+        result: dict[str, Any],
     ) -> Iterable[str]:
         """Shared row cells for each result (configuration + fps +
         latency)."""
@@ -126,33 +115,27 @@ class Benchmark(ABC):
         for x in configuration.values():
             yield f"[magenta]{x}"
 
-        # fps
-        fps_color = (
-            "yellow"
-            if 5 < result.fps < 15
-            else "red"
-            if result.fps < 5
-            else "green"
-        )
-        yield f"[{fps_color}]{result.fps:.2f}"
+        fps = result["fps"]
+        fps_color = "yellow" if 5 < fps < 15 else "red" if fps < 5 else "green"
+        yield f"[{fps_color}]{fps:.2f}"
 
-        # latency
-        if isinstance(result.latency, str):
+        latency = result.get("latency", "N/A")
+        if isinstance(latency, str):
             latency_color = "orange3"
-            yield f"[{latency_color}]{result.latency}"
+            yield f"[{latency_color}]{latency}"
         else:
             latency_color = (
                 "yellow"
-                if 50 < result.latency < 100
+                if 50 < latency < 100
                 else "red"
-                if result.latency > 100
+                if latency > 100
                 else "green"
             )
-            yield f"[{latency_color}]{result.latency:.5f}"
+            yield f"[{latency_color}]{latency:.5f}"
 
     def _extra_header(
         self,
-        results: list[tuple[Configuration, BenchmarkResult]],
+        results: list[tuple[Configuration, dict[str, Any]]],
     ) -> list[str]:
         """Columns to append after the base header (default: none)."""
         return []
@@ -160,7 +143,7 @@ class Benchmark(ABC):
     def _extra_row_cells(
         self,
         configuration: Configuration,
-        result: BenchmarkResult,
+        result: dict[str, Any],
     ) -> Iterable[str]:
         """Extra cells to append after the base row cells (default:
 
@@ -169,14 +152,11 @@ class Benchmark(ABC):
         return []
 
     def save_results(
-        self, results: list[tuple[Configuration, BenchmarkResult]]
+        self, results: list[tuple[Configuration, dict[str, Any]]]
     ) -> None:
         assert results, "No results to save"
         df = pl.DataFrame(
-            [
-                {**configuration, **result._asdict()}
-                for configuration, result in results
-            ]
+            [configuration | result for configuration, result in results]
         )
 
         # Split nested power list into two CSV-friendly columns
@@ -207,7 +187,7 @@ class Benchmark(ABC):
                 for config in self.all_configurations  # add only kwarg keys that are not already there to not overwrite
             ]
 
-        results: list[tuple[Configuration, BenchmarkResult]] = [
+        results: list[tuple[Configuration, dict[str, Any]]] = [
             (configuration, self.benchmark(configuration))
             for configuration in configurations
         ]

--- a/modelconverter/packages/rvc2/benchmark.py
+++ b/modelconverter/packages/rvc2/benchmark.py
@@ -1,13 +1,10 @@
 from pathlib import Path
+from typing import Any
 
 import depthai as dai
 import numpy as np
 
-from modelconverter.packages.base_benchmark import (
-    Benchmark,
-    BenchmarkResult,
-    Configuration,
-)
+from modelconverter.packages.base_benchmark import Benchmark, Configuration
 from modelconverter.utils import create_progress_handler, environ
 
 
@@ -31,7 +28,7 @@ class RVC2Benchmark(Benchmark):
     def all_configurations(self) -> list[Configuration]:
         return [{"num_threads": i} for i in [1, 2, 3]]
 
-    def benchmark(self, configuration: Configuration) -> BenchmarkResult:
+    def benchmark(self, configuration: Configuration) -> dict[str, Any]:
         return self._benchmark(self.model_path, **configuration)
 
     @staticmethod
@@ -41,7 +38,7 @@ class RVC2Benchmark(Benchmark):
         num_messages: int,
         num_threads: int,
         benchmark_time: int,
-    ) -> BenchmarkResult:
+    ) -> dict[str, Any]:
         device = dai.Device()
         if device.getPlatform() != dai.Platform.RVC2:
             raise ValueError(
@@ -138,4 +135,7 @@ class RVC2Benchmark(Benchmark):
                     on_tick()
 
             # Currently, the latency measurement is not supported on RVC2 by the depthai library.
-            return BenchmarkResult(float(np.mean(fps_list)), "N/A")
+            return {
+                "fps": float(np.mean(fps_list)),
+                "latency": "N/A",
+            }

--- a/modelconverter/packages/rvc3/benchmark.py
+++ b/modelconverter/packages/rvc3/benchmark.py
@@ -1,16 +1,13 @@
 import sys
 from datetime import datetime, timezone
 from statistics import median
+from typing import Any
 
 from loguru import logger
 from openvino.inference_engine.ie_api import IECore, StatusCode
 from rich.progress import track
 
-from modelconverter.packages.base_benchmark import (
-    Benchmark,
-    BenchmarkResult,
-    Configuration,
-)
+from modelconverter.packages.base_benchmark import Benchmark, Configuration
 
 
 class RVC3Benchmark(Benchmark):
@@ -25,11 +22,11 @@ class RVC3Benchmark(Benchmark):
     def all_configurations(self) -> list[Configuration]:
         return [{"requests": i} for i in range(1, 6)]
 
-    def benchmark(self, configuration: Configuration) -> BenchmarkResult:
+    def benchmark(self, configuration: Configuration) -> dict[str, Any]:
         return self._benchmark(str(self.model_path), **configuration)
 
     @staticmethod
-    def _benchmark(model_path: str, requests: int) -> BenchmarkResult:
+    def _benchmark(model_path: str, requests: int) -> dict[str, Any]:
         ie = IECore()
         exe_network = ie.load_network(
             model_path,
@@ -79,4 +76,4 @@ class RVC3Benchmark(Benchmark):
         times.sort()
         latency = median(times)
         fps = i / total_duration_sec
-        return BenchmarkResult(fps, latency)
+        return {"fps": fps, "latency": latency}

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -5,18 +5,14 @@ import shutil
 import tempfile
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Final
+from typing import Any, Final
 
 import depthai as dai
 import numpy as np
 import polars as pl
 from loguru import logger
 
-from modelconverter.packages.base_benchmark import (
-    Benchmark,
-    BenchmarkResult,
-    Configuration,
-)
+from modelconverter.packages.base_benchmark import Benchmark, Configuration
 from modelconverter.utils import (
     DataType,
     MonitorDSP,
@@ -177,7 +173,7 @@ class RVC4Benchmark(Benchmark):
             spec.data_type.as_numpy_dtype()
         )
 
-    def benchmark(self, configuration: Configuration) -> BenchmarkResult:
+    def benchmark(self, configuration: Configuration) -> dict[str, Any]:
         dai_benchmark = configuration.get("dai_benchmark")
         power_benchmark = configuration.get("power_benchmark")
         dsp_benchmark = configuration.get("dsp_benchmark")
@@ -228,9 +224,9 @@ class RVC4Benchmark(Benchmark):
                 result = self._benchmark_snpe(self.model_path, **configuration)
 
             if self.power_monitor:
-                result = result._replace(power=self.power_monitor.get_stats())
+                result["power"] = self.power_monitor.get_stats()
             if self.dsp_monitor:
-                result = result._replace(dsp=self.dsp_monitor.get_stats())
+                result["dsp"] = self.dsp_monitor.get_stats()
             return result
         finally:
             if self.power_monitor:
@@ -251,7 +247,7 @@ class RVC4Benchmark(Benchmark):
         num_images: int,
         profile: str,
         runtime: str,
-    ) -> BenchmarkResult:
+    ) -> dict[str, Any]:
         runtime = RUNTIMES.get(runtime, "use_dsp")
 
         if isinstance(model_path, str):
@@ -306,7 +302,7 @@ class RVC4Benchmark(Benchmark):
                 f"stdout:\n{stdout}"
             )
         fps = float(match.group(1))
-        return BenchmarkResult(fps=fps, latency="N/A")
+        return {"fps": fps, "latency": "N/A"}
 
     def _benchmark_dai(
         self,
@@ -318,7 +314,7 @@ class RVC4Benchmark(Benchmark):
         num_messages: int,
         benchmark_time: int,
         device_ip: str | None = None,
-    ) -> BenchmarkResult:
+    ) -> dict[str, Any]:
         if device_ip:
             device = dai.Device(dai.DeviceInfo(device_ip))
         else:
@@ -426,11 +422,16 @@ class RVC4Benchmark(Benchmark):
                     on_tick()
 
             # Currently, the latency measurement is only supported on RVC4 when using ImgFrame as the input to the BenchmarkOut which we don't do here.
-            return BenchmarkResult(float(np.mean(fps_list)), "N/A")
+            return {
+                "fps": float(np.mean(fps_list)),
+                "latency": float(np.mean(avg_latency_list))
+                if avg_latency_list
+                else "N/A",
+            }
 
     def _extra_header(
         self,
-        results: list[tuple[Configuration, BenchmarkResult]],
+        results: list[tuple[Configuration, dict[str, Any]]],
     ) -> list[str]:
         heads = []
         if self.power_monitor:
@@ -443,10 +444,10 @@ class RVC4Benchmark(Benchmark):
     def _extra_row_cells(
         self,
         configuration: Configuration,
-        result: BenchmarkResult,
+        result: dict[str, Any],
     ) -> Iterable[str]:
-        power_sys, power_core = result.power
-        dsp = result.dsp
+        power_sys, power_core = result.get("power", (None, None))
+        dsp = result.get("dsp")
 
         if self.power_monitor:
             yield f"{power_sys:.2f}" if power_sys else "[orange3]N/A"


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Makes benchmark results more easily scalable to incorporate various HW measurements.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Changed the benchmark results from a named tuple to a generic dictionary.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
