### PR TITLE
Support conversion using AIMET-returned encodings

### DIFF
--- a/modelconverter/packages/base_exporter.py
+++ b/modelconverter/packages/base_exporter.py
@@ -21,7 +21,10 @@ from modelconverter.utils.config import (
     RandomCalibrationConfig,
     SingleStageConfig,
 )
-from modelconverter.utils.onnx_compatibility import save_onnx_model
+from modelconverter.utils.onnx_compatibility import (
+    get_external_data_path,
+    save_onnx_model,
+)
 from modelconverter.utils.subprocess import SubprocessResult
 from modelconverter.utils.types import InputFileType, Target
 
@@ -71,14 +74,15 @@ class Exporter(ABC):
             self.intermediate_outputs_dir / sanitized_model_name,
         )
         shutil.copy(input_model, self.output_dir / sanitized_model_name)
-        if input_model.with_suffix(".onnx_data").exists():
+        external_data_path = get_external_data_path(input_model)
+        if external_data_path is not None:
             shutil.copy(
-                input_model.with_suffix(".onnx_data"),
-                self.intermediate_outputs_dir,
+                external_data_path,
+                self.intermediate_outputs_dir / external_data_path.name,
             )
             shutil.copy(
-                input_model.with_suffix(".onnx_data"),
-                self.output_dir,
+                external_data_path,
+                self.output_dir / external_data_path.name,
             )
         if self.input_file_type == InputFileType.IR:
             assert self.config.input_bin is not None
@@ -165,9 +169,8 @@ class Exporter(ABC):
         save_onnx_model(
             onnx_sim,
             onnx_sim_path,
-            save_as_external_data=self.input_model.with_suffix(
-                ".onnx_data"
-            ).exists(),
+            save_as_external_data=get_external_data_path(self.input_model)
+            is not None,
             location=f"{onnx_sim_path.name}_data",
         )
         return onnx_sim_path

--- a/modelconverter/packages/rvc4/exporter.py
+++ b/modelconverter/packages/rvc4/exporter.py
@@ -279,6 +279,17 @@ class RVC4Exporter(Exporter):
             encodings_dict = self.encodings.model_dump(
                 mode="json", exclude_none=True
             )
