### PR TITLE
Unified passing of input models

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ modelconverter convert rvc3 --path configs/resnet18.yaml \
 Specify all options via the command line without a config file:
 
 ```bash
-modelconverter convert rvc2 input_model models/yolov6n.onnx \
+modelconverter convert rvc2 --path models/yolov6n.onnx \
                         scale_values "[255,255,255]" \
                         inputs.0.encoding.from RGB \
                         inputs.0.encoding.to BGR \

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -100,7 +100,8 @@ def convert(
     opts: list[str] | None
         A list of optional CLI overrides for the configuration file.
     path: str | None
-        A URL or a path to the configuration file or NN Archive.
+        A URL or a path to the configuration file, NN Archive
+        or a standalone model file.
     output_dir: str | None
         Name of the directory where the exported model will be saved.
     to: Literal["native", "nn_archive"]
@@ -126,6 +127,31 @@ def convert(
     if output_dir is not None:
         output_dir = sanitize_net_name(output_dir)
     t = time.time()
+
+    opts = opts or []
+    if path is not None:
+        suffix = Path(path).suffix
+        if suffix in {".xml", ".bin"} and target not in {
+            Target.RVC2,
+            Target.RVC3,
+        }:
+            raise ValueError(
+                f"OpenVINO IR format is not supported for target {target.name}."
+            )
+        if suffix in {".onnx", ".xml", ".dlc", ".tflite"}:
+            opts = ["input_model", path, *opts]
+            if suffix == ".xml":
+                opts += ["input_bin", str(Path(path).with_suffix(".bin"))]
+            path = None
+        elif suffix == ".bin":
+            opts = [
+                "input_model",
+                str(Path(path).with_suffix(".xml")),
+                "input_bin",
+                path,
+                *opts,
+            ]
+            path = None
 
     with catch_exceptions():
         init_dirs()

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -141,7 +141,11 @@ def convert(
         if suffix in {".onnx", ".xml", ".dlc", ".tflite"}:
             opts = ["input_model", path, *opts]
             if suffix == ".xml":
-                opts += ["input_bin", str(Path(path).with_suffix(".bin"))]
+                opts = [
+                    "input_bin",
+                    str(Path(path).with_suffix(".bin")),
+                    *opts,
+                ]
             path = None
         elif suffix == ".bin":
             opts = [


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Makes the CLI behavior more consistent.
All variants of input models can be now specified using the `--path` argument.
(before only NN Archive and `YAML` files were supported by `--path`).
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Injecting the content of `--path` to `opts` if it is a standalone model.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
