### PR TITLE
Tightening the RVC4 DAI Benchmark code and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,8 +615,8 @@ optionally saves the results to a `.csv` file.
 > Benchmark input support depends on the target and backend:
 >
 > - **RVC2**: `--model-path` can be a local `.blob`, an NN Archive (`.tar.xz`), or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
-> - **RVC4** with `--dai-benchmark true` (default): `--model-path` can be an NN Archive (`.tar.xz`) or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
-> - **RVC4** with `--dai-benchmark false`: `--model-path` can be a local `.dlc`, an NN Archive (`.tar.xz`), or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
+> - **RVC4** with `--dai-benchmark` (default): `--model-path` can be an NN Archive (`.tar.xz`) or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
+> - **RVC4** with `--no-dai-benchmark`: `--model-path` can be a local `.dlc`, an NN Archive (`.tar.xz`), or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
 >
 > To access models from different teams in Luxonis HubAI, remember to update the `HUBAI_API_KEY` environment variable accordingly.
 
@@ -632,7 +632,7 @@ optionally saves the results to a `.csv` file.
 > **Device Connection Requirements for RVC4**: The device must be connected and accessible either using the [Android Debug Bridge (ADB)](https://developer.android.com/tools/adb) or via SSH for the benchmarking to work in the following cases:
 >
 > - When `--device-monitor` is enabled (requires ADB or SSH connection to the device to calculate power consumption)
-> - When benchmarking is conducted using the SNPE tools (by setting `--dai-benchmark` to `False`, default is `True`)
+> - When benchmarking is conducted using the SNPE tools (with `--no-dai-benchmark`; default is `--dai-benchmark`)
 >
 > The tool can find the correct device automatically but you can also specify it with the `--device-id` flag.
 

--- a/README.md
+++ b/README.md
@@ -605,14 +605,20 @@ For usage instructions, see `modelconverter benchmark --help`.
 **Example:**
 
 ```bash
-modelconverter benchmark rvc4 --model-path <path_to_model.xml>
+modelconverter benchmark rvc4 --model-path <path_to_model.tar.xz>
 ```
 
 The command prints a table with the benchmark results to the console and
 optionally saves the results to a `.csv` file.
 
 > [!NOTE]
-> For **RVC2** and **RVC4**: The `--model-path` can be a path to a local .blob file, an NN Archive file (.tar.xz), or a name of a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai). To access models from different teams in Luxonis HubAI, remember to update the HUBAI_API_KEY environment variable respectively.
+> Benchmark input support depends on the target and backend:
+>
+> - **RVC2**: `--model-path` can be a local `.blob`, an NN Archive (`.tar.xz`), or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
+> - **RVC4** with `--dai-benchmark true` (default): `--model-path` can be an NN Archive (`.tar.xz`) or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
+> - **RVC4** with `--dai-benchmark false`: `--model-path` can be a local `.dlc`, an NN Archive (`.tar.xz`), or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
+>
+> To access models from different teams in Luxonis HubAI, remember to update the `HUBAI_API_KEY` environment variable accordingly.
 
 > [!NOTE]
 > **Benchmark Duration Control (RVC2/RVC4)**: Two flags can affect the duration of benchmarking:
@@ -625,7 +631,7 @@ optionally saves the results to a `.csv` file.
 > [!IMPORTANT]
 > **Device Connection Requirements for RVC4**: The device must be connected and accessible either using the [Android Debug Bridge (ADB)](https://developer.android.com/tools/adb) or via SSH for the benchmarking to work in the following cases:
 >
-> - When `--device-monitor` is enabled (requires ADB or SSH connection to the device calculate power consumption)
+> - When `--device-monitor` is enabled (requires ADB or SSH connection to the device to calculate power consumption)
 > - When benchmarking is conducted using the SNPE tools (by setting `--dai-benchmark` to `False`, default is `True`)
 >
 > The tool can find the correct device automatically but you can also specify it with the `--device-id` flag.

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -326,6 +326,45 @@ class RVC4Benchmark(Benchmark):
         benchmark_time: int,
         device_ip: str | None = None,
     ) -> dict[str, Any]:
