### PR TITLE
Granular ONNX optimizations, deprecated `disable_onnx_optimization`

### DIFF
--- a/modelconverter/packages/base_exporter.py
+++ b/modelconverter/packages/base_exporter.py
@@ -44,7 +44,7 @@ class Exporter(ABC):
         self.outputs = {out.name: out for out in config.outputs}
         self.keep_intermediate_outputs = config.keep_intermediate_outputs
         self.disable_onnx_simplification = config.disable_onnx_simplification
-        self.disable_onnx_optimization = config.disable_onnx_optimization
+        self.onnx_optimizations = config.onnx_optimizations
 
         self.model_name = sanitize_net_name(input_model.stem)
         self.original_model_name = sanitize_net_name(

--- a/modelconverter/packages/rvc2/exporter.py
+++ b/modelconverter/packages/rvc2/exporter.py
@@ -115,7 +115,7 @@ class RVC2Exporter(Exporter):
                 inp.encoding.from_ = Encoding.BGR
                 inp.encoding.to = Encoding.BGR
 
-        if not self.config.disable_onnx_optimization:
+        if not self.onnx_optimizations.all_disabled():
             onnx_modifier = ONNXModifier(
                 model_path=self.input_model,
                 output_path=self._attach_suffix(
@@ -126,7 +126,9 @@ class RVC2Exporter(Exporter):
 
             try:
                 if (
-                    onnx_modifier.modify_onnx()
+                    onnx_modifier.modify_onnx(
+                        **self.onnx_optimizations.model_dump()
+                    )
                     and onnx_modifier.compare_outputs()
                 ):
                     logger.info("ONNX model has been optimized for RVC2.")

--- a/modelconverter/packages/rvc4/exporter.py
+++ b/modelconverter/packages/rvc4/exporter.py
@@ -72,7 +72,7 @@ class RVC4Exporter(Exporter):
                 self.inputs,
             )
 
-            if not config.disable_onnx_optimization:
+            if not self.onnx_optimizations.all_disabled():
                 onnx_modifier = ONNXModifier(
                     model_path=self.input_model,
                     output_path=self._attach_suffix(
@@ -82,7 +82,9 @@ class RVC4Exporter(Exporter):
 
                 try:
                     if (
-                        onnx_modifier.modify_onnx()
+                        onnx_modifier.modify_onnx(
+                            **self.onnx_optimizations.model_dump()
+                        )
                         and onnx_modifier.compare_outputs()
                     ):
                         logger.info("ONNX model has been optimized for RVC4.")

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from itertools import chain
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
@@ -399,6 +400,35 @@ class SingleStageConfig(BaseModelExtraForbid):
         if optimizations in {"all", True}:
             data["onnx_optimizations"] = ONNXOptimizationsConfig()
         elif optimizations in {"none", None, False}:
+            data["onnx_optimizations"] = ONNXOptimizationsConfig(
+                fuse_add_mul_to_bn=False,
+                fuse_comb_add_mul_to_conv=False,
+                fuse_single_add_mul_to_conv=False,
+                fuse_split_concat_to_conv=False,
+                substitute_sub_with_add=False,
+                substitute_div_with_mul=False,
+            )
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_disable_onnx_optimizations(
+        cls, data: dict[str, Any]
+    ) -> dict[str, Any]:
+        if "disable_onnx_optimizations" not in data:
+            return data
+        if data.pop("disable_onnx_optimizations", False):
+            warnings.warn(
+                "`disable_onnx_optimizations` is deprecated. Please use "
+                "`onnx_optimizations: false` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if "onnx_optimizations" in data:
+                raise ValueError(
+                    "Cannot specify both `disable_onnx_optimizations` and "
+                    "`onnx_optimizations` at the same time."
+                )
             data["onnx_optimizations"] = ONNXOptimizationsConfig(
                 fuse_add_mul_to_bn=False,
                 fuse_comb_add_mul_to_conv=False,

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -397,9 +397,9 @@ class SingleStageConfig(BaseModelExtraForbid):
         if "onnx_optimizations" not in data:
             return data
         optimizations = data["onnx_optimizations"]
-        if optimizations in {"all", True}:
+        if optimizations in ["all", True]:
             data["onnx_optimizations"] = ONNXOptimizationsConfig()
-        elif optimizations in {"none", None, False}:
+        elif optimizations in ["none", None, False]:
             data["onnx_optimizations"] = ONNXOptimizationsConfig(
                 fuse_add_mul_to_bn=False,
                 fuse_comb_add_mul_to_conv=False,

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -336,6 +336,27 @@ class RVC4Config(TargetConfig):
         return self
 
 
+class ONNXOptimizationsConfig(BaseModelExtraForbid):
+    fuse_add_mul_to_bn: bool = True
+    fuse_comb_add_mul_to_conv: bool = True
+    fuse_single_add_mul_to_conv: bool = True
+    fuse_split_concat_to_conv: bool = True
+    substitute_sub_with_add: bool = True
+    substitute_div_with_mul: bool = True
+
+    def all_disabled(self) -> bool:
+        return not any(
+            [
+                self.fuse_add_mul_to_bn,
+                self.fuse_comb_add_mul_to_conv,
+                self.fuse_single_add_mul_to_conv,
+                self.fuse_split_concat_to_conv,
+                self.substitute_sub_with_add,
+                self.substitute_div_with_mul,
+            ]
+        )
+
+
 class SingleStageConfig(BaseModelExtraForbid):
     input_model: Path
     input_bin: Path | None = None
@@ -346,7 +367,7 @@ class SingleStageConfig(BaseModelExtraForbid):
 
     keep_intermediate_outputs: bool = True
     disable_onnx_simplification: bool = False
-    disable_onnx_optimization: bool = False
+    onnx_optimizations: ONNXOptimizationsConfig = ONNXOptimizationsConfig()
     output_remote_url: str | None = None
     intermediate_outputs_remote_url: str | None = None
     put_file_plugin: str | None = None
@@ -366,6 +387,27 @@ class SingleStageConfig(BaseModelExtraForbid):
             return self.rvc3
         if target == Target.RVC4:
             return self.rvc4
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_onnx_optimizations(
+        cls, data: dict[str, Any]
+    ) -> dict[str, Any]:
+        if "onnx_optimizations" not in data:
+            return data
+        optimizations = data["onnx_optimizations"]
+        if optimizations in {"all", True}:
+            data["onnx_optimizations"] = ONNXOptimizationsConfig()
+        elif optimizations in {"none", None, False}:
+            data["onnx_optimizations"] = ONNXOptimizationsConfig(
+                fuse_add_mul_to_bn=False,
+                fuse_comb_add_mul_to_conv=False,
+                fuse_single_add_mul_to_conv=False,
+                fuse_split_concat_to_conv=False,
+                substitute_sub_with_add=False,
+                substitute_div_with_mul=False,
+            )
+        return data
 
     @model_validator(mode="before")
     @classmethod

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -345,7 +345,7 @@ class ONNXModifier:
         try:
             self.onnx_model, _ = simplify(
                 self.model_path.as_posix(),
-                perform_optimization=True and not self.skip_optimization,
+                perform_optimization=not self.skip_optimization,
                 skip_constant_folding=self.skip_constant_folding,
             )
         except Exception as e:
@@ -641,7 +641,9 @@ class ONNXModifier:
                 # Skip optimization for nodes followed by Erf operations due to conversion compatibility issues with SNPE 2.32.6.
                 if any(n.op == "Erf" for n in next_nodes):
                     logger.warning(
-                        f"Skipping `substitute_node_by_type ({source_node} -> {target_node})` optimization for node {node.name} with op {node.op} because it is followed by an Erf node."
+                        f"Skipping `substitute_node_by_type ({source_node} -> {target_node})` "
+                        f"optimization for node '{node.name}' with op '{node.op}' "
+                        "because it is followed by an 'Erf' node."
                     )
                     continue
                 constant = self.get_constant_value(node, constant_map)
@@ -1314,7 +1316,15 @@ class ONNXModifier:
             )
             self.revert_changes()
 
-    def modify_onnx(self) -> bool:
+    def modify_onnx(
+        self,
+        substitute_sub_with_add: bool = True,
+        substitute_div_with_mul: bool = True,
+        fuse_add_mul_to_bn: bool = True,
+        fuse_comb_add_mul_to_conv: bool = True,
+        fuse_single_add_mul_to_conv: bool = True,
+        fuse_split_concat_to_conv: bool = True,
+    ) -> bool:
         """Modify the ONNX model by applying a series of optimizations.
 
         @param passes: List of optimization passes to apply to the ONNX
@@ -1327,39 +1337,40 @@ class ONNXModifier:
             )
             return False
 
-        optimization_steps = [
-            (
+        if substitute_div_with_mul:
+            self.apply_optimization_step(
                 "Substitute Div -> Mul nodes",
                 lambda: self.substitute_node_by_type(
                     source_node="Div", target_node="Mul"
                 ),
-            ),
-            (
+            )
+        if substitute_sub_with_add:
+            self.apply_optimization_step(
                 "Substitute Sub -> Add nodes",
                 lambda: self.substitute_node_by_type(
                     source_node="Sub", target_node="Add"
                 ),
-            ),
-            (
+            )
+        if fuse_add_mul_to_bn:
+            self.apply_optimization_step(
                 "Fuse Add and Mul nodes to BatchNormalization nodes",
                 self.fuse_add_mul_to_bn,
-            ),
-            (
+            )
+        if fuse_comb_add_mul_to_conv:
+            self.apply_optimization_step(
                 "Fuse Add and Mul nodes to Conv nodes (combined)",
                 self.fuse_comb_add_mul_to_conv,
-            ),
-            (
+            )
+        if fuse_single_add_mul_to_conv:
+            self.apply_optimization_step(
                 "Fuse Add and Mul nodes to Conv nodes (single)",
                 self.fuse_single_add_mul_to_conv,
-            ),
-            (
+            )
+        if fuse_split_concat_to_conv:
+            self.apply_optimization_step(
                 "Fuse Split and Concat nodes to Conv nodes",
                 self.fuse_split_concat_to_conv,
-            ),
-        ]
-
-        for step_name, optimization_func in optimization_steps:
-            self.apply_optimization_step(step_name, optimization_func)
+            )
 
         try:
             self.export_onnx()

--- a/shared_with_container/configs/defaults.yaml
+++ b/shared_with_container/configs/defaults.yaml
@@ -88,8 +88,41 @@ stages:
     # Do not run ONNX simplifier on the provided model.
     disable_onnx_simplification: false
 
-    # Do not run ONNX graph optimizations on the provided model.
-    disable_onnx_optimization: false
+    # Settings for ONNX optimizations. By default, all optimizations
+    # are enabled. To disable all optimizations at once, set
+    # `onnx_optimizations` to `False` or `None`.
+    onnx_optimizations:
+      # Replace sub with add and neg.
+      substitute_sub_with_add: true
+
+      # Replace div with mul and reciprocal.
+      substitute_div_with_mul: true
+
+      # Fuse Add/Sub and Mul nodes that come immediately after a Conv
+      # node into a BatchNormalization node.
+      # The fusion patterns considered are:
+      # 1. Conv -> Add -> Mul
+      # 2. Conv -> Mul -> Add
+      # 3. Conv -> Mul
+      # 4. Conv -> Add
+      fuse_add_mul_to_bn: true
+
+      # Fuse combinations of Add and Mul nodes preceding a Conv node
+      # directly into the Conv node itself.
+      # The fusion patterns considered are:
+      # 1. Add -> Mul -> Conv
+      # 2. Mul -> Add -> Conv
+      fuse_comb_add_mul_to_conv: true
+
+      # Fuse Add and Mul nodes that precede a Conv node directly into
+      # the Conv node.
+      fuse_single_add_mul_to_conv: true
+
+      # Fuse Split and Concat nodes that come before a Conv node into
+      # the Conv node.
+      # If any intermediate nodes have channel dimensions, the order of
+      # the channels is reversed.
+      fuse_split_concat_to_conv: true
 
     # List of input names with shapes,
     # data types, values for freezing and input modifiers.

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -94,7 +94,14 @@ DEFAULT_CALIBRATION_CONFIG = {
 DEFAULT_GENERAL_CONFIG = {
     "keep_intermediate_outputs": True,
     "disable_onnx_simplification": False,
-    "disable_onnx_optimization": False,
+    "onnx_optimizations": {
+        "fuse_add_mul_to_bn": True,
+        "fuse_comb_add_mul_to_conv": True,
+        "fuse_single_add_mul_to_conv": True,
+        "fuse_split_concat_to_conv": True,
+        "substitute_sub_with_add": True,
+        "substitute_div_with_mul": True,
+    },
     "output_remote_url": None,
     "intermediate_outputs_remote_url": None,
     "put_file_plugin": None,


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Gives the user finer control over what ONNX optimizations will be applied.
Useful for models that fail to convert with the full set of optimizations.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Deprecated `disable_onnx_optimizations`
- New field `onnx_optimizations` 

**`config.yaml`**
```yaml
# Settings for ONNX optimizations. By default, all optimizations
# are enabled. To disable all optimizations at once, set
# `onnx_optimizations` to `False` or `None`.
onnx_optimizations:
  # Replace sub with add and neg.
  substitute_sub_with_add: true

  # Replace div with mul and reciprocal.
  substitute_div_with_mul: true

  # Fuse Add/Sub and Mul nodes that come immediately after a Conv
  # node into a BatchNormalization node.
  # The fusion patterns considered are:
  # 1. Conv -> Add -> Mul
  # 2. Conv -> Mul -> Add
  # 3. Conv -> Mul
  # 4. Conv -> Add
  fuse_add_mul_to_bn: true

  # Fuse combinations of Add and Mul nodes preceding a Conv node
  # directly into the Conv node itself.
  # The fusion patterns considered are:
  # 1. Add -> Mul -> Conv
  # 2. Mul -> Add -> Conv
  fuse_comb_add_mul_to_conv: true

  # Fuse Add and Mul nodes that precede a Conv node directly into
  # the Conv node.
  fuse_single_add_mul_to_conv: true

  # Fuse Split and Concat nodes that come before a Conv node into
  # the Conv node.
  # If any intermediate nodes have channel dimensions, the order of
  # the channels is reversed.
  fuse_split_concat_to_conv: true
```

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * ONNX optimization configuration now offers granular per-pass controls, enabling selective optimization instead of a single on/off toggle.

* **Refactor**
  * Restructured optimization settings for improved flexibility and configuration clarity.

* **Chores**
  * Legacy optimization flag deprecated with automatic migration and warning messages for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->