### PR TITLE
HAILO: Fix docker build

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -75,7 +75,7 @@ jobs:
         run: |
           pip uninstall luxonis-ml -y
           pip install \
-            "luxonis-ml[data,nn_archive] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" \
+            "luxonis-ml[data,nn-archive] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" \
             --upgrade --force-reinstall
 
       - name: Run Unit Tests

--- a/docker/hailo/Dockerfile
+++ b/docker/hailo/Dockerfile
@@ -20,7 +20,10 @@ RUN <<EOF
 
     set -e
 
-    pip install --upgrade pip --no-cache-dir
+    # pip 26 ignores the non-PEP517 install path we need for the DALI TF
+    # plugin archive and falls back to an isolated build that crashes on
+    # missing pkg_resources.
+    pip install --no-cache-dir "pip==25.0.1"
     pip install -r requirements.txt --no-cache-dir
     python - <<PY
 from urllib.request import urlretrieve

--- a/docker/hailo/Dockerfile
+++ b/docker/hailo/Dockerfile
@@ -1,10 +1,12 @@
 ARG VERSION=2025.04
+ARG DALI_VERSION=1.49.0
 
 FROM hailo_ai_sw_suite_${VERSION//./-}:1
 
 USER root
 
 ARG VERSION
+ARG DALI_VERSION
 
 ENV VERSION=${VERSION//./-}
 ENV IN_DOCKER=
@@ -20,10 +22,32 @@ RUN <<EOF
 
     pip install --upgrade pip --no-cache-dir
     pip install -r requirements.txt --no-cache-dir
-    pip install -U --extra-index-url \
-        https://developer.download.nvidia.com/compute/redist \
-        --no-cache-dir --use-pep517 --no-build-isolation \
-        -r requirements-hailo.txt
+    python - <<PY
+from urllib.request import urlretrieve
+
+version = "${DALI_VERSION}"
+base_url = "https://developer.download.nvidia.com/compute/redist"
+artifacts = [
+    (
+        f"{base_url}/nvidia-dali-cuda120/"
+        f"nvidia_dali_cuda120-{version}-py3-none-manylinux2014_x86_64.whl",
+        f"/tmp/nvidia_dali_cuda120-{version}-py3-none-manylinux2014_x86_64.whl",
+    ),
+    (
+        f"{base_url}/nvidia-dali-tf-plugin-cuda120/"
+        f"nvidia_dali_tf_plugin_cuda120-{version}.tar.gz",
+        f"/tmp/nvidia_dali_tf_plugin_cuda120-{version}.tar.gz",
+    ),
+]
+
+for url, dest in artifacts:
+    urlretrieve(url, dest)
+PY
+    pip install --no-cache-dir --no-deps \
+        "/tmp/nvidia_dali_cuda120-${DALI_VERSION}-py3-none-manylinux2014_x86_64.whl"
+    PIP_USE_PEP517=0 pip install --no-cache-dir --no-deps \
+        "/tmp/nvidia_dali_tf_plugin_cuda120-${DALI_VERSION}.tar.gz"
+    pip install --no-cache-dir -r requirements-hailo.txt
 
 EOF
 

--- a/modelconverter/packages/hailo/requirements.txt
+++ b/modelconverter/packages/hailo/requirements.txt
@@ -1,5 +1,6 @@
-nvidia-dali-cuda120==1.49.0
-nvidia-dali-tf-plugin-cuda120==1.49.0
+# DALI is installed from local archives in docker/hailo/Dockerfile because
+# pip currently corrupts the tf-plugin archive when downloading it by name
+# from NVIDIA's index.
 protobuf==3.20.3
 matplotlib==3.10.6
 pyparsing==2.4.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["."]
+include = ["modelconverter*"]
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Pillow
-luxonis-ml[data,nn_archive,s3,gcs]>=0.8.4
+luxonis-ml[data,nn-archive,s3,gcs]>=0.8.4
 cyclopts==4.8.0
 onnx==1.21.0
 onnxruntime


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Restrict setuptools package discovery to `modelconverter*` so installs only ship the intended Python package; verified wheel/source installs and CLI entrypoints still work.
- Normalize the `luxonis-ml` extra name from `nn_archive` to `nn-archive` to match published package metadata and avoid a misleading pip warning/future dependency issues.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