+        if isinstance(model_path, str):
+            modelPath = Path(
+                dai.getModelFromZoo(
+                    dai.NNModelDescription(
+                        model_path,
+                        platform=dai.Platform.RVC4.name,
+                    ),
+                    apiKey=environ.HUBAI_API_KEY or "",
+                )
+            )
+        elif str(model_path).endswith(".tar.xz"):
+            modelPath = Path(model_path)
+        elif str(model_path).endswith(".dlc"):
+            raise ValueError(
+                "DLC model format is not currently supported for dai-benchmark. Please use SNPE for DLC models."
+            )
+        else:
+            raise ValueError(
+                "Unsupported model format. Supported formats: .tar.xz, or HubAI model slug."
+            )
+
+        model_archive = dai.NNArchive(modelPath)
+        try:
+            logger.info("Trying to get input specs from the DLC file...")
+            input_specs = self._get_dlc_input_specs(modelPath)
+        except Exception as e:
+            logger.warning(
+                f"Failed to read input specs from the DLC "
+                f"with error: {e}. Reading from the archive."
+            )
+            input_specs = self._get_archive_input_specs(model_archive)
+
+        inputData = dai.NNData()
+        for spec in input_specs:
+            input_data = self._create_random_input(spec)
+            inputData.addTensor(
+                spec.name, input_data, dataType=spec.data_type.as_dai_dtype()
+            )
+
         if device_ip:
             device = dai.Device(dai.DeviceInfo(device_ip))
         else:
@@ -345,57 +384,13 @@ class RVC4Benchmark(Benchmark):
             f"Using {device.getPlatformAsString()} device on IP {device.getDeviceInfo().name}."
         )
 
-        if isinstance(model_path, str):
-            modelPath = Path(
-                dai.getModelFromZoo(
-                    dai.NNModelDescription(
-                        model_path,
-                        platform=device.getPlatformAsString(),
-                    ),
-                    apiKey=environ.HUBAI_API_KEY or "",
-                )
-            )
-        elif str(model_path).endswith(".tar.xz"):
-            modelPath = Path(model_path)
-        elif str(model_path).endswith(".dlc"):
-            raise ValueError(
-                "DLC model format is not currently supported for dai-benchmark. Please use SNPE for DLC models."
-            )
-        else:
-            raise ValueError(
-                "Unsupported model format. Supported formats: .tar.xz, or HubAI model slug."
-            )
-
-        input_specs: list[InputSpec] = []
-        if isinstance(model_path, str) or str(model_path).endswith(".tar.xz"):
-            model_archive = dai.NNArchive(modelPath)
-            try:
-                logger.info("Trying to get input specs from the DLC file...")
-                input_specs = self._get_dlc_input_specs(modelPath)
-            except Exception as e:
-                logger.warning(
-                    f"Failed to read input specs from the DLC "
-                    f"with error: {e}. Reading from the archive."
-                )
-                input_specs = self._get_archive_input_specs(model_archive)
-
-        inputData = dai.NNData()
-        for spec in input_specs:
-            input_data = self._create_random_input(spec)
-            inputData.addTensor(
-                spec.name, input_data, dataType=spec.data_type.as_dai_dtype()
-            )
-
         with dai.Pipeline(device) as pipeline:
             benchmarkOut = pipeline.create(dai.node.BenchmarkOut)
             benchmarkOut.setRunOnHost(False)
             benchmarkOut.setFps(-1)
 
             neuralNetwork = pipeline.create(dai.node.NeuralNetwork)