+            # DAI does not support custom TF8 encodings on exposed model IO.
+            # Keep AIMET's internal tensor encodings, but normalize the
+            # inputs/outputs to the default int8 IO.
+            for name in (
+                list(self.inputs.keys())
+                + list(self.outputs.keys())
+                + self.extra_quant_tensors
+            ):
+                encodings_dict["activation_encodings"][name] = [
+                    {"bitwidth": 8, "dtype": "int"}
+                ]
         else:
             encodings_dict = {
                 "activation_encodings": {},

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -1,4 +1,3 @@
-import json
 import warnings
 from itertools import chain
 from pathlib import Path
@@ -20,6 +19,7 @@ from typing_extensions import Self
 
 from modelconverter.utils.calibration_data import download_calibration_data
 from modelconverter.utils.constants import MISC_DIR, MODELS_DIR
+from modelconverter.utils.encodings import parse_encodings
 from modelconverter.utils.filesystem_utils import resolve_path
 from modelconverter.utils.layout import make_default_layout
 from modelconverter.utils.metadata import Metadata, get_metadata
@@ -303,129 +303,6 @@ class QuantizationOverridesItem(BaseModelExtraForbid):
         if value is None:
             return None
         return str(value)
-
-
-ALLOWED_ENCODING_KEYS = {
-    "bitwidth",
-    "is_symmetric",
-    "dtype",
-    "max",
-    "min",
-    "offset",
-    "scale",
-}
-
-
-def _scalarize_encoding_value(value: Any) -> Any:
-    if isinstance(value, list) and len(value) == 1:
-        return value[0]
-    return value
-
-
-def _normalize_encoding_item(
-    item: dict[str, Any],
-) -> dict[str, Any]:
-    normalized = dict(item)
-
-    if "bitwidth" not in normalized and "bw" in normalized:
-        normalized["bitwidth"] = normalized["bw"]
-
-    if "is_symmetric" not in normalized and "is_sym" in normalized:
-        normalized["is_symmetric"] = normalized["is_sym"]
-
-    dtype = normalized.get("dtype")
-    if isinstance(dtype, str):
-        normalized["dtype"] = dtype.lower()
-
-    for key in ["scale", "offset", "min", "max"]:
-        if key in normalized:
-            normalized[key] = _scalarize_encoding_value(normalized[key])
-
-    return {
-        key: value
-        for key, value in normalized.items()
-        if key in ALLOWED_ENCODING_KEYS
-    }
-
-
-def _expand_encoding_item(item: dict[str, Any]) -> list[dict[str, Any]]:
-    normalized = _normalize_encoding_item(item)
-    vector_lengths = [
-        len(value)
-        for key, value in normalized.items()
-        if key in {"scale", "offset", "min", "max"} and isinstance(value, list)
-    ]
-    if not vector_lengths:
-        return [normalized]
-
-    size = vector_lengths[0]
-    if any(length != size for length in vector_lengths):
-        raise ValueError("Per-channel encoding fields must have matching lengths.")
-
-    expanded = []
-    for idx in range(size):
-        entry = {}
-        for key, value in normalized.items():
-            entry[key] = value[idx] if isinstance(value, list) else value
-        expanded.append(entry)
-    return expanded
-
-
-def _normalize_encoding_group(
-    entries: Any,
-) -> dict[str, list[dict[str, Any]]]:
-    if isinstance(entries, dict):
-        normalized = {}
-        for name, value in entries.items():
-            values = value if isinstance(value, list) else [value]
-            items = []
-            for item in values:
-                if not isinstance(item, dict):
-                    raise TypeError(
-                        f"Expected dict encoding entry, got {type(item).__name__}."
-                    )
-                items.extend(_expand_encoding_item(item))
-            normalized[name] = items
-        return normalized
-
-    if not isinstance(entries, list):
-        raise TypeError(
-            f"Expected encoding group to be a list or dict, got {type(entries).__name__}."
-        )
-
-    normalized = {}
-    for item in entries:
-        if not isinstance(item, dict):
-            raise TypeError(
-                f"Expected dict encoding entry, got {type(item).__name__}."
-            )
-        name = item.get("name")
-        if not isinstance(name, str) or not name:
-            raise ValueError(f"Missing or invalid tensor name in entry: {item}")
-        normalized.setdefault(name, []).extend(_expand_encoding_item(item))
-    return normalized
-
-
-def parse_encodings(value: Any) -> "Encodings":
-    if isinstance(value, Encodings):
-        return value
-
-    if isinstance(value, str):
-        value = json.loads(value)
-
-    if not isinstance(value, dict):
-        raise TypeError(
-            f"Expected encodings to deserialize to a dict, got {type(value).__name__}."
-        )
-
-    return Encodings(
-        activation_encodings=_normalize_encoding_group(
-            value.get("activation_encodings", {})
-        ),
-        param_encodings=_normalize_encoding_group(
-            value.get("param_encodings", {})
-        ),
-    )
 
 
 class Encodings(BaseModelExtraForbid):

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -349,6 +349,8 @@ class RVC4Config(TargetConfig):
             return None
 
         if isinstance(value, str):
+            if value.lstrip().startswith("{"):
+                return parse_encodings(value)
             value_path = resolve_path(value, MISC_DIR)
             return parse_encodings(value_path.read_text())
 

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -23,7 +23,10 @@ from modelconverter.utils.constants import MISC_DIR, MODELS_DIR
 from modelconverter.utils.filesystem_utils import resolve_path
 from modelconverter.utils.layout import make_default_layout
 from modelconverter.utils.metadata import Metadata, get_metadata
-from modelconverter.utils.onnx_compatibility import save_onnx_model
+from modelconverter.utils.onnx_compatibility import (
+    get_external_data_path,
+    save_onnx_model,
+)
 from modelconverter.utils.types import (
     DataType,
     Encoding,
@@ -287,6 +290,129 @@ class QuantizationOverridesItem(BaseModelExtraForbid):
         return str(value)
 
 
+ALLOWED_ENCODING_KEYS = {
+    "bitwidth",
+    "is_symmetric",
+    "dtype",
+    "max",
+    "min",
+    "offset",
+    "scale",
+}
+
+
+def _scalarize_encoding_value(value: Any) -> Any:
+    if isinstance(value, list) and len(value) == 1:
+        return value[0]
+    return value
+
+
+def _normalize_encoding_item(
+    item: dict[str, Any],
+) -> dict[str, Any]:
+    normalized = dict(item)
+
+    if "bitwidth" not in normalized and "bw" in normalized:
+        normalized["bitwidth"] = normalized["bw"]
+
+    if "is_symmetric" not in normalized and "is_sym" in normalized:
+        normalized["is_symmetric"] = normalized["is_sym"]
+
+    dtype = normalized.get("dtype")
+    if isinstance(dtype, str):
+        normalized["dtype"] = dtype.lower()
+
+    for key in ["scale", "offset", "min", "max"]:
+        if key in normalized:
+            normalized[key] = _scalarize_encoding_value(normalized[key])
+
+    return {
+        key: value
+        for key, value in normalized.items()
+        if key in ALLOWED_ENCODING_KEYS
+    }
+
+
+def _expand_encoding_item(item: dict[str, Any]) -> list[dict[str, Any]]:
+    normalized = _normalize_encoding_item(item)
+    vector_lengths = [
+        len(value)
+        for key, value in normalized.items()
+        if key in {"scale", "offset", "min", "max"} and isinstance(value, list)
+    ]
+    if not vector_lengths:
+        return [normalized]
+
+    size = vector_lengths[0]
+    if any(length != size for length in vector_lengths):
+        raise ValueError("Per-channel encoding fields must have matching lengths.")
+
+    expanded = []
+    for idx in range(size):
+        entry = {}
+        for key, value in normalized.items():
+            entry[key] = value[idx] if isinstance(value, list) else value
+        expanded.append(entry)
+    return expanded
+
+
+def _normalize_encoding_group(
+    entries: Any,
+) -> dict[str, list[dict[str, Any]]]:
+    if isinstance(entries, dict):
+        normalized = {}
+        for name, value in entries.items():
+            values = value if isinstance(value, list) else [value]
+            items = []
+            for item in values:
+                if not isinstance(item, dict):
+                    raise TypeError(
+                        f"Expected dict encoding entry, got {type(item).__name__}."
+                    )
+                items.extend(_expand_encoding_item(item))
+            normalized[name] = items
+        return normalized
+
+    if not isinstance(entries, list):
+        raise TypeError(
+            f"Expected encoding group to be a list or dict, got {type(entries).__name__}."
+        )
+
+    normalized = {}
+    for item in entries:
+        if not isinstance(item, dict):
+            raise TypeError(
+                f"Expected dict encoding entry, got {type(item).__name__}."
+            )
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"Missing or invalid tensor name in entry: {item}")
+        normalized.setdefault(name, []).extend(_expand_encoding_item(item))
+    return normalized
+
+
+def parse_encodings(value: Any) -> "Encodings":
+    if isinstance(value, Encodings):
+        return value
+
+    if isinstance(value, str):
+        value = json.loads(value)
+
+    if not isinstance(value, dict):
+        raise TypeError(
+            f"Expected encodings to deserialize to a dict, got {type(value).__name__}."
+        )
+
+    return Encodings(
+        activation_encodings=_normalize_encoding_group(
+            value.get("activation_encodings", {})
+        ),
+        param_encodings=_normalize_encoding_group(
+            value.get("param_encodings", {})
+        ),
+    )
+
+
 class Encodings(BaseModelExtraForbid):
     activation_encodings: dict[str, list[QuantizationOverridesItem]]
     param_encodings: dict[str, list[QuantizationOverridesItem]]
@@ -321,7 +447,7 @@ class RVC4Config(TargetConfig):
             self.snpe_onnx_to_dlc_args.pop(qo_index)
             encodings_json = self.snpe_onnx_to_dlc_args.pop(qo_index)
             with open(encodings_json) as f:
-                self.encodings = Encodings.model_validate_json(f.read())
+                self.encodings = parse_encodings(f.read())
         return self
 
     @field_validator("encodings", mode="before")
@@ -332,9 +458,9 @@ class RVC4Config(TargetConfig):
 
         if isinstance(value, str):
             value_path = resolve_path(value, MISC_DIR)
-            return Encodings(**json.loads(value_path.read_text()))
+            return parse_encodings(value_path.read_text())
 
-        return Encodings(**value)
+        return parse_encodings(value)
 
     @model_validator(mode="after")
     def _validate_fp16(self) -> Self:
@@ -830,10 +956,7 @@ def generate_renamed_onnx(
     onnx_path = Path(onnx_path)
     output_path = Path(output_path)
     model = onnx.load(str(onnx_path))
-    if onnx_path.with_suffix(".onnx_data").exists():
-        model_data_path = onnx_path.with_suffix(".onnx_data")
-    else:
-        model_data_path = None
+    model_data_path = get_external_data_path(onnx_path)
 
     for node in model.graph.node:
         for i, input_name in enumerate(node.input):

--- a/modelconverter/utils/encodings.py
+++ b/modelconverter/utils/encodings.py
@@ -1,0 +1,126 @@
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from modelconverter.utils.config import Encodings
+
+
+ALLOWED_ENCODING_KEYS = {
+    "bitwidth",
+    "is_symmetric",
+    "dtype",
+    "max",
+    "min",
+    "offset",
+    "scale",
+}
+
+
+def _scalarize_encoding_value(value: Any) -> Any:
+    if isinstance(value, list) and len(value) == 1:
+        return value[0]
+    return value
+
+
+def _normalize_encoding_item(item: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(item)
+
+    if "bitwidth" not in normalized and "bw" in normalized:
+        normalized["bitwidth"] = normalized["bw"]
+
+    if "is_symmetric" not in normalized and "is_sym" in normalized:
+        normalized["is_symmetric"] = normalized["is_sym"]
+
+    dtype = normalized.get("dtype")
+    if isinstance(dtype, str):
+        normalized["dtype"] = dtype.lower()
+
+    for key in ["scale", "offset", "min", "max"]:
+        if key in normalized:
+            normalized[key] = _scalarize_encoding_value(normalized[key])
+
+    return {
+        key: value
+        for key, value in normalized.items()
+        if key in ALLOWED_ENCODING_KEYS
+    }
+
+
+def _expand_encoding_item(item: dict[str, Any]) -> list[dict[str, Any]]:
+    normalized = _normalize_encoding_item(item)
+    vector_lengths = [
+        len(value)
+        for key, value in normalized.items()
+        if key in {"scale", "offset", "min", "max"} and isinstance(value, list)
+    ]
+    if not vector_lengths:
+        return [normalized]
+
+    size = vector_lengths[0]
+    if any(length != size for length in vector_lengths):
+        raise ValueError("Per-channel encoding fields must have matching lengths.")
+
+    expanded = []
+    for idx in range(size):
+        entry = {}
+        for key, value in normalized.items():
+            entry[key] = value[idx] if isinstance(value, list) else value
+        expanded.append(entry)
+    return expanded
+
+
+def _normalize_encoding_group(entries: Any) -> dict[str, list[dict[str, Any]]]:
+    if isinstance(entries, dict):
+        normalized = {}
+        for name, value in entries.items():
+            values = value if isinstance(value, list) else [value]
+            items = []
+            for item in values:
+                if not isinstance(item, dict):
+                    raise TypeError(
+                        f"Expected dict encoding entry, got {type(item).__name__}."
+                    )
+                items.extend(_expand_encoding_item(item))
+            normalized[name] = items
+        return normalized
+
+    if not isinstance(entries, list):
+        raise TypeError(
+            f"Expected encoding group to be a list or dict, got {type(entries).__name__}."
+        )
+
+    normalized = {}
+    for item in entries:
+        if not isinstance(item, dict):
+            raise TypeError(
+                f"Expected dict encoding entry, got {type(item).__name__}."
+            )
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"Missing or invalid tensor name in entry: {item}")
+        normalized.setdefault(name, []).extend(_expand_encoding_item(item))
+    return normalized
+
+
+def parse_encodings(value: Any) -> "Encodings":
+    from modelconverter.utils.config import Encodings
+
+    if isinstance(value, Encodings):
+        return value
+
+    if isinstance(value, str):
+        value = json.loads(value)
+
+    if not isinstance(value, dict):
+        raise TypeError(
+            f"Expected encodings to deserialize to a dict, got {type(value).__name__}."
+        )
+
+    return Encodings(
+        activation_encodings=_normalize_encoding_group(
+            value.get("activation_encodings", {})
+        ),
+        param_encodings=_normalize_encoding_group(
+            value.get("param_encodings", {})
+        ),
+    )

--- a/modelconverter/utils/onnx_compatibility.py
+++ b/modelconverter/utils/onnx_compatibility.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import ml_dtypes
 import numpy as np
 import onnx
+from onnx.external_data_helper import ExternalDataInfo, uses_external_data
 
 
 def ensure_onnx_helper_compatibility() -> None:
@@ -63,14 +64,20 @@ def save_onnx_model(
 
     onnx.save(model, str(output_path))
 
-
 def get_external_data_path(model_path: str | Path) -> Path | None:
     model_path = Path(model_path)
-    candidates = [
-        model_path.with_suffix(".onnx_data"),
-        model_path.with_name(f"{model_path.name}.data"),
-    ]
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate
+    model = onnx.load(str(model_path), load_external_data=False)
+
+    tensors = list(model.graph.initializer)
+    tensors.extend(
+        sparse_tensor.values for sparse_tensor in model.graph.sparse_initializer
+    )
+    tensors.extend(
+        sparse_tensor.indices for sparse_tensor in model.graph.sparse_initializer
+    )
+    for tensor in tensors:
+        if uses_external_data(tensor):
+            location = ExternalDataInfo(tensor).location
+            if location:
+                return model_path.parent / location
     return None

--- a/modelconverter/utils/onnx_compatibility.py
+++ b/modelconverter/utils/onnx_compatibility.py
@@ -67,6 +67,7 @@ def save_onnx_model(
 def get_external_data_path(model_path: str | Path) -> Path | None:
     model_path = Path(model_path)
     model = onnx.load(str(model_path), load_external_data=False)
+    model_dir = model_path.parent.resolve()
 
     tensors = list(model.graph.initializer)
     tensors.extend(
@@ -79,5 +80,13 @@ def get_external_data_path(model_path: str | Path) -> Path | None:
         if uses_external_data(tensor):
             location = ExternalDataInfo(tensor).location
             if location:
-                return model_path.parent / location
+                candidate = (model_path.parent / location).resolve()
+                try:
+                    candidate.relative_to(model_dir)
+                except ValueError as exc:
+                    raise ValueError(
+                        "ONNX external data location must stay within the "
+                        f"model directory: {location}"
+                    ) from exc
+                return candidate
     return None

--- a/modelconverter/utils/onnx_compatibility.py
+++ b/modelconverter/utils/onnx_compatibility.py
@@ -62,3 +62,15 @@ def save_onnx_model(
         return
 
     onnx.save(model, str(output_path))
+
+
+def get_external_data_path(model_path: str | Path) -> Path | None:
+    model_path = Path(model_path)
+    candidates = [
+        model_path.with_suffix(".onnx_data"),
+        model_path.with_name(f"{model_path.name}.data"),
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -12,6 +12,7 @@ from onnxsim import simplify
 from modelconverter.utils.config import InputConfig, OutputConfig
 from modelconverter.utils.onnx_compatibility import (
     ensure_onnx_helper_compatibility,
+    get_external_data_path,
     save_onnx_model,
 )
 
@@ -112,8 +113,9 @@ def onnx_attach_normalization_to_inputs(
     reverse_only: bool = False,
 ) -> Path:
     model = onnx.load(str(model_path))
-    if model_path.with_suffix(".onnx_data").exists():
-        model_data_path = str(model_path).replace(".onnx", ".onnx_data")
+    external_data_path = get_external_data_path(model_path)
+    if external_data_path is not None:
+        model_data_path = str(external_data_path)
     else:
         model_data_path = None
 
@@ -326,10 +328,7 @@ class ONNXModifier:
         skip_constant_folding: bool = False,
     ) -> None:
         self.model_path = model_path
-        if model_path.with_suffix(".onnx_data").exists():
-            self.has_external_data = True
-        else:
-            self.has_external_data = False
+        self.has_external_data = get_external_data_path(model_path) is not None
         self.output_path = output_path
         self.skip_optimization = skip_optimization
         self.skip_constant_folding = skip_constant_folding
@@ -422,7 +421,7 @@ class ONNXModifier:
                     optimized_onnx_model,
                     tmp_onnx_file.name,
                     save_as_external_data=True,
-                    location=f"{tmp_onnx_file.name}_data",
+                    location=f"{Path(tmp_onnx_file.name).name}_data",
                 )
                 onnx.checker.check_model(tmp_onnx_file.name)
         else:

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -290,6 +290,15 @@ def create_yaml(append: str = "") -> str:
     return f.name
 
 
+def create_encodings_file(data: dict, suffix: str = ".json") -> str:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=suffix, delete=False
+    ) as f:
+        json.dump(data, f)
+        f.flush()
+    return f.name
+
+
 def load_and_compare(
     path: str | None,
     opts: list[str],
@@ -1554,3 +1563,148 @@ def test_defaults():
         },
     ).model_dump()
     assert default == empty
+
+
+def test_rvc4_encodings_path_accepts_aimet_format():
+    encodings_path = create_encodings_file(
+        {
+            "version": "1.0.0",
+            "activation_encodings": [
+                {
+                    "name": "image",
+                    "dtype": "INT",
+                    "bw": 8,
+                    "is_sym": False,
+                    "scale": [1.0],
+                    "offset": [0],
+                },
+                {
+                    "name": "feature_map",
+                    "dtype": "INT",
+                    "bw": 8,
+                    "is_sym": False,
+                    "scale": [0.25, 0.5],
+                    "offset": [-2, -4],
+                },
+            ],
+            "param_encodings": [
+                {
+                    "name": "conv.weight",
+                    "dtype": "FLOAT",
+                    "bw": 16,
+                }
+            ],
+        },
+        suffix=".encodings",
+    )
+
+    config = Config.get_config(
+        None,
+        {
+            "input_model": str(DATA_DIR / "dummy_model.onnx"),
+            "rvc4.encodings": encodings_path,
+        },
+    )
+
+    assert config.get("stages.dummy_model.rvc4.encodings").model_dump(
+        mode="json", exclude_none=True
+    ) == {
+        "activation_encodings": {
+            "image": [
+                {
+                    "bitwidth": 8,
+                    "is_symmetric": "False",
+                    "dtype": "int",
+                    "scale": 1.0,
+                    "offset": 0,
+                }
+            ],
+            "feature_map": [
+                {
+                    "bitwidth": 8,
+                    "is_symmetric": "False",
+                    "dtype": "int",
+                    "scale": 0.25,
+                    "offset": -2,
+                },
+                {
+                    "bitwidth": 8,
+                    "is_symmetric": "False",
+                    "dtype": "int",
+                    "scale": 0.5,
+                    "offset": -4,
+                },
+            ],
+        },
+        "param_encodings": {
+            "conv.weight": [
+                {
+                    "bitwidth": 16,
+                    "dtype": "float",
+                }
+            ]
+        },
+    }
+
+
+def test_rvc4_quantization_overrides_accepts_aimet_format():
+    encodings_path = create_encodings_file(
+        {
+            "version": "1.0.0",
+            "activation_encodings": [
+                {
+                    "name": "image",
+                    "dtype": "INT",
+                    "bw": 8,
+                    "is_sym": False,
+                    "scale": [1.0],
+                    "offset": [0],
+                }
+            ],
+            "param_encodings": [
+                {
+                    "name": "conv.weight",
+                    "dtype": "FLOAT",
+                    "bw": 16,
+                }
+            ],
+        },
+        suffix=".encodings",
+    )
+
+    config = Config.get_config(
+        None,
+        {
+            "input_model": str(DATA_DIR / "dummy_model.onnx"),
+            "rvc4.snpe_onnx_to_dlc_args": json.dumps(
+                ["--quantization_overrides", encodings_path]
+            ),
+        },
+    )
+
+    assert (
+        config.get("stages.dummy_model.rvc4.snpe_onnx_to_dlc_args") == []
+    )
+    assert config.get("stages.dummy_model.rvc4.encodings").model_dump(
+        mode="json", exclude_none=True
+    ) == {
+        "activation_encodings": {
+            "image": [
+                {
+                    "bitwidth": 8,
+                    "is_symmetric": "False",
+                    "dtype": "int",
+                    "scale": 1.0,
+                    "offset": 0,
+                }
+            ]
+        },
+        "param_encodings": {
+            "conv.weight": [
+                {
+                    "bitwidth": 16,
+                    "dtype": "float",
+                }
+            ]
+        },
+    }

--- a/tests/test_utils/test_onnx_compatibility.py
+++ b/tests/test_utils/test_onnx_compatibility.py
@@ -8,6 +8,7 @@ from modelconverter.packages.base_exporter import Exporter
 from modelconverter.utils.config import generate_renamed_onnx
 from modelconverter.utils.onnx_compatibility import (
     ensure_onnx_helper_compatibility,
+    get_external_data_path,
     save_onnx_model,
 )
 from modelconverter.utils.types import DataType
@@ -64,7 +65,13 @@ def test_simplify_onnx_falls_back_on_error(
     assert Exporter.simplify_onnx(DummyExporter()) == input_path
 
 
-def test_generate_renamed_onnx_overwrites_external_data(tmp_path: Path):
+@pytest.mark.parametrize(
+    "input_external_data_name",
+    ["external_input.onnx_data", "external_input.onnx.data"],
+)
+def test_generate_renamed_onnx_overwrites_external_data(
+    tmp_path: Path, input_external_data_name: str
+):
     input_tensor = helper.make_tensor_value_info(
         "input0", TensorProto.FLOAT, [1, 1024]
     )
@@ -95,9 +102,12 @@ def test_generate_renamed_onnx_overwrites_external_data(tmp_path: Path):
         model,
         input_path,
         save_as_external_data=True,
-        location=f"{input_path.name}_data",
+        location=input_external_data_name,
     )
-    assert input_path.with_name(f"{input_path.name}_data").exists()
+    assert input_path.with_name(input_external_data_name).exists()
+    assert get_external_data_path(input_path) == input_path.with_name(
+        input_external_data_name
+    )
 
     generate_renamed_onnx(input_path, {"output0": "renamed0"}, output_path)
     assert output_path.with_name(f"{output_path.name}_data").exists()


### PR DESCRIPTION
## Purpose
- AIMET-returned `.encodings` differ in layout from the usual `.json` encodings that we use for mixed exports.
-  rvc4.snpe_onnx_to_dlc_args now accepts --quantization_overrides <file> where <file> can be either:
  - the existing normalized JSON format
  - an AIMET .encodings file
- Format differences between AIMET `.encodings` and the current .json format:
    - bw -> bitwidth
    - is_sym -> is_symmetric
    - dtype should be lowercase
    - collapse singleton vectors like scale: [x]
    - expand per-channel vectors into the list format expected by SNPE override generation

Example command for conversion using the AIMET .encodings file:
`modelconverter --dev convert rvc4 --tool-version 2.41.0 --path <model-path> --to nn_archive disable_onnx_simplification true disable_onnx_optimizations true rvc4.quantization_mode CUSTOM rvc4.snpe_onnx_to_dlc_args '["--quantization_overrides",<.encodings file name>]' rvc4.snpe_dlc_quant_args '["--override_params"]' "inputs.0.calibration" '{"path":<calibration-images-path>,"max_images":<max-images>}'`

Example of running the returned detection model RVC4 NNArchive on-device:
<img width="872" height="446" alt="running_on_device" src="https://github.com/user-attachments/assets/40774bed-25dd-4b53-8beb-061a74a2b581" />


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of models that use external tensor data during import, optimization, and export.
  * Broader support for encoding configuration formats via normalized deserialization.

* **Bug Fixes**
  * External model data is detected more reliably and preserved alongside generated artifacts.
  * Quantization settings are now normalized/overridden consistently, including dtype and bitwidth for exposed activation encodings.

* **Tests**
  * Added coverage for loading encoding settings from file and command-line overrides.
  * Expanded validation for external-data model renaming and export behavior across naming styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->