### PR TITLE
Fix failing SNPE benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ There are two main ways to execute configure the conversion process:
 
 1. **NN Archive**:
    Alternatively, you can use an [NN Archive](https://docs.luxonis.com/software-v3/ai-inference/nn-archive/#NN%20Archive) as input. An NN Archive includes a model in one of the supported formats—ONNX (.onnx), OpenVINO IR (.xml and .bin), or TensorFlow Lite (.tflite)—alongside a `config.json` file. The config.json file follows a specific configuration format as described under the `Configuration` section.
-1. **YAML Configuration File (Legacy)**:
+2. **YAML Configuration File (Legacy)**:
    An alternative way to configure the conversion is through a YAML configuration file. For reference, you can check [defaults.yaml](shared_with_container/configs/defaults.yaml) and other examples located in the [shared_with_container/configs](shared_with_container/configs) directory.
 
 **Modifying Settings with Command-Line Arguments**:
@@ -359,11 +359,11 @@ You can run the built image either manually using the `docker run` command or us
    export AWS_S3_ENDPOINT_URL=<your_aws_s3_endpoint_url>
    ```
 
-1. If `shared_with_container` directory doesn't exist on your host, create it.
+2. If `shared_with_container` directory doesn't exist on your host, create it.
 
-1. Without remote files, place the model, config, and calibration data in the respective directories (refer [Sharing Files](#sharing-files)).
+3. Without remote files, place the model, config, and calibration data in the respective directories (refer [Sharing Files](#sharing-files)).
 
-1. Execute the conversion:
+4. Execute the conversion:
 
 - If using the `modelconverter` CLI:
 
@@ -611,23 +611,6 @@ modelconverter benchmark rvc4 --model-path <path_to_model.tar.xz>
 The command prints a table with the benchmark results to the console and
 optionally saves the results to a `.csv` file.
 
-> [!NOTE]
-> Benchmark input support depends on the target and backend:
->
-> - **RVC2**: `--model-path` can be a local `.blob`, an NN Archive (`.tar.xz`), or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
-> - **RVC4** with `--dai-benchmark` (default): `--model-path` can be an NN Archive (`.tar.xz`) or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
-> - **RVC4** with `--no-dai-benchmark`: `--model-path` can be a local `.dlc`, an NN Archive (`.tar.xz`), or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
->
-> To access models from different teams in Luxonis HubAI, remember to update the `HUBAI_API_KEY` environment variable accordingly.
-
-> [!NOTE]
-> **Benchmark Duration Control (RVC2/RVC4)**: Two flags can affect the duration of benchmarking:
->
-> - `--benchmark-time`: Duration in seconds for time-based benchmarking (default: 20)
-> - `--repetitions`: Number of iterations to perform (default: 10)
->
-> By default, the benchmarking uses `--benchmark-time` (20 seconds) which takes precedence over `--repetitions`. To use `--repetitions` instead, you must explicitly set `--benchmark-time` to a negative value (e.g., `--benchmark-time -1`).
-
 > [!IMPORTANT]
 > **Device Connection Requirements for RVC4**: The device must be connected and accessible either using the [Android Debug Bridge (ADB)](https://developer.android.com/tools/adb) or via SSH for the benchmarking to work in the following cases:
 >
@@ -636,13 +619,26 @@ optionally saves the results to a `.csv` file.
 >
 > The tool can find the correct device automatically but you can also specify it with the `--device-id` flag.
 
+> [!NOTE]
+> Benchmark input support depends on the target and backend:
+>
+> - **RVC2**: `--model-path` can be a local `.blob`, an NN Archive (`.tar.xz`), or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
+> - **RVC4** with `--dai-benchmark` (default): `--model-path` can be an NN Archive (`.tar.xz`) or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
+> - **RVC4** with `--no-dai-benchmark`: `--model-path` can be an NN Archive (`.tar.xz`), a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai) or a `.dlc` file.
+>   In the case of a `.dlc` file, the tool `snpe-dlc-info` must be accessible on the device.
+>
+> To access models from different teams in Luxonis HubAI, remember to update the `HUBAI_API_KEY` environment variable accordingly when using a model slug as an input.
+
+> [!NOTE]
+> If you experience Segmentation Faults (core dumps) during benchmarking on RVC4 using the SNPE backend (`--no-dai-benchmark`), it may be due to the device running out of memory. Try decreasing the value of `--num-images` (the default is 500) to reduce RAM usage.
+
 ## [RVC4] DLC model analysis
 
 ModelConverter offers additional analysis tools for the RVC4 platform. The tools provide an in-depth look at the following:
 
 1. The outputs of all layers in comparison to the ground truth ONNX model,
-1. The cycle usage of each layer on an RVC4 device.
-1. Visualizations for fast and easy comparison of multiple models.
+2. The cycle usage of each layer on an RVC4 device.
+3. Visualizations for fast and easy comparison of multiple models.
 
 This gives the user better insight into the successful quantization of a model, helps discover potential speed bottleneck layers, and allows for the comparison of different quantization parameters.
 

--- a/README.md
+++ b/README.md
@@ -609,7 +609,16 @@ modelconverter benchmark rvc4 --model-path <path_to_model.tar.xz>
 ```
 
 The command prints a table with the benchmark results to the console and
-optionally saves the results to a `.csv` file.
+kptionally saves the results to a `.csv` file.
+
+> [!NOTE]
+> **Duration Control**:
+> There are two ways how to specify the duration of the benchmark:
+> `depthai` backend (default):
+>
+> - `--benchmark-time`: The duration of the benchmark in seconds (default is 20 seconds).
+>   `SNPE` backend (only **RVC4** with `--no-dai-benchmark`):
+> - `--num-images`: The number of images to run through the model (default is 500). The total benchmark time will depend on the model size and complexity, as well as the device performance. Too many images may lead to an out-of-memory error, while too few images may lead to less accurate results. Adjust this parameter based on your specific situation and requirements.
 
 > [!IMPORTANT]
 > **Device Connection Requirements for RVC4**: The device must be connected and accessible either using the [Android Debug Bridge (ADB)](https://developer.android.com/tools/adb) or via SSH for the benchmarking to work in the following cases:

--- a/README.md
+++ b/README.md
@@ -634,7 +634,7 @@ kptionally saves the results to a `.csv` file.
 > - **RVC2**: `--model-path` can be a local `.blob`, an NN Archive (`.tar.xz`), or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
 > - **RVC4** with `--dai-benchmark` (default): `--model-path` can be an NN Archive (`.tar.xz`) or a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai).
 > - **RVC4** with `--no-dai-benchmark`: `--model-path` can be an NN Archive (`.tar.xz`), a model slug from [Luxonis HubAI](https://hub.luxonis.com/ai) or a `.dlc` file.
->   In the case of a `.dlc` file, the tool `snpe-dlc-info` must be accessible on the device.
+>   In the case of a `.dlc` file, the tool `snpe-dlc-info` must be available in `PATH` either on the host machine or on the device.
 >
 > To access models from different teams in Luxonis HubAI, remember to update the `HUBAI_API_KEY` environment variable accordingly when using a model slug as an input.
 

--- a/README.md
+++ b/README.md
@@ -617,7 +617,9 @@ kptionally saves the results to a `.csv` file.
 > `depthai` backend (default):
 >
 > - `--benchmark-time`: The duration of the benchmark in seconds (default is 20 seconds).
->   `SNPE` backend (only **RVC4** with `--no-dai-benchmark`):
+>
+> `SNPE` backend (only **RVC4** with `--no-dai-benchmark`):
+>
 > - `--num-images`: The number of images to run through the model (default is 500). The total benchmark time will depend on the model size and complexity, as well as the device performance. Too many images may lead to an out-of-memory error, while too few images may lead to less accurate results. Adjust this parameter based on your specific situation and requirements.
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -611,17 +611,6 @@ modelconverter benchmark rvc4 --model-path <path_to_model.tar.xz>
 The command prints a table with the benchmark results to the console and
 kptionally saves the results to a `.csv` file.
 
-> [!NOTE]
-> **Duration Control**:
-> There are two ways how to specify the duration of the benchmark:
-> `depthai` backend (default):
->
-> - `--benchmark-time`: The duration of the benchmark in seconds (default is 20 seconds).
->
-> `SNPE` backend (only **RVC4** with `--no-dai-benchmark`):
->
-> - `--num-images`: The number of images to run through the model (default is 500). The total benchmark time will depend on the model size and complexity, as well as the device performance. Too many images may lead to an out-of-memory error, while too few images may lead to less accurate results. Adjust this parameter based on your specific situation and requirements.
-
 > [!IMPORTANT]
 > **Device Connection Requirements for RVC4**: The device must be connected and accessible either using the [Android Debug Bridge (ADB)](https://developer.android.com/tools/adb) or via SSH for the benchmarking to work in the following cases:
 >
@@ -629,6 +618,18 @@ kptionally saves the results to a `.csv` file.
 > - When benchmarking is conducted using the SNPE tools (with `--no-dai-benchmark`; default is `--dai-benchmark`)
 >
 > The tool can find the correct device automatically but you can also specify it with the `--device-id` flag.
+
+> [!NOTE]
+> **Duration Control**:
+> There are two ways how to specify the duration of the benchmark:
+>
+> `depthai` backend (default):
+>
+> - `--benchmark-time`: The duration of the benchmark in seconds (default is 20 seconds).
+>
+> `SNPE` backend (only **RVC4** with `--no-dai-benchmark`):
+>
+> - `--num-images`: The number of images to run through the model (default is 500). The total benchmark time will depend on the model size and complexity, as well as the device performance. Too many images may lead to an out-of-memory error, while too few images may lead to less accurate results. Adjust this parameter based on your specific situation and requirements.
 
 > [!NOTE]
 > Benchmark input support depends on the target and backend:

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -330,7 +330,7 @@ def benchmark(
         Parameter(group="RVC4"),
     ] = "balanced",
     runtime: Annotated[Literal["dsp", "cpu"], Parameter(group="RVC4")] = "dsp",
-    num_images: Annotated[int, Parameter(group="RVC4")] = 5000,
+    num_images: Annotated[int, Parameter(group="RVC4")] = 500,
     device_ip: Annotated[str | None, Parameter(group="RVC4")] = None,
     device_id: Annotated[str | None, Parameter(group="RVC4")] = None,
     dai_benchmark: Annotated[bool, Parameter(group="RVC4")] = True,

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -330,7 +330,7 @@ def benchmark(
         Parameter(group="RVC4"),
     ] = "balanced",
     runtime: Annotated[Literal["dsp", "cpu"], Parameter(group="RVC4")] = "dsp",
-    num_images: Annotated[int, Parameter(group="RVC4")] = 1000,
+    num_images: Annotated[int, Parameter(group="RVC4")] = 1_000_000,
     device_ip: Annotated[str | None, Parameter(group="RVC4")] = None,
     device_id: Annotated[str | None, Parameter(group="RVC4")] = None,
     dai_benchmark: Annotated[bool, Parameter(group="RVC4")] = True,
@@ -366,7 +366,7 @@ def benchmark(
     runtime : str
         The SNPE runtime to use for inference (dsp or cpu).
     num_images : int
-        The number of images to use for inference.
+        The number of images to use for inference. Only relevant for SNPE backend.
     device_ip : str | None
         IP address of the device to run the benchmark on. Interchangeable with device_id. If neither is given, DAI selects the default device. If both are given, device_id takes precedence.
     device_id : str | None

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -309,6 +309,7 @@ def benchmark(
     model_path: str,
     full: bool = False,
     save: bool = False,
+    repetitions: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 10,
     benchmark_time: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 20,
     num_threads: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 2,
     num_messages: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 50,
@@ -348,8 +349,10 @@ def benchmark(
     save : bool
         If ``True``, saves the benchmark results to a file.
 
+    repetitions : int
+        The number of repetitions to perform. Only relevant for DAI benchmark.
     benchmark_time : int | None
-        The duration in seconds for time-based benchmarking.
+        The duration in seconds for time-based benchmarking (overrides repetitions).
     num_threads : int
         The number of threads to use for inference. Only relevant for DAI benchmark.
     num_messages : int
@@ -376,6 +379,7 @@ def benchmark(
 
     if target in {Target.RVC2, Target.RVC4}:
         kwargs = {
+            "repetitions": repetitions,
             "benchmark_time": benchmark_time,
             "num_threads": num_threads,
             "num_messages": num_messages,

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -309,7 +309,6 @@ def benchmark(
     model_path: str,
     full: bool = False,
     save: bool = False,
-    repetitions: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 10,
     benchmark_time: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 20,
     num_threads: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 2,
     num_messages: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 50,
@@ -349,10 +348,8 @@ def benchmark(
     save : bool
         If ``True``, saves the benchmark results to a file.
 
-    repetitions : int
-        The number of repetitions to perform. Only relevant for DAI benchmark.
     benchmark_time : int | None
-        The duration in seconds for time-based benchmarking (overrides repetitions).
+        The duration in seconds for time-based benchmarking.
     num_threads : int
         The number of threads to use for inference. Only relevant for DAI benchmark.
     num_messages : int
@@ -379,7 +376,6 @@ def benchmark(
 
     if target in {Target.RVC2, Target.RVC4}:
         kwargs = {
-            "repetitions": repetitions,
             "benchmark_time": benchmark_time,
             "num_threads": num_threads,
             "num_messages": num_messages,

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -330,7 +330,7 @@ def benchmark(
         Parameter(group="RVC4"),
     ] = "balanced",
     runtime: Annotated[Literal["dsp", "cpu"], Parameter(group="RVC4")] = "dsp",
-    num_images: Annotated[int, Parameter(group="RVC4")] = 1_000_000,
+    num_images: Annotated[int, Parameter(group="RVC4")] = 5000,
     device_ip: Annotated[str | None, Parameter(group="RVC4")] = None,
     device_id: Annotated[str | None, Parameter(group="RVC4")] = None,
     dai_benchmark: Annotated[bool, Parameter(group="RVC4")] = True,

--- a/modelconverter/packages/base_benchmark.py
+++ b/modelconverter/packages/base_benchmark.py
@@ -84,16 +84,21 @@ class Benchmark(ABC):
             box=box.ROUNDED,
         )
 
-        # HEADER
         header = [*self._base_header(results), *self._extra_header(results)]
-        for field in header:
-            table.add_column(f"[cyan]{field}")
+        result_rows = [
+            [
+                *self._base_row_cells(configuration, result),
+                *self._extra_row_cells(configuration, result),
+            ]
+            for configuration, result in results
+        ]
 
-        # ROWS
-        for configuration, result in results:
-            base_cells = list(self._base_row_cells(configuration, result))
-            extra_cells = list(self._extra_row_cells(configuration, result))
-            table.add_row(*base_cells, *extra_cells)
+        table.add_column("[cyan]metric")
+        for index in range(1, len(result_rows) + 1):
+            table.add_column(f"[cyan]run {index}")
+
+        for field, *cells in zip(header, *result_rows, strict=True):
+            table.add_row(f"[cyan]{field}", *cells)
 
         Console().print(table)
 

--- a/modelconverter/packages/base_benchmark.py
+++ b/modelconverter/packages/base_benchmark.py
@@ -192,10 +192,10 @@ class Benchmark(ABC):
                 for config in self.all_configurations  # add only kwarg keys that are not already there to not overwrite
             ]
 
-        results: list[tuple[Configuration, dict[str, Any]]] = [
-            (configuration, self.benchmark(configuration))
-            for configuration in configurations
-        ]
+        results = []
+        for configuration in configurations:
+            logger.info(f"Running with configuration: {configuration}")
+            results.append((configuration, self.benchmark(configuration)))
 
         # Clean up configuration keys: keep either benchmark_time or repetitions
         for configuration, _ in results:

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -1,6 +1,7 @@
 import io
 import json
 import re
+import shlex
 import shutil
 import tempfile
 from collections.abc import Iterable
@@ -148,39 +149,76 @@ class RVC4Benchmark(Benchmark):
             raise ValueError("num_images must be at least 1.")
 
         inputs_dir = f"/data/modelconverter/{self.model_name}/inputs"
+        input_list_path = (
+            f"/data/modelconverter/{self.model_name}/input_list.txt"
+        )
         real_input_count = min(num_images, self.MAX_REAL_SNPE_INPUTS)
 
-        input_list = ""
         self.handler.shell(f"mkdir -p {inputs_dir}")
-        for i in track(range(num_images), description="Preparing inputs"):
-            for spec in input_specs:
-                input_path = f"{inputs_dir}/{spec.name}_{i}.raw"
-                if i < real_input_count:
-                    input_data = self._create_random_input(spec)
-                    with tempfile.NamedTemporaryFile() as f:
-                        input_data.tofile(f)
-                        self.handler.push(f.name, input_path)
-                else:
-                    source_index = i % real_input_count
-                    source_path = (
-                        f"{inputs_dir}/{spec.name}_{source_index}.raw"
-                    )
-                    self.handler.shell(f"ln -f {source_path} {input_path}")
 
-                input_list += f"{spec.name}:={input_path} "
-            input_list += "\n"
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            local_input_list_path = tmp_path / "input_list.txt"
 
-        with tempfile.NamedTemporaryFile(delete=False) as f:
-            f.write(input_list.encode())
-            temp_path = Path(f.name)
+            with local_input_list_path.open("w", encoding="utf-8") as f:
+                for i in track(
+                    range(num_images), description="Preparing inputs"
+                ):
+                    input_paths: list[str] = []
+                    for spec in input_specs:
+                        input_path = f"{inputs_dir}/{spec.name}_{i}.raw"
+                        input_paths.append(f"{spec.name}:={input_path}")
 
-        try:
+                        if i < real_input_count:
+                            input_data = self._create_random_input(spec)
+                            local_input_path = (
+                                tmp_path / f"{spec.name}_{i}.raw"
+                            )
+                            input_data.tofile(local_input_path)
+                            self.handler.push(local_input_path, input_path)
+
+                    f.write(" ".join(input_paths))
+                    f.write(" \n")
+
             self.handler.push(
-                temp_path,
-                f"/data/modelconverter/{self.model_name}/input_list.txt",
+                local_input_list_path,
+                input_list_path,
             )
-        finally:
-            temp_path.unlink(missing_ok=True)
+
+        if num_images > real_input_count and input_specs:
+            self.handler.shell(
+                self._create_raw_input_link_script(
+                    input_specs,
+                    inputs_dir,
+                    real_input_count,
+                    num_images,
+                )
+            )
+
+    @staticmethod
+    def _create_raw_input_link_script(
+        input_specs: list[InputSpec],
+        inputs_dir: str,
+        real_input_count: int,
+        num_images: int,
+    ) -> str:
+        spec_names = " ".join(shlex.quote(spec.name) for spec in input_specs)
+        return "\n".join(
+            [
+                "set -eu",
+                f"inputs_dir={shlex.quote(inputs_dir)}",
+                f"real_input_count={real_input_count}",
+                f"num_images={num_images}",
+                f"for spec_name in {spec_names}; do",
+                '    i="$real_input_count"',
+                '    while [ "$i" -lt "$num_images" ]; do',
+                "        source_index=$((i % real_input_count))",
+                '        ln -f "$inputs_dir/${spec_name}_${source_index}.raw" "$inputs_dir/${spec_name}_${i}.raw"',
+                "        i=$((i + 1))",
+                "    done",
+                "done",
+            ]
+        )
 
     @staticmethod
     def _create_random_input(spec: InputSpec) -> np.ndarray:

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -162,7 +162,9 @@ class RVC4Benchmark(Benchmark):
 
             with local_input_list_path.open("w", encoding="utf-8") as f:
                 for i in track(
-                    range(num_images), description="Preparing inputs"
+                    range(num_images),
+                    description="Preparing inputs",
+                    total=min(num_images, self.MAX_REAL_SNPE_INPUTS),
                 ):
                     input_paths: list[str] = []
                     for spec in input_specs:
@@ -186,6 +188,11 @@ class RVC4Benchmark(Benchmark):
             )
 
         if num_images > real_input_count and input_specs:
+            logger.info(
+                f"Linking additional {num_images - real_input_count} inputs "
+                f"to the first {real_input_count} inputs to avoid filling "
+                "up the device storage."
+            )
             self.handler.shell(
                 self._create_raw_input_link_script(
                     input_specs,

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -206,7 +206,7 @@ class RVC4Benchmark(Benchmark):
             self.handler.shell(
                 self._create_raw_input_link_script(
                     input_specs,
-                    inputs_dir,
+                    str(inputs_dir),
                     real_input_count,
                     num_images,
                 )

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -294,7 +294,12 @@ class RVC4Benchmark(Benchmark):
                 self.monitor.stop()
             if not dai_benchmark:
                 # so we don't delete the wrong directory
-                assert self.model_name
+                # if `model_name` gets unset for any reason
+                if not self.model_name:
+                    raise AssertionError(
+                        "`model_name` is not set, "
+                        "cannot clean up model files on the device."
+                    )
 
                 self.handler.shell(
                     f"rm -rf /data/modelconverter/{self.model_name}"

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -148,17 +148,17 @@ class RVC4Benchmark(Benchmark):
         if num_images < 1:
             raise ValueError("num_images must be at least 1.")
 
-        inputs_dir = f"/data/modelconverter/{self.model_name}/inputs"
-        input_list_path = (
-            f"/data/modelconverter/{self.model_name}/input_list.txt"
-        )
+        model_dir = f"/data/modelconverter/{self.model_name}"
+        inputs_dir = f"{model_dir}/inputs"
         real_input_count = min(num_images, self.MAX_REAL_SNPE_INPUTS)
 
-        self.handler.shell(f"mkdir -p {inputs_dir}")
+        self.handler.shell(f"mkdir -p {model_dir}")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            local_input_list_path = tmp_path / "input_list.txt"
+            local_model_dir = Path(tmp_dir) / self.model_name
+            local_inputs_dir = local_model_dir / "inputs"
+            local_inputs_dir.mkdir(parents=True)
+            local_input_list_path = local_model_dir / "input_list.txt"
 
             with local_input_list_path.open("w", encoding="utf-8") as f:
                 for i in track(
@@ -173,19 +173,15 @@ class RVC4Benchmark(Benchmark):
 
                         if i < real_input_count:
                             input_data = self._create_random_input(spec)
-                            local_input_path = (
-                                tmp_path / f"{spec.name}_{i}.raw"
+                            local_input_path = local_inputs_dir / (
+                                f"{spec.name}_{i}.raw"
                             )
                             input_data.tofile(local_input_path)
-                            self.handler.push(local_input_path, input_path)
 
                     f.write(" ".join(input_paths))
                     f.write(" \n")
 
-            self.handler.push(
-                local_input_list_path,
-                input_list_path,
-            )
+            self.handler.push(local_model_dir, "/data/modelconverter")
 
         if num_images > real_input_count and input_specs:
             logger.info(

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -172,11 +172,15 @@ class RVC4Benchmark(Benchmark):
 
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write(input_list.encode())
+            temp_path = Path(f.name)
 
-        self.handler.push(
-            f.name,
-            f"/data/modelconverter/{self.model_name}/input_list.txt",
-        )
+        try:
+            self.handler.push(
+                temp_path,
+                f"/data/modelconverter/{self.model_name}/input_list.txt",
+            )
+        finally:
+            temp_path.unlink(missing_ok=True)
 
     @staticmethod
     def _create_random_input(spec: InputSpec) -> np.ndarray:

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -369,7 +369,7 @@ class RVC4Benchmark(Benchmark):
             self.monitor.start()
 
         logger.info("Starting SNPE benchmark...")
-        _, stdout, _ = self.handler.shell(
+        retcode, stdout, _ = self.handler.shell(
             # "source /data/modelconverter/source_me.sh && "
             "snpe-parallel-run "
             f"--container /data/modelconverter/{self.model_name}/model.dlc "
@@ -377,8 +377,14 @@ class RVC4Benchmark(Benchmark):
             f"--output_dir /data/modelconverter/{self.model_name}/outputs "
             f"--perf_profile {profile} "
             "--cpu_fallback true "
-            f"--{runtime}"
+            f"--{runtime}",
+            check=False,
         )
+        if retcode == 137:
+            raise RuntimeError(
+                "Benchmark process was killed, likely due to out-of-memory. "
+                "Consider decreasing the number of images (`--num-images`)."
+            )
         pattern = re.compile(r"(\d+\.\d+) infs/sec")
         match = pattern.search(stdout)
         if match is None:

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -161,12 +161,13 @@ class RVC4Benchmark(Benchmark):
                 input_list += f"{spec.name}:=/data/modelconverter/{self.model_name}/inputs/{spec.name}_{i}.raw "
             input_list += "\n"
 
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write(input_list.encode())
-            self.handler.push(
-                f.name,
-                f"/data/modelconverter/{self.model_name}/input_list.txt",
-            )
+
+        self.handler.push(
+            f.name,
+            f"/data/modelconverter/{self.model_name}/input_list.txt",
+        )
 
     @staticmethod
     def _create_random_input(spec: InputSpec) -> np.ndarray:

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -7,6 +7,7 @@ import tempfile
 from collections.abc import Iterable
 from contextlib import suppress
 from pathlib import Path
+from subprocess import CalledProcessError, SubprocessError
 from typing import Any, Final
 
 import depthai as dai
@@ -361,26 +362,34 @@ class RVC4Benchmark(Benchmark):
         )
         self._prepare_raw_inputs(input_specs, num_images)
 
+        logger.info("Starting SNPE benchmark...")
+
         if self.monitor:
             self.monitor.start()
 
-        logger.info("Starting SNPE benchmark...")
-        retcode, stdout, _ = self.handler.shell(
-            # "source /data/modelconverter/source_me.sh && "
-            "snpe-parallel-run "
-            f"--container /data/modelconverter/{self.model_name}/model.dlc "
-            f"--input_list /data/modelconverter/{self.model_name}/input_list.txt "
-            f"--output_dir /data/modelconverter/{self.model_name}/outputs "
-            f"--perf_profile {profile} "
-            "--cpu_fallback true "
-            f"--{runtime}",
-            check=False,
-        )
-        if retcode == 137:
-            raise RuntimeError(
-                "Benchmark process was killed, likely due to out-of-memory. "
-                "Consider decreasing the number of images (`--num-images`)."
+        try:
+            _, stdout, _ = self.handler.shell(
+                "snpe-parallel-run "
+                f"--container /data/modelconverter/{self.model_name}/model.dlc "
+                f"--input_list /data/modelconverter/{self.model_name}/input_list.txt "
+                f"--output_dir /data/modelconverter/{self.model_name}/outputs "
+                f"--perf_profile {profile} "
+                "--cpu_fallback true "
+                f"--{runtime}",
             )
+        except CalledProcessError as e:
+            if e.returncode == 137:
+                raise SubprocessError(
+                    "Benchmark process was killed, likely due to out-of-memory. "
+                    "Consider decreasing the number of images (`--num-images`)."
+                ) from e
+
+            raise SubprocessError(
+                f"Benchmark process failed with return code {e.returncode}.\n"
+                f"stdout:\n{e.stdout}\n"
+                f"stderr:\n{e.stderr}"
+            ) from e
+
         pattern = re.compile(r"(\d+\.\d+) infs/sec")
         match = pattern.search(stdout)
         if match is None:

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -141,6 +141,9 @@ class RVC4Benchmark(Benchmark):
     def _prepare_raw_inputs(
         self, input_specs: list[InputSpec], num_images: int
     ) -> None:
+        logger.info(
+            f"Preparing {num_images} synthetic inputs for benchmarking."
+        )
         input_list = ""
         self.handler.shell(
             f"mkdir -p /data/modelconverter/{self.model_name}/inputs"
@@ -288,6 +291,10 @@ class RVC4Benchmark(Benchmark):
             raise ValueError(
                 "Unsupported model format. Supported formats: .dlc, or HubAI model slug."
             )
+        logger.info(
+            f"Using SNPE profile '{profile}' and runtime '{runtime}' for benchmarking."
+        )
+        logger.info(f"Moving model '{dlc_path.name}' to the device.")
 
         self.handler.shell(f"mkdir -p /data/modelconverter/{self.model_name}")
         self.handler.push(
@@ -295,6 +302,7 @@ class RVC4Benchmark(Benchmark):
         )
         self._prepare_raw_inputs(input_specs, num_images)
 
+        logger.info("Starting SNPE benchmark...")
         _, stdout, _ = self.handler.shell(
             # "source /data/modelconverter/source_me.sh && "
             "snpe-parallel-run "

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -69,7 +69,7 @@ class RVC4Benchmark(Benchmark):
         return {
             "profile": "balanced",
             "runtime": "dsp",
-            "num_images": 1000,
+            "num_images": 500,
             "dai_benchmark": True,
             "repetitions": 10,
             "benchmark_time": 20,

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -320,7 +320,7 @@ class RVC4Benchmark(Benchmark):
                 f"stdout:\n{stdout}"
             )
         fps = float(match.group(1))
-        return {"fps": fps, "latency": None}
+        return {"fps": fps, "latency": "N/A"}
 
     def _benchmark_dai(
         self,
@@ -445,7 +445,7 @@ class RVC4Benchmark(Benchmark):
                     on_tick()
 
             # Currently, the latency measurement is only supported on RVC4 when using ImgFrame as the input to the BenchmarkOut which we don't do here.
-            return {"fps": float(np.mean(fps_list)), "latency": None}
+            return {"fps": float(np.mean(fps_list)), "latency": "N/A"}
 
     def _extra_header(
         self,

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -51,6 +51,8 @@ RUNTIMES: dict[str, str] = {
 
 
 class RVC4Benchmark(Benchmark):
+    MAX_REAL_SNPE_INPUTS = 100
+
     @property
     def default_configuration(self) -> Configuration:
         """
@@ -142,21 +144,30 @@ class RVC4Benchmark(Benchmark):
     def _prepare_raw_inputs(
         self, input_specs: list[InputSpec], num_images: int
     ) -> None:
+        if num_images < 1:
+            raise ValueError("num_images must be at least 1.")
+
+        inputs_dir = f"/data/modelconverter/{self.model_name}/inputs"
+        real_input_count = min(num_images, self.MAX_REAL_SNPE_INPUTS)
+
         input_list = ""
-        self.handler.shell(
-            f"mkdir -p /data/modelconverter/{self.model_name}/inputs"
-        )
+        self.handler.shell(f"mkdir -p {inputs_dir}")
         for i in track(range(num_images), description="Preparing inputs"):
             for spec in input_specs:
-                input_data = self._create_random_input(spec)
-                with tempfile.NamedTemporaryFile() as f:
-                    input_data.tofile(f)
-                    self.handler.push(
-                        f.name,
-                        f"/data/modelconverter/{self.model_name}/inputs/{spec.name}_{i}.raw",
+                input_path = f"{inputs_dir}/{spec.name}_{i}.raw"
+                if i < real_input_count:
+                    input_data = self._create_random_input(spec)
+                    with tempfile.NamedTemporaryFile() as f:
+                        input_data.tofile(f)
+                        self.handler.push(f.name, input_path)
+                else:
+                    source_index = i % real_input_count
+                    source_path = (
+                        f"{inputs_dir}/{spec.name}_{source_index}.raw"
                     )
+                    self.handler.shell(f"ln -f {source_path} {input_path}")
 
-                input_list += f"{spec.name}:=/data/modelconverter/{self.model_name}/inputs/{spec.name}_{i}.raw "
+                input_list += f"{spec.name}:={input_path} "
             input_list += "\n"
 
         with tempfile.NamedTemporaryFile(delete=False) as f:

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -107,18 +107,32 @@ class RVC4Benchmark(Benchmark):
             raise ValueError("Expected .dlc, or .tar.xz model format.")
 
         csv_path = Path("info.csv")
-        subprocess_run(
-            [
-                "snpe-dlc-info",
-                "-i",
-                model_path,
-                "-s",
-                csv_path,
-            ],
-            silent=True,
-        )
-        content = csv_path.read_text()
-        csv_path.unlink()
+        if shutil.which("snpe-dlc-info") is not None:
+            subprocess_run(
+                [
+                    "snpe-dlc-info",
+                    "-i",
+                    model_path,
+                    "-s",
+                    csv_path,
+                ],
+                silent=True,
+            )
+            content = csv_path.read_text()
+            csv_path.unlink()
+        elif self.handler.shell("snpe-dlc-info -h", check=False)[0] == 0:
+            self.handler.shell(f"mkdir -p {self.device_pwd}")
+            self.handler.push(model_path, self.device_pwd / "model.dlc")
+            device_csv_path = self.device_pwd / "info.csv"
+            self.handler.shell(
+                f"snpe-dlc-info -i {self.device_pwd / 'model.dlc'} -s {device_csv_path}",
+            )
+            _, content, _ = self.handler.shell(f"cat {device_csv_path}")
+        else:
+            raise RuntimeError(
+                "Neither local nor remote `snpe-dlc-info` "
+                "command is available to read the DLC input specs."
+            )
 
         start_marker = "Input Name,Dimensions,Type,Encoding Info"
         end_marker = "Output Name,Dimensions,Type,Encoding Info"
@@ -149,11 +163,10 @@ class RVC4Benchmark(Benchmark):
         if num_images < 1:
             raise ValueError("num_images must be at least 1.")
 
-        model_dir = f"/data/modelconverter/{self.model_name}"
-        inputs_dir = f"{model_dir}/inputs"
+        inputs_dir = self.device_pwd / "inputs"
         real_input_count = min(num_images, self.MAX_REAL_SNPE_INPUTS)
 
-        self.handler.shell(f"mkdir -p {model_dir}")
+        self.handler.shell(f"mkdir -p {self.device_pwd}")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             local_model_dir = Path(tmp_dir) / self.model_name
@@ -182,7 +195,7 @@ class RVC4Benchmark(Benchmark):
                     f.write(" ".join(input_paths))
                     f.write(" \n")
 
-            self.handler.push(local_model_dir, "/data/modelconverter")
+            self.handler.push(local_model_dir, self.device_pwd.parent)
 
         if num_images > real_input_count and input_specs:
             logger.info(
@@ -250,6 +263,7 @@ class RVC4Benchmark(Benchmark):
             self.handler = create_handler(device_ip, device_adb_id)
 
         configuration["device_ip"] = device_ip
+        self.device_pwd = Path("/", "data", "modelconverter", self.model_name)
 
         self.monitor = None
         idle_measurements = {}
@@ -298,9 +312,7 @@ class RVC4Benchmark(Benchmark):
                         "cannot clean up model files on the device."
                     )
 
-                self.handler.shell(
-                    f"rm -rf /data/modelconverter/{self.model_name}"
-                )
+                self.handler.shell(f"rm -rf {self.device_pwd}")
 
     def _benchmark_snpe(
         self,
@@ -356,10 +368,8 @@ class RVC4Benchmark(Benchmark):
         )
         logger.info(f"Moving model '{dlc_path.name}' to the device.")
 
-        self.handler.shell(f"mkdir -p /data/modelconverter/{self.model_name}")
-        self.handler.push(
-            str(dlc_path), f"/data/modelconverter/{self.model_name}/model.dlc"
-        )
+        self.handler.shell(f"mkdir -p {self.device_pwd}")
+        self.handler.push(str(dlc_path), f"{self.device_pwd}/model.dlc")
         self._prepare_raw_inputs(input_specs, num_images)
 
         logger.info("Starting SNPE benchmark...")
@@ -370,9 +380,9 @@ class RVC4Benchmark(Benchmark):
         try:
             _, stdout, _ = self.handler.shell(
                 "snpe-parallel-run "
-                f"--container /data/modelconverter/{self.model_name}/model.dlc "
-                f"--input_list /data/modelconverter/{self.model_name}/input_list.txt "
-                f"--output_dir /data/modelconverter/{self.model_name}/outputs "
+                f"--container {self.device_pwd}/model.dlc "
+                f"--input_list {self.device_pwd}/input_list.txt "
+                f"--output_dir {self.device_pwd}/outputs "
                 f"--perf_profile {profile} "
                 "--cpu_fallback true "
                 f"--{runtime}",

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -320,7 +320,7 @@ class RVC4Benchmark(Benchmark):
                 f"stdout:\n{stdout}"
             )
         fps = float(match.group(1))
-        return {"fps": fps, "latency": "N/A"}
+        return {"fps": fps, "latency": None}
 
     def _benchmark_dai(
         self,
@@ -445,12 +445,7 @@ class RVC4Benchmark(Benchmark):
                     on_tick()
 
             # Currently, the latency measurement is only supported on RVC4 when using ImgFrame as the input to the BenchmarkOut which we don't do here.
-            return {
-                "fps": float(np.mean(fps_list)),
-                "latency": float(np.mean(avg_latency_list))
-                if avg_latency_list
-                else "N/A",
-            }
+            return {"fps": float(np.mean(fps_list)), "latency": None}
 
     def _extra_header(
         self,

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -13,6 +13,7 @@ import numpy as np
 import polars as pl
 from depthai import XLinkPlatform
 from loguru import logger
+from rich.progress import track
 
 from modelconverter.packages.base_benchmark import Benchmark, Configuration
 from modelconverter.utils import (
@@ -141,14 +142,11 @@ class RVC4Benchmark(Benchmark):
     def _prepare_raw_inputs(
         self, input_specs: list[InputSpec], num_images: int
     ) -> None:
-        logger.info(
-            f"Preparing {num_images} synthetic inputs for benchmarking."
-        )
         input_list = ""
         self.handler.shell(
             f"mkdir -p /data/modelconverter/{self.model_name}/inputs"
         )
-        for i in range(num_images):
+        for i in track(range(num_images), description="Preparing inputs"):
             for spec in input_specs:
                 input_data = self._create_random_input(spec)
                 with tempfile.NamedTemporaryFile() as f:

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -415,9 +415,9 @@ class RVC4Benchmark(Benchmark):
             input_specs = self._get_dlc_input_specs(resolved_model_path)
         except Exception as e:
             logger.warning(
-                f"Failed to read input specs from the DLC "
-                f"with error: {e}. Reading from the archive."
+                f"Failed to read input specs from the DLC with error: {e}"
             )
+            logger.info("Reading specs from the archive.")
             input_specs = self._get_archive_input_specs(model_archive)
 
         input_data_packet = dai.NNData()

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -199,7 +199,6 @@ class RVC4Benchmark(Benchmark):
         if device_monitor:
             self.monitor = DeviceMonitor(self.handler)
             idle_measurements = self.monitor.get_idle_measurements()
-            self.monitor.start()
 
         try:
             if dai_benchmark:
@@ -301,6 +300,9 @@ class RVC4Benchmark(Benchmark):
         )
         self._prepare_raw_inputs(input_specs, num_images)
 
+        if self.monitor:
+            self.monitor.start()
+
         logger.info("Starting SNPE benchmark...")
         _, stdout, _ = self.handler.shell(
             # "source /data/modelconverter/source_me.sh && "
@@ -390,6 +392,9 @@ class RVC4Benchmark(Benchmark):
         logger.info(
             f"Using {device.getPlatformAsString()} device on IP {device.getDeviceInfo().name}."
         )
+
+        if self.monitor:
+            self.monitor.start()
 
         with dai.Pipeline(device) as pipeline:
             benchmark_out = pipeline.create(dai.node.BenchmarkOut)

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -313,7 +313,7 @@ class RVC4Config(TargetConfig):
             self.snpe_onnx_to_dlc_args.pop(qo_index)
             encodings_json = self.snpe_onnx_to_dlc_args.pop(qo_index)
             with open(encodings_json) as f:
-                self.encodings = Encodings.model_validate_json(json.load(f))
+                self.encodings = Encodings.model_validate_json(f.read())
         return self
 
     @field_validator("encodings", mode="before")

--- a/modelconverter/utils/device_handlers.py
+++ b/modelconverter/utils/device_handlers.py
@@ -14,15 +14,28 @@ class DeviceHandler(ABC):
     over a concrete transport such as SSH or ADB.
     """
 
+    def __init__(self, silent: bool = True) -> None:
+        """Initialize the device handler.
+
+        @param silent: If C{True}, suppress command logging by default.
+        @type silent: bool
+        """
+        self.silent = silent
+
     @abstractmethod
-    def shell(self, cmd: str, *, check: bool = True) -> tuple[int, str, str]:
+    def shell(
+        self, cmd: str, *, check: bool = True, silent: bool | None = None
+    ) -> tuple[int, str, str]:
         """Execute a shell command on the target device.
 
-        @param cmd: Shell command to execute on the device.
         @type cmd: str
+        @param cmd: Shell command to execute on the device.
+        @type check: bool
         @param check: If C{True}, propagate subprocess failures as
             exceptions.
-        @type check: bool
+        @type silent: bool | None
+        @param silent: If C{True}, suppress command logging. If C{None},
+            use the default logging behavior of the handler.
         @return: A tuple containing return code, stdout, and stderr.
         @rtype: tuple[int, str, str]
         """
@@ -111,56 +124,32 @@ class SSHHandler(DeviceHandler):
     """Device handler implementation based on SSH and SCP."""
 
     def __init__(self, ip: str, silent: bool = True) -> None:
-        """Initialize the SSH handler.
+        """Initialize an SSH handler for the target device.
 
         @param ip: Target device IP address.
         @type ip: str
         @param silent: If C{True}, suppress command logging.
         @type silent: bool
         """
+        super().__init__(silent)
         self._address = f"root@{ip}"
-        self.silent = silent
 
     @override
-    def shell(self, cmd: str, *, check: bool = True) -> tuple[int, str, str]:
-        """Execute a shell command on the remote device over SSH.
-
-        @param cmd: Shell command to execute remotely.
-        @type cmd: str
-        @param check: If C{True}, propagate subprocess failures as
-            exceptions.
-        @type check: bool
-        @return: A tuple containing return code, stdout, and stderr.
-        @rtype: tuple[int, str, str] @raises
-            subprocess.CalledProcessError: If C{check} is enabled and
-            the SSH command exits with a non-zero status.
-        """
+    def shell(
+        self, cmd: str, *, check: bool = True, silent: bool | None = None
+    ) -> tuple[int, str, str]:
         return self.run(
             "ssh",
             self._address,
             cmd,
             check=check,
-            silent=self.silent,
+            silent=silent or self.silent,
         )
 
     @override
     def pull(
         self, src: PathType, dst: PathType, *, check: bool = True
     ) -> tuple[int, str, str]:
-        """Copy a file or directory from the remote device using SCP.
-
-        @param src: Source path on the remote device.
-        @type src: PathType
-        @param dst: Destination path on the local machine.
-        @type dst: PathType
-        @param check: If C{True}, propagate subprocess failures as
-            exceptions.
-        @type check: bool
-        @return: A tuple containing return code, stdout, and stderr.
-        @rtype: tuple[int, str, str] @raises
-            subprocess.CalledProcessError: If C{check} is enabled and
-            the SCP command exits with a non-zero status.
-        """
         return self.run(
             "scp",
             f"{self._address}:{src}",
@@ -174,20 +163,6 @@ class SSHHandler(DeviceHandler):
     def push(
         self, src: PathType, dst: PathType, *, check: bool = True
     ) -> tuple[int, str, str]:
-        """Copy a file or directory to the remote device using SCP.
-
-        @param src: Source path on the local machine.
-        @type src: PathType
-        @param dst: Destination path on the remote device.
-        @type dst: PathType
-        @param check: If C{True}, propagate subprocess failures as
-            exceptions.
-        @type check: bool
-        @return: A tuple containing return code, stdout, and stderr.
-        @rtype: tuple[int, str, str] @raises
-            subprocess.CalledProcessError: If C{check} is enabled and
-            the SCP command exits with a non-zero status.
-        """
         return self.run(
             "scp",
             src,
@@ -204,7 +179,7 @@ class AdbHandler(DeviceHandler):
     def __init__(
         self, device_id: str | None = None, silent: bool = True
     ) -> None:
-        """Initialize the ADB handler.
+        """Initialize an ADB handler for the target device.
 
         If no device ID is provided, the first connected device is
         selected.
@@ -217,30 +192,12 @@ class AdbHandler(DeviceHandler):
             connected device is available.
         @raises ValueError: If the specified device is not connected.
         """
+        super().__init__(silent)
         device_id = self._check_adb_connection(device_id)
         self._device_args = ["-s", device_id] if device_id else []
-        self.silent = silent
 
     @override
     def run(self, *args, check: bool = True, **kwargs) -> tuple[int, str, str]:
-        """Run an ADB command after requesting root access.
-
-        The method first invokes C{adb root} for the selected device and
-        then executes the requested ADB subcommand.
-
-        @param args: ADB subcommand arguments.
-        @type args: tuple
-        @param check: If C{True}, propagate subprocess failures as
-            exceptions.
-        @type check: bool
-        @param kwargs: Additional keyword arguments forwarded to the
-            base implementation.
-        @type kwargs: dict
-        @return: A tuple containing return code, stdout, and stderr.
-        @rtype: tuple[int, str, str] @raises
-            subprocess.CalledProcessError: If C{check} is enabled and
-            either C{adb root} or the requested ADB command fails.
-        """
         subprocess.run(
             ["adb", *map(str, self._device_args), "root"],
             capture_output=True,
@@ -251,59 +208,23 @@ class AdbHandler(DeviceHandler):
         )
 
     @override
-    def shell(self, cmd: str, *, check: bool = True) -> tuple[int, str, str]:
-        """Execute a shell command on the ADB-connected device.
-
-        @param cmd: Shell command to execute on the device.
-        @type cmd: str
-        @param check: If C{True}, propagate subprocess failures as
-            exceptions.
-        @type check: bool
-        @return: A tuple containing return code, stdout, and stderr.
-        @rtype: tuple[int, str, str] @raises
-            subprocess.CalledProcessError: If C{check} is enabled and
-            the ADB shell command exits with a non-zero status.
-        """
-        return self.run("shell", cmd, check=check)
+    def shell(
+        self, cmd: str, *, check: bool = True, silent: bool | None = None
+    ) -> tuple[int, str, str]:
+        return self.run(
+            "shell", cmd, check=check, silent=silent or self.silent
+        )
 
     @override
     def pull(
         self, src: PathType, dst: PathType, *, check: bool = True
     ) -> tuple[int, str, str]:
-        """Copy a file or directory from the device using ADB.
-
-        @param src: Source path on the device.
-        @type src: PathType
-        @param dst: Destination path on the local machine.
-        @type dst: PathType
-        @param check: If C{True}, propagate subprocess failures as
-            exceptions.
-        @type check: bool
-        @return: A tuple containing return code, stdout, and stderr.
-        @rtype: tuple[int, str, str] @raises
-            subprocess.CalledProcessError: If C{check} is enabled and
-            the ADB pull command exits with a non-zero status.
-        """
         return self.run("pull", src, dst, check=check)
 
     @override
     def push(
         self, src: PathType, dst: PathType, check: bool = True
     ) -> tuple[int, str, str]:
-        """Copy a file or directory to the device using ADB.
-
-        @param src: Source path on the local machine.
-        @type src: PathType
-        @param dst: Destination path on the device.
-        @type dst: PathType
-        @param check: If C{True}, propagate subprocess failures as
-            exceptions.
-        @type check: bool
-        @return: A tuple containing return code, stdout, and stderr.
-        @rtype: tuple[int, str, str] @raises
-            subprocess.CalledProcessError: If C{check} is enabled and
-            the ADB push command exits with a non-zero status.
-        """
         return self.run("push", src, dst, check=check)
 
     def _check_adb_connection(self, device_id: str | None) -> str:

--- a/modelconverter/utils/device_handlers.py
+++ b/modelconverter/utils/device_handlers.py
@@ -6,8 +6,6 @@ from loguru import logger
 from luxonis_ml.typing import PathType
 from typing_extensions import override
 
-from modelconverter.utils.subprocess import SubprocessHandle
-
 
 class DeviceHandler(ABC):
     """Abstract interface for communicating with a device.
@@ -93,10 +91,12 @@ class DeviceHandler(ABC):
         args = list(map(str, args))
         if not silent:
             logger.info(f"{' '.join(args)}")
-        with SubprocessHandle(args, silent=silent) as handle:
-            handle.wait()
-        result = handle.result()
-
+        result = subprocess.run(
+            args,
+            **kwargs,
+            capture_output=True,
+            check=check,
+        )
         stdout = result.stdout
         stderr = result.stderr
         assert result.returncode is not None

--- a/modelconverter/utils/device_handlers.py
+++ b/modelconverter/utils/device_handlers.py
@@ -143,7 +143,7 @@ class SSHHandler(DeviceHandler):
             self._address,
             cmd,
             check=check,
-            silent=silent or self.silent,
+            silent=silent if silent is not None else self.silent,
         )
 
     @override
@@ -212,7 +212,10 @@ class AdbHandler(DeviceHandler):
         self, cmd: str, *, check: bool = True, silent: bool | None = None
     ) -> tuple[int, str, str]:
         return self.run(
-            "shell", cmd, check=check, silent=silent or self.silent
+            "shell",
+            cmd,
+            check=check,
+            silent=silent if silent is not None else self.silent,
         )
 
     @override

--- a/modelconverter/utils/device_handlers.py
+++ b/modelconverter/utils/device_handlers.py
@@ -6,6 +6,8 @@ from loguru import logger
 from luxonis_ml.typing import PathType
 from typing_extensions import override
 
+from modelconverter.utils.subprocess import SubprocessHandle
+
 
 class DeviceHandler(ABC):
     """Abstract interface for communicating with a device.
@@ -91,12 +93,10 @@ class DeviceHandler(ABC):
         args = list(map(str, args))
         if not silent:
             logger.info(f"{' '.join(args)}")
-        result = subprocess.run(
-            args,
-            **kwargs,
-            capture_output=True,
-            check=check,
-        )
+        with SubprocessHandle(args, silent=silent) as handle:
+            handle.wait()
+        result = handle.result()
+
         stdout = result.stdout
         stderr = result.stderr
         assert result.returncode is not None

--- a/modelconverter/utils/device_handlers.py
+++ b/modelconverter/utils/device_handlers.py
@@ -226,7 +226,7 @@ class AdbHandler(DeviceHandler):
 
     @override
     def push(
-        self, src: PathType, dst: PathType, check: bool = True
+        self, src: PathType, dst: PathType, *, check: bool = True
     ) -> tuple[int, str, str]:
         return self.run("push", src, dst, check=check)
 

--- a/modelconverter/utils/device_handlers.py
+++ b/modelconverter/utils/device_handlers.py
@@ -152,8 +152,8 @@ class SSHHandler(DeviceHandler):
     ) -> tuple[int, str, str]:
         return self.run(
             "scp",
-            f"{self._address}:{src}",
             "-r",
+            f"{self._address}:{src}",
             dst,
             check=check,
             silent=self.silent,
@@ -165,9 +165,9 @@ class SSHHandler(DeviceHandler):
     ) -> tuple[int, str, str]:
         return self.run(
             "scp",
+            "-r",
             src,
             f"{self._address}:{dst}",
-            "-r",
             check=check,
             silent=self.silent,
         )


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixed various issues with RVC4 benchmarking on SNPE backend.
 
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Fixed using an empty input list causing Segmentation fault
- Added more logging for the SNPE benchmark
- Sped up the preparation of raw data
  - All files are pushed at once 
  - Only 100 files are created, the rest are hard links to prevent the device from running out of memory (the raw data can be pretty large)
  - Decreased the default number of images to 500 to lower the chance of OOM on the default settings 
- Postponed the start of device monitoring so it does not run during data preparation 
- Results table is now rendered vertically instead of horizontally
- Possible OOM memory errors are now detected and the user is advised to decrease the number of images
- Added option to pass `silent` to `DeviceHandler.shell` for easier debugging
- Removed duplicate docs in device handlers (inherited through `@override`)
- Removed latency reporting from `depthai` because reported number is incorrect due to a lack of support
- `snpe-dlc-info` can be either on the device or on the host
- Expanded README

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Faster, bulk staging of benchmark inputs with progress feedback and a cap on generated inputs; safer linking for extras.
  * Prefer local DLC inspection when available, with automatic fallback to remote extraction.
  * Benchmark results table transposed for clearer metric-by-metric view; adjusted image-count defaults.

* **Bug Fixes**
  * Improved benchmark lifecycle and logging; explicit handling for killed runs; dai-benchmark reports latency as "N/A" when appropriate.

* **Documentation**
  * Clarified and reorganized README guidance for configuration, running, and RVC4 usage.

* **Style**
  * Configurable command verbosity to reduce noisy device output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->