-            if isinstance(model_path, str) or str(model_path).endswith(
-                ".tar.xz"
-            ):
-                neuralNetwork.setNNArchive(model_archive)
+            neuralNetwork.setNNArchive(model_archive)
 
             neuralNetwork.setBackendProperties(
                 {

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -327,7 +327,7 @@ class RVC4Benchmark(Benchmark):
         device_ip: str | None = None,
     ) -> dict[str, Any]:
         if isinstance(model_path, str):
-            modelPath = Path(
+            resolved_model_path = Path(
                 dai.getModelFromZoo(
                     dai.NNModelDescription(
                         model_path,
@@ -337,7 +337,7 @@ class RVC4Benchmark(Benchmark):
                 )
             )
         elif str(model_path).endswith(".tar.xz"):
-            modelPath = Path(model_path)
+            resolved_model_path = Path(model_path)
         elif str(model_path).endswith(".dlc"):
             raise ValueError(
                 "DLC model format is not currently supported for dai-benchmark. Please use SNPE for DLC models."
@@ -347,10 +347,10 @@ class RVC4Benchmark(Benchmark):
                 "Unsupported model format. Supported formats: .tar.xz, or HubAI model slug."
             )
 
-        model_archive = dai.NNArchive(modelPath)
+        model_archive = dai.NNArchive(resolved_model_path)
         try:
             logger.info("Trying to get input specs from the DLC file...")
-            input_specs = self._get_dlc_input_specs(modelPath)
+            input_specs = self._get_dlc_input_specs(resolved_model_path)
         except Exception as e:
             logger.warning(
                 f"Failed to read input specs from the DLC "
@@ -358,10 +358,10 @@ class RVC4Benchmark(Benchmark):
             )
             input_specs = self._get_archive_input_specs(model_archive)
 
-        inputData = dai.NNData()
+        input_data_packet = dai.NNData()
         for spec in input_specs:
             input_data = self._create_random_input(spec)
-            inputData.addTensor(
+            input_data_packet.addTensor(
                 spec.name, input_data, dataType=spec.data_type.as_dai_dtype()
             )
 
@@ -385,35 +385,35 @@ class RVC4Benchmark(Benchmark):
         )
 
         with dai.Pipeline(device) as pipeline:
-            benchmarkOut = pipeline.create(dai.node.BenchmarkOut)
-            benchmarkOut.setRunOnHost(False)
-            benchmarkOut.setFps(-1)
+            benchmark_out = pipeline.create(dai.node.BenchmarkOut)
+            benchmark_out.setRunOnHost(False)
+            benchmark_out.setFps(-1)
 
-            neuralNetwork = pipeline.create(dai.node.NeuralNetwork)
-            neuralNetwork.setNNArchive(model_archive)
+            neural_network = pipeline.create(dai.node.NeuralNetwork)
+            neural_network.setNNArchive(model_archive)
 
-            neuralNetwork.setBackendProperties(
+            neural_network.setBackendProperties(
                 {
                     "runtime": runtime,
                     "performance_profile": profile,
                 }
             )
 
-            neuralNetwork.setNumInferenceThreads(num_threads)
+            neural_network.setNumInferenceThreads(num_threads)
 
-            benchmarkIn = pipeline.create(dai.node.BenchmarkIn)
-            benchmarkIn.setRunOnHost(False)
-            benchmarkIn.sendReportEveryNMessages(num_messages)
-            benchmarkIn.logReportsAsWarnings(False)
+            benchmark_in = pipeline.create(dai.node.BenchmarkIn)
+            benchmark_in.setRunOnHost(False)
+            benchmark_in.sendReportEveryNMessages(num_messages)
+            benchmark_in.logReportsAsWarnings(False)
 
-            benchmarkOut.out.link(neuralNetwork.input)
-            neuralNetwork.out.link(benchmarkIn.input)
+            benchmark_out.out.link(neural_network.input)
+            neural_network.out.link(benchmark_in.input)
 
-            outputQueue = benchmarkIn.report.createOutputQueue()
-            inputQueue = benchmarkOut.input.createInputQueue()
+            output_queue = benchmark_in.report.createOutputQueue()
+            input_queue = benchmark_out.input.createInputQueue()
 
             pipeline.start()
-            inputQueue.send(inputData)
+            input_queue.send(input_data_packet)
 
             progress, on_tick, should_continue = create_progress_handler(
                 benchmark_time, repetitions
@@ -424,15 +424,15 @@ class RVC4Benchmark(Benchmark):
 
             with progress:
                 while pipeline.isRunning() and should_continue():
-                    benchmarkReport = outputQueue.get()
-                    if not isinstance(benchmarkReport, dai.BenchmarkReport):
+                    benchmark_report = output_queue.get()
+                    if not isinstance(benchmark_report, dai.BenchmarkReport):
                         raise TypeError(
-                            f"Expected BenchmarkReport, got {type(benchmarkReport)}"
+                            f"Expected BenchmarkReport, got {type(benchmark_report)}"
                         )
 
-                    fps_list.append(benchmarkReport.fps)
+                    fps_list.append(benchmark_report.fps)
                     avg_latency_list.append(
-                        benchmarkReport.averageLatency * 1000
+                        benchmark_report.averageLatency * 1000
                     )
 
                     on_tick()


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Simplifying the code since only RVC4 NNArchive is acceptable path for DAI Benchmark
- Clearer README
- Putting NNArchive manipulation before DAI device init

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated benchmarking guide with a clearer model-path format breakdown for RVC2 and RVC4, HubAI API key guidance, and clarified device-monitor requirement (ADB/SSH) for power measurement.

* **Improvements**
  * More reliable benchmark handling of different model package formats and improved model retrieval, input-spec detection, and device selection for RVC4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->