### PR TITLE
Support for `onnxslim`

### DIFF
--- a/modelconverter/packages/base_exporter.py
+++ b/modelconverter/packages/base_exporter.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import cv2
 import numpy as np
+import onnx
 from loguru import logger
 
 from modelconverter.utils import (
@@ -43,7 +44,7 @@ class Exporter(ABC):
 
         self.outputs = {out.name: out for out in config.outputs}
         self.keep_intermediate_outputs = config.keep_intermediate_outputs
-        self.disable_onnx_simplification = config.disable_onnx_simplification
+        self.onnx_simplification = config.onnx_simplification
         self.disable_onnx_optimization = config.disable_onnx_optimization
 
         self.model_name = sanitize_net_name(input_model.stem)
@@ -95,7 +96,7 @@ class Exporter(ABC):
         self.input_model = self.intermediate_outputs_dir / sanitized_model_name
 
         if (
-            not self.disable_onnx_simplification
+            self.onnx_simplification
             and self.input_file_type == InputFileType.ONNX
         ):
             self.input_model = self.simplify_onnx()
@@ -122,7 +123,19 @@ class Exporter(ABC):
     def simplify_onnx(self) -> Path:
         logger.info("Simplifying ONNX.")
         try:
-            from onnxsim import simplify
+            if self.onnx_simplification == "onnxsim":
+                from onnxsim import simplify
+
+                logger.info("Using `onnxsim` for simplification.")
+            else:
+                from onnxslim import slim
+
+                logger.info("Using `onnxslim` for simplification.")
+
+                def simplify(model: str) -> tuple[onnx.ModelProto, bool]:
+                    slimmed = slim(onnx.load(model))
+                    return slimmed, bool(slimmed)  # type: ignore
+
         except ImportError:
             logger.warning(
                 "onnxsim not installed, proceeding without simplification."

--- a/modelconverter/packages/base_exporter.py
+++ b/modelconverter/packages/base_exporter.py
@@ -127,7 +127,7 @@ class Exporter(ABC):
                 from onnxsim import simplify
 
                 logger.info("Using `onnxsim` for simplification.")
-            else:
+            elif self.onnx_simplification == "onnxslim":
                 from onnxslim import slim
 
                 logger.info("Using `onnxslim` for simplification.")
@@ -137,9 +137,10 @@ class Exporter(ABC):
                     return slimmed, bool(slimmed)  # type: ignore
 
         except ImportError:
+            backend = self.onnx_simplification
             logger.warning(
-                "onnxsim not installed, proceeding without simplification."
-                "Please install it using `pip install onnxsim`."
+                f"`{backend}` not installed, proceeding without simplification."
+                f"Please install it using `pip install {backend}`."
             )
             return self.input_model
 

--- a/modelconverter/packages/rvc4/exporter.py
+++ b/modelconverter/packages/rvc4/exporter.py
@@ -34,9 +34,6 @@ class RVC4Exporter(Exporter):
     target: Target = Target.RVC4
 
     def __init__(self, config: SingleStageConfig, output_dir: Path):
-        # NOTE: Handled inside `snpe-onnx-to-dlc` command.
-        config.disable_onnx_simplification = True
-
         super().__init__(config=config, output_dir=output_dir)
 
         rvc4_cfg = config.rvc4

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -362,7 +362,7 @@ class SingleStageConfig(BaseModelExtraForbid):
     def validate_onnx_simplification(
         cls, data: dict[str, Any]
     ) -> dict[str, Any]:
-        if data.get("disable_onnx_simplification", False):
+        if data.pop("disable_onnx_simplification", False):
             warnings.warn(
                 "`disable_onnx_simplification` is deprecated. Please use "
                 "`onnx_simplification` set to `False` instead.",

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -363,6 +363,12 @@ class SingleStageConfig(BaseModelExtraForbid):
         cls, data: dict[str, Any]
     ) -> dict[str, Any]:
         if data.pop("disable_onnx_simplification", False):
+            if "onnx_simplification" in data:
+                raise ValueError(
+                    "Cannot specify both `disable_onnx_simplification` "
+                    "and `onnx_simplification`."
+                )
+
             warnings.warn(
                 "`disable_onnx_simplification` is deprecated. Please use "
                 "`onnx_simplification` set to `False` instead.",

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from itertools import chain
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
@@ -345,7 +346,7 @@ class SingleStageConfig(BaseModelExtraForbid):
     outputs: Annotated[list[OutputConfig], Field(min_length=1)] = []
 
     keep_intermediate_outputs: bool = True
-    disable_onnx_simplification: bool = False
+    onnx_simplification: Literal["onnxsim", "onnxslim", False] = "onnxsim"
     disable_onnx_optimization: bool = False
     output_remote_url: str | None = None
     intermediate_outputs_remote_url: str | None = None
@@ -355,6 +356,21 @@ class SingleStageConfig(BaseModelExtraForbid):
     rvc2: RVC2Config = RVC2Config()
     rvc3: RVC3Config = RVC3Config()
     rvc4: RVC4Config = RVC4Config()
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_onnx_simplification(
+        cls, data: dict[str, Any]
+    ) -> dict[str, Any]:
+        if data.get("disable_onnx_simplification", False):
+            warnings.warn(
+                "`disable_onnx_simplification` is deprecated. Please use "
+                "`onnx_simplification` set to `False` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            data["onnx_simplification"] = False
+        return data
 
     def get_target_config(self, target: Target) -> TargetConfig:
         """Returns the target configuration for the given target."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ luxonis-ml[data,nn-archive,s3,gcs]>=0.8.5
 cyclopts==4.8.0
 onnx==1.21.0
 onnxruntime
+onnxsim~=0.6
+onnxslim~=0.1
 onnxsim
 docker
 keyring

--- a/shared_with_container/configs/defaults.yaml
+++ b/shared_with_container/configs/defaults.yaml
@@ -85,8 +85,10 @@ stages:
     # Keep the intermediate files created during the compilation.
     keep_intermediate_outputs: true
 
-    # Do not run ONNX simplifier on the provided model.
-    disable_onnx_simplification: false
+    # What ONNX simplification method to use.
+    # Options are: onnxsim (default), onnxslim (experimental),
+    # or `False` to disable simplification.
+    onnx_simplification: "onnxsim"
 
     # Do not run ONNX graph optimizations on the provided model.
     disable_onnx_optimization: false

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -93,7 +93,7 @@ DEFAULT_CALIBRATION_CONFIG = {
 
 DEFAULT_GENERAL_CONFIG = {
     "keep_intermediate_outputs": True,
-    "disable_onnx_simplification": False,
+    "onnx_simplification": "onnxsim",
     "disable_onnx_optimization": False,
     "output_remote_url": None,
     "intermediate_outputs_remote_url": None,

--- a/tests/test_utils/test_onnx_compatibility.py
+++ b/tests/test_utils/test_onnx_compatibility.py
@@ -59,6 +59,7 @@ def test_simplify_onnx_falls_back_on_error(
     class DummyExporter:
         input_model = input_path
         _attach_suffix = staticmethod(Exporter._attach_suffix)
+        onnx_simplification = "onnxsim"
 
     assert Exporter.simplify_onnx(DummyExporter()) == input_path
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
`onnxslim` can slightly increase the performance of the model.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Removed option `disable_onnx_simplification`
- Added `onnx_simplification` which can take either `"onnxsim"` (default), `"onnxslim"`, or `False`
  - Setting to `False` equivalent to `disable_onnx_simplification=True` 

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ONNX model simplification now supports selectable backends (default "onnxsim"), an experimental "onnxslim", or disabling simplification.

* **Bug Fixes**
  * Download fallback: when directory checks are forbidden, single-file downloads proceed instead of failing.

* **Chores**
  * Replaced deprecated boolean setting with a new multi-value configuration; legacy setting auto-migrates with a deprecation warning and optional backend packages added.

* **Tests**
  * Updated defaults and tests to cover the new simplification option and the download-fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->