### PR TITLE
Added PostHog telementry

### DIFF
--- a/.github/workflows/actions_autoupdate.yaml
+++ b/.github/workflows/actions_autoupdate.yaml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
+env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
+
 jobs:
   update-github-actions:
     runs-on: ubuntu-latest

--- a/.github/workflows/bom-test.yaml
+++ b/.github/workflows/bom-test.yaml
@@ -27,6 +27,7 @@ on:
         type: string
 
 env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
   DISTINCT_ID: ${{ github.event.inputs.distinct_id }}
   DEPTHAI_VERSION: ${{ github.event.inputs.depthai_version }}
   OS_VERSION: ${{ github.event.inputs.os_version }}

--- a/.github/workflows/bom-test.yaml
+++ b/.github/workflows/bom-test.yaml
@@ -78,8 +78,11 @@ jobs:
             OS_VERSION_OPTION="--os-version $OS_VERSION"
           fi
 
-          if [[ "$DEPTHAI_VERSION" =~ ^3\.[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
+          if [[ "$DEPTHAI_VERSION" =~ ^3\.(8|9|[1-9][0-9])\.[0-9]{1,2}$ ]]; then
             DEPTHAI_VERSION_CHECKED="$DEPTHAI_VERSION"
+          else
+            echo "DEPTHAI_VERSION must be within >=3.8.0,<4.0.0; got: $DEPTHAI_VERSION" >&2
+            exit 1
           fi
           : "${INFLUX_TOKEN:?INFLUX_TOKEN is required on the runner}"
           : "${INFLUX_BUCKET:?INFLUX_BUCKET must be set by the workflow}"

--- a/.github/workflows/hailo_publish.yaml
+++ b/.github/workflows/hailo_publish.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
+
 jobs:
   hailo-publish:
     strategy:

--- a/.github/workflows/hailo_test.yaml
+++ b/.github/workflows/hailo_test.yaml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
+
 jobs:
   hailo-test:
     strategy:

--- a/.github/workflows/modelconverter_test.yaml
+++ b/.github/workflows/modelconverter_test.yaml
@@ -26,6 +26,7 @@ permissions:
   packages: read
 
 env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,6 +33,7 @@ permissions:
   packages: write
 
 env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
   GAR_LOCATION: us-central1
   PACKAGE: ${{ inputs.package }}
   NAME: luxonis/modelconverter-${{ inputs.package }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/rvc2_publish.yaml
+++ b/.github/workflows/rvc2_publish.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
+
 jobs:
   rvc2-publish:
     strategy:

--- a/.github/workflows/rvc2_test.yaml
+++ b/.github/workflows/rvc2_test.yaml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
+
 jobs:
   rvc2-test:
     strategy:

--- a/.github/workflows/rvc3_publish.yaml
+++ b/.github/workflows/rvc3_publish.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
+
 jobs:
   rvc3-publish:
     uses: ./.github/workflows/publish.yaml

--- a/.github/workflows/rvc3_test.yaml
+++ b/.github/workflows/rvc3_test.yaml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
+
 jobs:
   rvc3-test:
     uses: ./.github/workflows/modelconverter_test.yaml

--- a/.github/workflows/rvc4_publish.yaml
+++ b/.github/workflows/rvc4_publish.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
+
 jobs:
   rvc4-publish:
     strategy:

--- a/.github/workflows/rvc4_test.yaml
+++ b/.github/workflows/rvc4_test.yaml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
+
 jobs:
   rvc4-test:
     strategy:

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -3,6 +3,9 @@ name: Semgrep SAST Scan
 on:
   pull_request:
 
+env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
+
 jobs:
   semgrep:
     # User definable name of this GitHub Actions job.

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -38,6 +38,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  LUXONIS_TELEMETRY_ENABLED: "false"
+
 jobs:
   utils-test:
     runs-on: ubuntu-latest

--- a/docker/rvc2/Dockerfile
+++ b/docker/rvc2/Dockerfile
@@ -107,6 +107,16 @@ ENV IN_DOCKER=
 ENV VERSION=${VERSION}
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/python3.8/site-packages/openvino/libs/
 
+RUN <<EOF
+
+    set -e
+
+    apt-get update
+    apt-get install -y --no-install-recommends git
+    rm -rf /var/lib/apt/lists/*
+
+EOF
+
 
 COPY --link --from=base \
     /usr/lib/x86_64-linux-gnu/libcurl.so.4 \

--- a/docker/rvc3/Dockerfile
+++ b/docker/rvc3/Dockerfile
@@ -63,6 +63,16 @@ WORKDIR /app
 ENV IN_DOCKER=
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/python3.8/site-packages/openvino/libs/
 
+RUN <<EOF
+
+    set -e
+
+    apt-get update
+    apt-get install -y --no-install-recommends git
+    rm -rf /var/lib/apt/lists/*
+
+EOF
+
 COPY --link --from=base \
     /usr/lib/x86_64-linux-gnu/libcurl.so.4 \
     /usr/lib/x86_64-linux-gnu/libnghttp2.so.14 \

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -151,35 +151,36 @@ def convert(
     phase = "configuration"
     caught_exc: BaseException | None = None
 
-    if path is not None:
-        suffix = Path(path).suffix
-        if suffix in {".xml", ".bin"} and target not in {
-            Target.RVC2,
-            Target.RVC3,
-        }:
-            raise ValueError(
-                f"OpenVINO IR format is not supported for target {target.name}."
-            )
-        if suffix in {".onnx", ".xml", ".dlc", ".tflite"}:
-            opts = ["input_model", path, *opts]
-            if suffix == ".xml":
+    try:
+        main_stage_provided = main_stage is not None
+        if path is not None:
+            suffix = Path(path).suffix
+            if suffix in {".xml", ".bin"} and target not in {
+                Target.RVC2,
+                Target.RVC3,
+            }:
+                raise ValueError(
+                    f"OpenVINO IR format is not supported for target {target.name}."
+                )
+            if suffix in {".onnx", ".xml", ".dlc", ".tflite"}:
+                opts = ["input_model", path, *opts]
+                if suffix == ".xml":
+                    opts = [
+                        "input_bin",
+                        str(Path(path).with_suffix(".bin")),
+                        *opts,
+                    ]
+                path = None
+            elif suffix == ".bin":
                 opts = [
+                    "input_model",
+                    str(Path(path).with_suffix(".xml")),
                     "input_bin",
-                    str(Path(path).with_suffix(".bin")),
+                    path,
                     *opts,
                 ]
-            path = None
-        elif suffix == ".bin":
-            opts = [
-                "input_model",
-                str(Path(path).with_suffix(".xml")),
-                "input_bin",
-                path,
-                *opts,
-            ]
-            path = None
+                path = None
 
-    try:
         init_dirs()
         cfg, archive_cfg, _main_stage = get_configs(target, path, list(opts))
         main_stage = main_stage or _main_stage
@@ -220,7 +221,7 @@ def convert(
                 ),
                 archive_output_mode=to,
                 archive_preprocess=archive_preprocess,
-                main_stage_provided=main_stage is not None,
+                main_stage_provided=main_stage_provided,
             ),
         )
         runtime_telemetry.capture(
@@ -240,7 +241,13 @@ def convert(
 
             archive_name = None
             if original_path is not None and is_nn_archive(original_path):
-                archive_name = Path(original_path).name.split(".")[0]
+                archive_filename = Path(original_path).name
+                archive_suffix = "".join(Path(original_path).suffixes)
+                archive_name = (
+                    archive_filename.removesuffix(archive_suffix)
+                    if archive_suffix
+                    else archive_filename
+                )
 
             assert main_stage is not None
             out_models = [
@@ -323,45 +330,48 @@ def convert(
         logger.info(
             f"Conversion finished in {time.monotonic() - t:.2f} seconds"
         )
-        if conversion_summary is not None and conversion_start is not None:
-            failure_reason = runtime_failure_reason_from_exception(
-                caught_exc, phase=phase
-            )
-            runtime_telemetry.capture(
-                RESULT_EVENT,
-                build_flow_properties(
-                    conversion_run_id,
-                    "result_recorded",
-                    {
-                        **{
+        failure_reason = runtime_failure_reason_from_exception(
+            caught_exc, phase=phase
+        )
+        runtime_telemetry.capture(
+            RESULT_EVENT,
+            build_flow_properties(
+                conversion_run_id,
+                "result_recorded",
+                {
+                    **(
+                        {
                             key: value
                             for key, value in conversion_summary.items()
                             if key != "flow_step"
-                        },
-                        **build_conversion_result_properties(
-                            result=(
-                                "success"
-                                if caught_exc is None
-                                else (
-                                    "interrupted"
-                                    if failure_reason == "user_interrupt"
-                                    else "failed"
-                                )
-                            ),
-                            failure_reason=failure_reason,
-                            duration_ms=int(
-                                (time.monotonic() - conversion_start) * 1000
-                            ),
-                            output_artifact_count=output_artifact_count,
-                            uploaded_output=uploaded_output,
-                            uploaded_intermediate_outputs=uploaded_intermediate_outputs,
-                            peak_ram_bytes=peak_ram_bytes,
+                        }
+                        if conversion_summary is not None
+                        else {"target": target.value}
+                    ),
+                    **build_conversion_result_properties(
+                        result=(
+                            "success"
+                            if caught_exc is None
+                            else (
+                                "interrupted"
+                                if failure_reason == "user_interrupt"
+                                else "failed"
+                            )
                         ),
-                    },
-                ),
-                include_system_metadata=True,
-                distinct_id=conversion_run_id,
-            )
+                        failure_reason=failure_reason,
+                        duration_ms=int(
+                            (time.monotonic() - (conversion_start or t)) * 1000
+                        ),
+                        output_artifact_count=output_artifact_count,
+                        uploaded_output=uploaded_output,
+                        uploaded_intermediate_outputs=uploaded_intermediate_outputs,
+                        peak_ram_bytes=peak_ram_bytes,
+                    ),
+                },
+            ),
+            include_system_metadata=True,
+            distinct_id=conversion_run_id,
+        )
         os.environ.pop(CONVERSION_RUN_ID_ENV_VAR, None)
 
 
@@ -802,6 +812,7 @@ def launcher(
 
     assert target is not None
     command_telemetry = get_component_telemetry()
+    previous_conversion_run_id = os.environ.get(CONVERSION_RUN_ID_ENV_VAR)
     conversion_run_id = get_conversion_run_id()
     command_start = time.monotonic()
     caught_exc: BaseException | None = None
@@ -812,31 +823,40 @@ def launcher(
         caught_exc = exc
         raise
     finally:
-        command_telemetry.capture(
-            COMMAND_EVENT,
-            build_command_properties(
-                conversion_run_id=conversion_run_id,
-                target=target,
-                runs_in_docker=not running_in_docker,
-                dev_image=dev,
-                gpu_enabled=gpu,
-                target_tool_version=resolve_target_tool_version(
+        try:
+            command_telemetry.capture(
+                COMMAND_EVENT,
+                build_command_properties(
+                    conversion_run_id=conversion_run_id,
                     target=target,
-                    tool_version=tool_version,
-                    image=image,
+                    runs_in_docker=not running_in_docker,
+                    dev_image=dev,
+                    gpu_enabled=gpu,
+                    target_tool_version=resolve_target_tool_version(
+                        target=target,
+                        tool_version=tool_version,
+                        image=image,
+                    ),
+                    custom_image_provided=image is not None,
+                    memory_limit_set=memory is not None,
+                    cpu_limit_set=cpus is not None,
+                    result=command_result_from_exception(caught_exc),
+                    failure_reason=command_failure_reason_from_exception(
+                        caught_exc
+                    ),
+                    duration_ms=int((time.monotonic() - command_start) * 1000),
                 ),
-                custom_image_provided=image is not None,
-                memory_limit_set=memory is not None,
-                cpu_limit_set=cpus is not None,
-                result=command_result_from_exception(caught_exc),
-                failure_reason=command_failure_reason_from_exception(
-                    caught_exc
-                ),
-                duration_ms=int((time.monotonic() - command_start) * 1000),
-            ),
-            include_system_metadata=True,
-            distinct_id=conversion_run_id,
-        )
+                include_system_metadata=True,
+                distinct_id=conversion_run_id,
+            )
+        finally:
+            if previous_conversion_run_id is None:
+                os.environ.pop(CONVERSION_RUN_ID_ENV_VAR, None)
+            else:
+                # Restore in case this is used elsewhere
+                os.environ[CONVERSION_RUN_ID_ENV_VAR] = (
+                    previous_conversion_run_id
+                )
 
 
 if __name__ == "__main__":

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -1,7 +1,6 @@
 import importlib.metadata
 import os
 import re
-import resource
 import signal
 import sys
 import time
@@ -43,6 +42,24 @@ from modelconverter.utils.config import SingleStageConfig
 from modelconverter.utils.constants import MODELS_DIR
 from modelconverter.utils.general import sanitize_net_name
 from modelconverter.utils.nn_archive import generate_archive
+from modelconverter.utils.telemetry import (
+    COMMAND_EVENT,
+    CONFIGURED_EVENT,
+    CONVERSION_RUN_ID_ENV_VAR,
+    RESULT_EVENT,
+    build_command_properties,
+    build_conversion_result_properties,
+    build_conversion_summary,
+    build_flow_properties,
+    command_failure_reason_from_exception,
+    command_result_from_exception,
+    detect_config_source,
+    get_component_telemetry,
+    get_conversion_run_id,
+    peak_ram_usage_bytes,
+    resolve_target_tool_version,
+    runtime_failure_reason_from_exception,
+)
 from modelconverter.utils.types import Target
 
 app = App(
@@ -115,15 +132,25 @@ def convert(
     def handle_signal(signum: int, frame: Any) -> None:
         signame = signal.Signals(signum).name
         logger.error(f"{signame} received, exiting...")
-        sys.exit(1)
+        sys.exit(130)
 
     signal.signal(signal.SIGTERM, handle_signal)
 
     if output_dir is not None:
         output_dir = sanitize_net_name(output_dir)
-    t = time.time()
+    t = time.monotonic()
+    runtime_telemetry = get_component_telemetry()
+    conversion_run_id = get_conversion_run_id()
+    original_path = path
+    opts: list[str] = list(opts or [])
+    conversion_start: float | None = None
+    conversion_summary: dict[str, Any] | None = None
+    output_artifact_count: int | None = None
+    uploaded_output = False
+    uploaded_intermediate_outputs = False
+    phase = "configuration"
+    caught_exc: BaseException | None = None
 
-    opts = opts or []
     if path is not None:
         suffix = Path(path).suffix
         if suffix in {".xml", ".bin"} and target not in {
@@ -152,7 +179,7 @@ def convert(
             ]
             path = None
 
-    with catch_exceptions():
+    try:
         init_dirs()
         cfg, archive_cfg, _main_stage = get_configs(target, path, list(opts))
         main_stage = main_stage or _main_stage
@@ -182,6 +209,29 @@ def convert(
                 output_dir=output_path,
             )
 
+        conversion_summary = build_flow_properties(
+            conversion_run_id,
+            "configuration_resolved",
+            build_conversion_summary(
+                cfg,
+                target=target,
+                config_source=detect_config_source(
+                    original_path, opts, archive_cfg
+                ),
+                archive_output_mode=to,
+                archive_preprocess=archive_preprocess,
+                main_stage_provided=main_stage is not None,
+            ),
+        )
+        runtime_telemetry.capture(
+            CONFIGURED_EVENT,
+            conversion_summary,
+            include_system_metadata=True,
+            distinct_id=conversion_run_id,
+        )
+
+        conversion_start = time.monotonic()
+        phase = "conversion"
         out_models = exporter.run()
         if not isinstance(out_models, list):
             out_models = [out_models]
@@ -189,8 +239,8 @@ def convert(
             from modelconverter.packages.base_exporter import Exporter
 
             archive_name = None
-            if path is not None and is_nn_archive(path):
-                archive_name = Path(path).name.split(".")[0]
+            if original_path is not None and is_nn_archive(original_path):
+                archive_name = Path(original_path).name.split(".")[0]
 
             assert main_stage is not None
             out_models = [
@@ -212,6 +262,7 @@ def convert(
                     archive_name=archive_name,
                 )
             ]
+        output_artifact_count = len(out_models)
 
         if isinstance(exporter.config, SingleStageConfig):
             _cfg = exporter.config
@@ -222,6 +273,7 @@ def convert(
         put_file_plugin = _cfg.put_file_plugin
 
         if upload_url is not None:
+            phase = "upload_output"
             for model_path in out_models:
                 logger.info(f"Uploading {model_path} to {upload_url}")
                 upload_to_remote(
@@ -229,10 +281,10 @@ def convert(
                     upload_url,
                     put_file_plugin,
                 )
-
-            logger.info("Conversion finished successfully")
+            uploaded_output = True
 
         if intermediate_url is not None:
+            phase = "upload_intermediate"
             exporters = (
                 exporter.exporters.values()
                 if isinstance(exporter, MultiStageExporter)
@@ -247,9 +299,70 @@ def convert(
                     intermediate_url,
                     put_file_plugin,
                 )
-    ram = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-    logger.info(f"Peak RAM usage: {ram:.2f} MB")
-    logger.info(f"Conversion finished in {time.time() - t:.2f} seconds")
+            uploaded_intermediate_outputs = True
+
+        logger.info("Conversion finished successfully")
+    except KeyboardInterrupt as exc:
+        caught_exc = exc
+        logger.error("Keyboard interrupt received, exiting...")
+        raise SystemExit(130) from exc
+    except SystemExit as exc:
+        caught_exc = exc
+        raise
+    except ModelconverterException as exc:
+        caught_exc = exc
+        logger.exception("Encountered an exception in the conversion process!")
+        raise SystemExit(1) from exc
+    except Exception as exc:
+        caught_exc = exc
+        logger.exception("Encountered an unexpected error!")
+        raise SystemExit(2) from exc
+    finally:
+        peak_ram_bytes = peak_ram_usage_bytes()
+        logger.info(f"Peak RAM usage: {peak_ram_bytes / (1024 * 1024):.2f} MB")
+        logger.info(
+            f"Conversion finished in {time.monotonic() - t:.2f} seconds"
+        )
+        if conversion_summary is not None and conversion_start is not None:
+            failure_reason = runtime_failure_reason_from_exception(
+                caught_exc, phase=phase
+            )
+            runtime_telemetry.capture(
+                RESULT_EVENT,
+                build_flow_properties(
+                    conversion_run_id,
+                    "result_recorded",
+                    {
+                        **{
+                            key: value
+                            for key, value in conversion_summary.items()
+                            if key != "flow_step"
+                        },
+                        **build_conversion_result_properties(
+                            result=(
+                                "success"
+                                if caught_exc is None
+                                else (
+                                    "interrupted"
+                                    if failure_reason == "user_interrupt"
+                                    else "failed"
+                                )
+                            ),
+                            failure_reason=failure_reason,
+                            duration_ms=int(
+                                (time.monotonic() - conversion_start) * 1000
+                            ),
+                            output_artifact_count=output_artifact_count,
+                            uploaded_output=uploaded_output,
+                            uploaded_intermediate_outputs=uploaded_intermediate_outputs,
+                            peak_ram_bytes=peak_ram_bytes,
+                        ),
+                    },
+                ),
+                include_system_metadata=True,
+                distinct_id=conversion_run_id,
+            )
+        os.environ.pop(CONVERSION_RUN_ID_ENV_VAR, None)
 
 
 @app.command(group=docker_commands)
@@ -629,6 +742,9 @@ def launcher(
     ] = None,
 ):
     command, bound, _ = app.parse_args(tokens)
+    target = bound.arguments.get("target")
+    is_convert_command = getattr(command, "__name__", "") == "convert"
+    running_in_docker = in_docker()
 
     if memory is not None:
         if not re.match(r"^\d+(?:[bkmgBKMG])?$", memory):
@@ -643,40 +759,81 @@ def launcher(
     if cpus is not None and cpus <= 0:
         raise ValueError("CPUs value must be a positive number.")
 
-    if in_docker():
-        return command(*bound.args, **bound.kwargs)
+    def run_in_configured_environment() -> Any:
+        if running_in_docker:
+            return command(*bound.args, **bound.kwargs)
 
-    tag = "dev" if dev else "latest"
+        assert target is not None
+        tag = "dev" if dev else "latest"
+        if dev:
+            version = tool_version or get_default_target_version(target.value)
+            # CI invokes multiple dev docker commands per job; reuse the first
+            # local build so later commands don't rebuild the same image again.
+            if not (
+                os.getenv("CI") == "true"
+                and get_local_docker_image(
+                    target.value,
+                    bare_tag=tag,
+                    version=version,
+                    image=image,
+                )
+            ):
+                docker_build(
+                    target.value, bare_tag=tag, version=version, image=image
+                )
 
-    target = bound.arguments["target"]
+        docker_exec(
+            target.value,
+            *tokens,
+            bare_tag=tag,
+            use_gpu=gpu,
+            version=tool_version,
+            image=image,
+            memory=memory,
+            cpus=cpus,
+        )
+        return None
 
-    if dev:
-        version = tool_version or get_default_target_version(target.value)
-        # CI invokes multiple dev docker commands per job; reuse the first
-        # local build so later commands don't rebuild the same image again.
-        if not (
-            os.getenv("CI") == "true"
-            and get_local_docker_image(
-                target.value,
-                bare_tag=tag,
-                version=version,
-                image=image,
-            )
-        ):
-            docker_build(
-                target.value, bare_tag=tag, version=version, image=image
-            )
+    if not is_convert_command:
+        return run_in_configured_environment()
 
-    docker_exec(
-        target.value,
-        *tokens,
-        bare_tag=tag,
-        use_gpu=gpu,
-        version=tool_version,
-        image=image,
-        memory=memory,
-        cpus=cpus,
-    )
+    assert target is not None
+    command_telemetry = get_component_telemetry()
+    conversion_run_id = get_conversion_run_id()
+    command_start = time.monotonic()
+    caught_exc: BaseException | None = None
+
+    try:
+        return run_in_configured_environment()
+    except BaseException as exc:
+        caught_exc = exc
+        raise
+    finally:
+        command_telemetry.capture(
+            COMMAND_EVENT,
+            build_command_properties(
+                conversion_run_id=conversion_run_id,
+                target=target,
+                runs_in_docker=not running_in_docker,
+                dev_image=dev,
+                gpu_enabled=gpu,
+                target_tool_version=resolve_target_tool_version(
+                    target=target,
+                    tool_version=tool_version,
+                    image=image,
+                ),
+                custom_image_provided=image is not None,
+                memory_limit_set=memory is not None,
+                cpu_limit_set=cpus is not None,
+                result=command_result_from_exception(caught_exc),
+                failure_reason=command_failure_reason_from_exception(
+                    caught_exc
+                ),
+                duration_ms=int((time.monotonic() - command_start) * 1000),
+            ),
+            include_system_metadata=True,
+            distinct_id=conversion_run_id,
+        )
 
 
 if __name__ == "__main__":

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -797,6 +797,9 @@ def launcher(
     if not is_convert_command:
         return run_in_configured_environment()
 
+    if running_in_docker:  # to suppress duplicate COMMAND_EVENT capture
+        return run_in_configured_environment()
+
     assert target is not None
     command_telemetry = get_component_telemetry()
     conversion_run_id = get_conversion_run_id()

--- a/modelconverter/utils/__init__.py
+++ b/modelconverter/utils/__init__.py
@@ -12,7 +12,6 @@ from .docker_utils import (
     docker_exec,
     get_container_memory_available,
     get_container_memory_limit,
-    get_default_target_version,
     get_docker_image,
     get_local_docker_image,
     in_docker,
@@ -47,6 +46,7 @@ from .onnx_tools import (
 )
 from .progress_handler import create_progress_handler
 from .subprocess import SubprocessHandle, subprocess_run
+from .target_versions import get_default_target_version
 from .types import DataType
 
 __all__ = [

--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -22,6 +22,9 @@ from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
 
 import docker
 from modelconverter import __version__
+from modelconverter.utils.target_versions import (
+    get_default_target_version,
+)
 from modelconverter.utils.telemetry import telemetry_environment
 
 
@@ -46,17 +49,6 @@ def get_docker_client_from_active_context() -> docker.DockerClient:
         kwargs["tls"] = True
 
     return docker.DockerClient(**kwargs)
-
-
-def get_default_target_version(
-    target: Literal["rvc2", "rvc3", "rvc4", "hailo"],
-) -> str:
-    return {
-        "rvc2": "2022.3.0",
-        "rvc3": "2022.3.0",
-        "rvc4": "2.41.0",
-        "hailo": "2025.04",
-    }[target]
 
 
 def rvc4_tag_version(version: str) -> str:

--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -22,6 +22,7 @@ from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
 
 import docker
 from modelconverter import __version__
+from modelconverter.utils.telemetry import telemetry_environment
 
 
 def get_docker_client_from_active_context() -> docker.DockerClient:
@@ -72,22 +73,27 @@ def generate_compose_config(
     gpu: bool = False,
     memory: str | None = None,
     cpus: float | None = None,
+    extra_environment: dict[str, str] | None = None,
 ) -> str:
+    environment = {
+        "AWS_ACCESS_KEY_ID": environ.AWS_ACCESS_KEY_ID.get_secret_value()
+        if environ.AWS_ACCESS_KEY_ID
+        else "",
+        "AWS_SECRET_ACCESS_KEY": environ.AWS_SECRET_ACCESS_KEY.get_secret_value()
+        if environ.AWS_SECRET_ACCESS_KEY
+        else "",
+        "AWS_S3_ENDPOINT_URL": environ.AWS_S3_ENDPOINT_URL or "",
+        "LUXONISML_BUCKET": environ.LUXONISML_BUCKET or "",
+        "TF_CPP_MIN_LOG_LEVEL": "3",
+        "GOOGLE_APPLICATION_CREDENTIALS": "/run/secrets/gcp-credentials",
+    }
+    if extra_environment:
+        environment.update(extra_environment)
+
     config = {
         "services": {
             "modelconverter": {
-                "environment": {
-                    "AWS_ACCESS_KEY_ID": environ.AWS_ACCESS_KEY_ID.get_secret_value()
-                    if environ.AWS_ACCESS_KEY_ID
-                    else "",
-                    "AWS_SECRET_ACCESS_KEY": environ.AWS_SECRET_ACCESS_KEY.get_secret_value()
-                    if environ.AWS_SECRET_ACCESS_KEY
-                    else "",
-                    "AWS_S3_ENDPOINT_URL": environ.AWS_S3_ENDPOINT_URL or "",
-                    "LUXONISML_BUCKET": environ.LUXONISML_BUCKET or "",
-                    "TF_CPP_MIN_LOG_LEVEL": "3",
-                    "GOOGLE_APPLICATION_CREDENTIALS": "/run/secrets/gcp-credentials",
-                },
+                "environment": environment,
                 "volumes": [
                     f"{Path.cwd().absolute() / 'shared_with_container'}:/app/shared_with_container"
                 ],
@@ -452,6 +458,7 @@ def docker_exec(
                 gpu=use_gpu and target == "hailo",
                 memory=memory,
                 cpus=cpus,
+                extra_environment=telemetry_environment(),
             ).encode()
         )
 

--- a/modelconverter/utils/target_versions.py
+++ b/modelconverter/utils/target_versions.py
@@ -1,0 +1,12 @@
+from typing import Literal
+
+
+def get_default_target_version(
+    target: Literal["rvc2", "rvc3", "rvc4", "hailo"],
+) -> str:
+    return {
+        "rvc2": "2022.3.0",
+        "rvc3": "2022.3.0",
+        "rvc4": "2.41.0",
+        "hailo": "2025.04",
+    }[target]

--- a/modelconverter/utils/telemetry.py
+++ b/modelconverter/utils/telemetry.py
@@ -10,6 +10,7 @@ from luxonis_ml.nn_archive.config import Config as NNArchiveConfig
 from luxonis_ml.telemetry import (
     Telemetry,
     TelemetryConfig,
+    TelemetryDefaults,
     get_or_init,
     system_context_provider,
 )
@@ -36,6 +37,12 @@ FLOW_NAME = "modelconverter_conversion_lifecycle"
 COMMAND_EVENT = "modelconverter_command_ran"
 CONFIGURED_EVENT = "modelconverter_conversion_configured"
 RESULT_EVENT = "modelconverter_conversion_result_recorded"
+MODELCONVERTER_TELEMETRY_DEFAULTS = TelemetryDefaults(
+    enabled=True,
+    backend="posthog",
+    api_key="phc_ojEByaCiZZ5eigzaM43PaEVbfLfFDF5NgkXEMPabrT9a",
+    endpoint="https://us.i.posthog.com",
+)
 
 
 def get_conversion_run_id() -> str:
@@ -68,7 +75,9 @@ def get_component_telemetry() -> Telemetry:
     return get_or_init(
         "modelconverter",
         library_version=__version__,
-        config=TelemetryConfig.from_environ(),
+        config=TelemetryConfig.from_environ(
+            defaults=MODELCONVERTER_TELEMETRY_DEFAULTS
+        ),
         system_context_providers=[system_context_provider],
     )
 

--- a/modelconverter/utils/telemetry.py
+++ b/modelconverter/utils/telemetry.py
@@ -235,9 +235,13 @@ def build_conversion_result_properties(
 def command_result_from_exception(exc: BaseException | None) -> str:
     if exc is None:
         return "success"
-    if isinstance(exc, (KeyboardInterrupt, SystemExit)) and getattr(
-        exc, "code", None
-    ) in {None, 130}:
+    code = getattr(exc, "code", None)
+    if isinstance(exc, SystemExit) and code in {None, 0}:
+        return "success"
+    if isinstance(exc, (KeyboardInterrupt, SystemExit)) and code in {
+        None,
+        130,
+    }:
         return "interrupted"
     return "failed"
 
@@ -247,9 +251,13 @@ def command_failure_reason_from_exception(
 ) -> str | None:
     if exc is None:
         return None
-    if isinstance(exc, (KeyboardInterrupt, SystemExit)) and getattr(
-        exc, "code", None
-    ) in {None, 130}:
+    code = getattr(exc, "code", None)
+    if isinstance(exc, SystemExit) and code in {None, 0}:
+        return None
+    if isinstance(exc, (KeyboardInterrupt, SystemExit)) and code in {
+        None,
+        130,
+    }:
         return "user_interrupt"
     return "runtime_error"
 
@@ -350,10 +358,14 @@ def _target_configuration(
         )
 
     if isinstance(target_config, RVC3Config):
-        return {
-            "pot_target_device": target_config.pot_target_device.value.lower(),
-            "compress_to_fp16": target_config.compress_to_fp16,
-        }
+        return _drop_none(
+            {
+                "pot_target_device": (
+                    target_config.pot_target_device.value.lower()
+                ),
+                "compress_to_fp16": target_config.compress_to_fp16,
+            }
+        )
 
     if isinstance(target_config, RVC4Config):
         return _drop_none(

--- a/modelconverter/utils/telemetry.py
+++ b/modelconverter/utils/telemetry.py
@@ -1,0 +1,398 @@
+import os
+import resource
+import sys
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from luxonis_ml.nn_archive import is_nn_archive
+from luxonis_ml.nn_archive.config import Config as NNArchiveConfig
+from luxonis_ml.telemetry import (
+    Telemetry,
+    TelemetryConfig,
+    get_or_init,
+    system_context_provider,
+)
+
+from modelconverter import __version__
+from modelconverter.utils import get_default_target_version
+from modelconverter.utils.config import (
+    Config,
+    HailoConfig,
+    ImageCalibrationConfig,
+    LinkCalibrationConfig,
+    RandomCalibrationConfig,
+    RVC2Config,
+    RVC3Config,
+    RVC4Config,
+    SingleStageConfig,
+)
+from modelconverter.utils.types import Target
+
+CONVERSION_RUN_ID_ENV_VAR = "MODELCONVERTER_CONVERSION_RUN_ID"
+FLOW_NAME = "modelconverter_conversion_lifecycle"
+COMMAND_EVENT = "modelconverter_command_ran"
+CONFIGURED_EVENT = "modelconverter_conversion_configured"
+RESULT_EVENT = "modelconverter_conversion_result_recorded"
+
+
+def get_conversion_run_id() -> str:
+    conversion_run_id = os.environ.get(CONVERSION_RUN_ID_ENV_VAR)
+    if conversion_run_id:
+        return conversion_run_id
+    conversion_run_id = str(uuid4())
+    os.environ[CONVERSION_RUN_ID_ENV_VAR] = conversion_run_id
+    return conversion_run_id
+
+
+def telemetry_environment() -> dict[str, str]:
+    env = {}
+    for key in [
+        CONVERSION_RUN_ID_ENV_VAR,
+        "LUXONIS_TELEMETRY_ENABLED",
+        "LUXONIS_TELEMETRY_BACKEND",
+        "LUXONIS_TELEMETRY_API_KEY",
+        "LUXONIS_TELEMETRY_ENDPOINT",
+        "LUXONIS_TELEMETRY_DEBUG",
+        "LUXONIS_TELEMETRY_IS_LUXONIS_CLOUD",
+    ]:
+        value = os.environ.get(key)
+        if value is not None:
+            env[key] = value
+    return env
+
+
+def get_component_telemetry() -> Telemetry:
+    return get_or_init(
+        "modelconverter",
+        library_version=__version__,
+        config=TelemetryConfig.from_environ(),
+        system_context_providers=[system_context_provider],
+    )
+
+
+def build_command_properties(
+    *,
+    conversion_run_id: str,
+    target: Target,
+    runs_in_docker: bool,
+    dev_image: bool,
+    gpu_enabled: bool,
+    target_tool_version: str | None,
+    custom_image_provided: bool,
+    memory_limit_set: bool,
+    cpu_limit_set: bool,
+    result: str,
+    duration_ms: int,
+    failure_reason: str | None = None,
+) -> dict[str, Any]:
+    return _drop_none(
+        {
+            "conversion_run_id": conversion_run_id,
+            "command_name": "convert",
+            "target": target.value,
+            "runs_in_docker": runs_in_docker,
+            "dev_image": dev_image,
+            "gpu_enabled": gpu_enabled,
+            "target_tool_version": target_tool_version,
+            "custom_image_provided": custom_image_provided,
+            "memory_limit_set": memory_limit_set,
+            "cpu_limit_set": cpu_limit_set,
+            "result": result,
+            "failure_reason": failure_reason,
+            "duration_ms": duration_ms,
+        }
+    )
+
+
+def build_conversion_summary(
+    cfg: Config,
+    *,
+    target: Target,
+    config_source: str,
+    archive_output_mode: str,
+    archive_preprocess: bool,
+    main_stage_provided: bool,
+) -> dict[str, Any]:
+    stages = list(cfg.stages.values())
+    inputs = [inp for stage in stages for inp in stage.inputs]
+    outputs = [out for stage in stages for out in stage.outputs]
+    input_formats = [stage.input_file_type for stage in stages]
+    input_format_values = [
+        file_type.value.lower() for file_type in input_formats
+    ]
+    target_configs = [stage.get_target_config(target) for stage in stages]
+    disable_calibration = any(
+        target_cfg.disable_calibration for target_cfg in target_configs
+    )
+    calibration_sources = {
+        _calibration_source(inp.calibration)
+        for inp in inputs
+        if _calibration_source(inp.calibration) is not None
+    }
+
+    return _drop_none(
+        {
+            "target": target.value,
+            "config_source": config_source,
+            "stage_count_bucket": bucket_count(len(stages)),
+            "is_multistage": len(stages) > 1,
+            "main_stage_provided": main_stage_provided,
+            "archive_output_mode": archive_output_mode,
+            "archive_preprocess": archive_preprocess,
+            "input_model_format": (
+                input_format_values[0] if input_format_values else None
+            ),
+            "multiple_input_model_formats": (
+                len(set(input_formats)) > 1 if input_formats else None
+            ),
+            "input_count_bucket": bucket_count(len(inputs))
+            if inputs
+            else None,
+            "output_count_bucket": (
+                bucket_count(len(outputs)) if outputs else None
+            ),
+            "calibration_source": (
+                next(iter(calibration_sources))
+                if len(calibration_sources) == 1 and not disable_calibration
+                else None
+            ),
+            "disable_calibration": disable_calibration,
+            "keep_intermediate_outputs": any(
+                stage.keep_intermediate_outputs for stage in stages
+            ),
+            "disable_onnx_simplification": all(
+                stage.onnx_simplification is False for stage in stages
+            ),
+            "disable_onnx_optimization": all(
+                stage.onnx_optimizations.all_disabled() for stage in stages
+            ),
+            "has_remote_output": any(
+                stage.output_remote_url is not None for stage in stages
+            ),
+            "has_remote_intermediate_output": any(
+                stage.intermediate_outputs_remote_url is not None
+                for stage in stages
+            ),
+            "target_configuration": _target_configuration(target, stages),
+        }
+    )
+
+
+def build_flow_properties(
+    conversion_run_id: str, flow_step: str, properties: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "flow_name": FLOW_NAME,
+        "conversion_run_id": conversion_run_id,
+        "flow_step": flow_step,
+        **properties,
+    }
+
+
+def build_conversion_result_properties(
+    *,
+    result: str,
+    duration_ms: int,
+    uploaded_output: bool,
+    uploaded_intermediate_outputs: bool,
+    failure_reason: str | None = None,
+    output_artifact_count: int | None = None,
+    peak_ram_bytes: int | None = None,
+) -> dict[str, Any]:
+    return _drop_none(
+        {
+            "result": result,
+            "failure_reason": failure_reason,
+            "duration_ms": duration_ms,
+            "output_artifact_count_bucket": (
+                bucket_count(output_artifact_count)
+                if output_artifact_count is not None
+                else None
+            ),
+            "uploaded_output": uploaded_output,
+            "uploaded_intermediate_outputs": uploaded_intermediate_outputs,
+            "peak_ram_usage_bucket": (
+                bucket_memory_bytes(peak_ram_bytes)
+                if peak_ram_bytes is not None
+                else None
+            ),
+        }
+    )
+
+
+def command_result_from_exception(exc: BaseException | None) -> str:
+    if exc is None:
+        return "success"
+    if isinstance(exc, (KeyboardInterrupt, SystemExit)) and getattr(
+        exc, "code", None
+    ) in {None, 130}:
+        return "interrupted"
+    return "failed"
+
+
+def command_failure_reason_from_exception(
+    exc: BaseException | None,
+) -> str | None:
+    if exc is None:
+        return None
+    if isinstance(exc, (KeyboardInterrupt, SystemExit)) and getattr(
+        exc, "code", None
+    ) in {None, 130}:
+        return "user_interrupt"
+    return "runtime_error"
+
+
+def runtime_failure_reason_from_exception(
+    exc: BaseException | None, *, phase: str
+) -> str | None:
+    if exc is None:
+        return None
+    if isinstance(exc, (KeyboardInterrupt, SystemExit)) and getattr(
+        exc, "code", None
+    ) in {None, 130}:
+        return "user_interrupt"
+    if phase == "configuration":
+        return "config_error"
+    if phase.startswith("upload"):
+        return "upload_error"
+    return "conversion_error"
+
+
+def resolve_target_tool_version(
+    *, target: Target, tool_version: str | None, image: str | None
+) -> str | None:
+    if image is not None and ":" in image.rsplit("/", maxsplit=1)[-1]:
+        return None
+    return tool_version or get_default_target_version(target.value)
+
+
+def detect_config_source(
+    path: str | None,
+    opts: list[str],
+    archive_cfg: NNArchiveConfig | None,
+) -> str:
+    if archive_cfg is not None:
+        if path and is_nn_archive(path):
+            return "nn_archive"
+        return "archive_directory"
+    if path and _looks_like_model_input(path):
+        return "direct_model_input"
+    if "input_model" in opts[::2]:
+        return "direct_model_input"
+    return "yaml_config"
+
+
+def _looks_like_model_input(path: str) -> bool:
+    suffixes = {suffix.lower() for suffix in Path(path).suffixes}
+    return bool(
+        suffixes & {".onnx", ".xml", ".bin", ".dlc", ".tflite", ".pt", ".pth"}
+    )
+
+
+def bucket_count(value: int | None) -> str | None:
+    if value is None:
+        return None
+    if value <= 0:
+        return "0"
+    if value == 1:
+        return "1"
+    if value <= 4:
+        return "2_4"
+    return "5_plus"
+
+
+def bucket_memory_bytes(value: int | None) -> str | None:
+    if value is None:
+        return None
+    mib = value / (1024 * 1024)
+    if mib < 512:
+        return "under_512m"
+    if mib < 1024:
+        return "512m_1g"
+    if mib < 4096:
+        return "1g_4g"
+    return "above_4g"
+
+
+def peak_ram_usage_bytes() -> int:
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform == "darwin":
+        return int(peak)
+    return int(peak * 1024)
+
+
+def _target_configuration(
+    target: Target, stages: list[SingleStageConfig]
+) -> dict[str, Any] | None:
+    first_stage = stages[0]
+    target_config = first_stage.get_target_config(target)
+
+    if isinstance(target_config, RVC2Config):
+        return _drop_none(
+            {
+                "number_of_shaves": target_config.number_of_shaves,
+                "superblob": target_config.superblob,
+                "n_workers_bucket": bucket_count(target_config.n_workers),
+                "compress_to_fp16": target_config.compress_to_fp16,
+            }
+        )
+
+    if isinstance(target_config, RVC3Config):
+        return {
+            "pot_target_device": target_config.pot_target_device.value.lower(),
+            "compress_to_fp16": target_config.compress_to_fp16,
+        }
+
+    if isinstance(target_config, RVC4Config):
+        return _drop_none(
+            {
+                "quantization_mode": (
+                    target_config.quantization_mode.value.lower()
+                ),
+                "optimization_level": target_config.optimization_level,
+                "use_per_channel_quantization": (
+                    target_config.use_per_channel_quantization
+                ),
+                "use_per_row_quantization": (
+                    target_config.use_per_row_quantization
+                ),
+                "keep_raw_images": target_config.keep_raw_images,
+                "htp_soc_count_bucket": bucket_count(
+                    len(target_config.htp_socs)
+                ),
+                "has_quantization_overrides": (
+                    target_config.encodings is not None
+                ),
+            }
+        )
+
+    if isinstance(target_config, HailoConfig):
+        return _drop_none(
+            {
+                "optimization_level": target_config.optimization_level,
+                "compression_level": target_config.compression_level,
+                "batch_size_bucket": bucket_count(target_config.batch_size),
+                "disable_compilation": target_config.disable_compilation,
+                "hw_arch": target_config.hw_arch,
+                "alls_count_bucket": bucket_count(len(target_config.alls)),
+            }
+        )
+
+    return None
+
+
+def _calibration_source(calibration: Any) -> str | None:
+    if isinstance(calibration, ImageCalibrationConfig):
+        return "image_directory"
+    if isinstance(calibration, RandomCalibrationConfig):
+        return "random"
+    if isinstance(calibration, LinkCalibrationConfig):
+        return "remote_link"
+    return None
+
+
+def _drop_none(properties: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value for key, value in properties.items() if value is not None
+    }

--- a/modelconverter/utils/telemetry.py
+++ b/modelconverter/utils/telemetry.py
@@ -15,7 +15,6 @@ from luxonis_ml.telemetry import (
 )
 
 from modelconverter import __version__
-from modelconverter.utils import get_default_target_version
 from modelconverter.utils.config import (
     Config,
     HailoConfig,
@@ -26,6 +25,9 @@ from modelconverter.utils.config import (
     RVC3Config,
     RVC4Config,
     SingleStageConfig,
+)
+from modelconverter.utils.target_versions import (
+    get_default_target_version,
 )
 from modelconverter.utils.types import Target
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Pillow
-luxonis-ml[data,nn-archive,s3,gcs]>=0.8.5
+luxonis-ml[data,nn_archive,s3,gcs,telemetry]~=0.9.0
 cyclopts~=4.16
 onnx==1.21.0
 onnxruntime

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Pillow
-luxonis-ml[data,nn_archive,s3,gcs,telemetry]~=0.9.0
+# luxonis-ml[data,nn_archive,s3,gcs,telemetry]~=0.9.0
+luxonis-ml[data,nn_archive,s3,gcs,telemetry] @ git+https://github.com/luxonis/luxonis-ml.git@feat/telemetry
 cyclopts~=4.16
 onnx==1.21.0
 onnxruntime

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Pillow
 # luxonis-ml[data,nn_archive,s3,gcs,telemetry]~=0.9.0
-luxonis-ml[data,nn_archive,s3,gcs,telemetry] @ git+https://github.com/luxonis/luxonis-ml.git@feat/telemetry
+luxonis-ml[data,nn_archive,s3,gcs,telemetry] @ git+https://github.com/luxonis/luxonis-ml.git@main
 cyclopts~=4.16
 onnx==1.21.0
 onnxruntime

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Pillow
-# luxonis-ml[data,nn_archive,s3,gcs,telemetry]~=0.9.0
-luxonis-ml[data,nn_archive,s3,gcs,telemetry] @ git+https://github.com/luxonis/luxonis-ml.git@main
+luxonis-ml[data,nn_archive,s3,gcs,telemetry]~=0.9.0
 cyclopts~=4.16
 onnx==1.21.0
 onnxruntime

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 from itertools import chain
@@ -16,6 +17,8 @@ from .test_packages.metrics import (
     ResnetMetric,
     YoloV6Metric,
 )
+
+os.environ.setdefault("LUXONIS_TELEMETRY_ENABLED", "false")
 
 ConvertEnv: TypeAlias = tuple[
     str,

--- a/tests/test_utils/test_telemetry.py
+++ b/tests/test_utils/test_telemetry.py
@@ -13,6 +13,8 @@ from modelconverter.utils.telemetry import (
     MODELCONVERTER_TELEMETRY_DEFAULTS,
     build_conversion_result_properties,
     build_conversion_summary,
+    command_failure_reason_from_exception,
+    command_result_from_exception,
     detect_config_source,
     get_component_telemetry,
 )
@@ -160,6 +162,11 @@ def test_build_conversion_result_properties():
     }
 
 
+def test_command_result_from_exception_treats_system_exit_zero_as_success():
+    assert command_result_from_exception(SystemExit(0)) == "success"
+    assert command_failure_reason_from_exception(SystemExit(0)) is None
+
+
 def test_generate_compose_config_includes_extra_environment():
     compose = yaml.safe_load(
         generate_compose_config(
@@ -183,6 +190,7 @@ def test_get_component_telemetry_uses_modelconverter_defaults(
     monkeypatch.delenv("LUXONIS_TELEMETRY_API_KEY", raising=False)
     monkeypatch.delenv("LUXONIS_TELEMETRY_ENDPOINT", raising=False)
     monkeypatch.delenv("LUXONIS_TELEMETRY_DEBUG", raising=False)
+    monkeypatch.delenv("LUXONIS_TELEMETRY_ENABLED", raising=False)
 
     telemetry = get_component_telemetry()
 

--- a/tests/test_utils/test_telemetry.py
+++ b/tests/test_utils/test_telemetry.py
@@ -1,0 +1,156 @@
+from pathlib import Path
+
+import yaml
+from onnx import checker, helper
+from onnx.onnx_pb import TensorProto
+
+from modelconverter.utils.config import Config
+from modelconverter.utils.docker_utils import generate_compose_config
+from modelconverter.utils.telemetry import (
+    build_conversion_result_properties,
+    build_conversion_summary,
+    detect_config_source,
+)
+from modelconverter.utils.types import Target
+
+
+def _create_dummy_onnx(path: Path) -> None:
+    input_tensor = helper.make_tensor_value_info(
+        "input0", TensorProto.FLOAT, [1, 3, 64, 64]
+    )
+    output_tensor = helper.make_tensor_value_info(
+        "output0", TensorProto.FLOAT, [1, 10]
+    )
+    node = helper.make_node(
+        "Flatten",
+        inputs=["input0"],
+        outputs=["output0"],
+    )
+    graph = helper.make_graph(
+        [node],
+        "DummyModel",
+        [input_tensor],
+        [output_tensor],
+    )
+    model = helper.make_model(graph, producer_name="test")
+    checker.check_model(model)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(model.SerializeToString())
+
+
+def test_build_conversion_summary_rvc4(tmp_path: Path) -> None:
+    model_path = tmp_path / "dummy_model.onnx"
+    calibration_path = tmp_path / "calibration"
+    calibration_path.mkdir()
+    _create_dummy_onnx(model_path)
+
+    cfg = Config(
+        name="dummy",
+        input_model=str(model_path),
+        calibration={"path": str(calibration_path)},
+        keep_intermediate_outputs=False,
+        onnx_simplification=False,
+        onnx_optimizations=False,
+        output_remote_url="s3://bucket/output",
+        intermediate_outputs_remote_url="s3://bucket/intermediate",
+        rvc4={
+            "optimization_level": 3,
+            "quantization_mode": "INT8_STANDARD",
+            "use_per_channel_quantization": True,
+            "use_per_row_quantization": False,
+            "keep_raw_images": True,
+            "htp_socs": ["sm8550", "qcs8550"],
+        },
+    )
+
+    summary = build_conversion_summary(
+        cfg,
+        target=Target.RVC4,
+        config_source="direct_model_input",
+        archive_output_mode="nn_archive",
+        archive_preprocess=False,
+        main_stage_provided=True,
+    )
+
+    assert summary == {
+        "target": "rvc4",
+        "config_source": "direct_model_input",
+        "stage_count_bucket": "1",
+        "is_multistage": False,
+        "main_stage_provided": True,
+        "archive_output_mode": "nn_archive",
+        "archive_preprocess": False,
+        "input_model_format": "onnx",
+        "multiple_input_model_formats": False,
+        "input_count_bucket": "1",
+        "output_count_bucket": "1",
+        "has_calibration": True,
+        "calibration_source": "image_directory",
+        "disable_calibration": False,
+        "keep_intermediate_outputs": False,
+        "disable_onnx_simplification": True,
+        "disable_onnx_optimization": True,
+        "has_remote_output": True,
+        "has_remote_intermediate_output": True,
+        "target_configuration": {
+            "quantization_mode": "int8_standard",
+            "optimization_level": 3,
+            "use_per_channel_quantization": True,
+            "use_per_row_quantization": False,
+            "keep_raw_images": True,
+            "htp_soc_count_bucket": "2_4",
+            "has_quantization_overrides": False,
+        },
+    }
+
+
+def test_detect_config_source():
+    assert detect_config_source("model.onnx", [], None) == "direct_model_input"
+    assert detect_config_source("config.yaml", [], None) == "yaml_config"
+    assert (
+        detect_config_source(None, ["input_model", "model.onnx"], None)
+        == "direct_model_input"
+    )
+    assert detect_config_source("archive.tar.xz", [], object()) == "nn_archive"
+    assert (
+        detect_config_source("archive_dir", [], object())
+        == "archive_directory"
+    )
+
+
+def test_build_conversion_result_properties():
+    properties = build_conversion_result_properties(
+        result="failed",
+        failure_reason="upload_error",
+        duration_ms=1234,
+        output_artifact_count=3,
+        uploaded_output=True,
+        uploaded_intermediate_outputs=False,
+        peak_ram_bytes=2 * 1024 * 1024 * 1024,
+    )
+
+    assert properties == {
+        "result": "failed",
+        "failure_reason": "upload_error",
+        "duration_ms": 1234,
+        "output_artifact_count_bucket": "2_4",
+        "uploaded_output": True,
+        "uploaded_intermediate_outputs": False,
+        "peak_ram_usage_bucket": "1g_4g",
+    }
+
+
+def test_generate_compose_config_includes_extra_environment():
+    compose = yaml.safe_load(
+        generate_compose_config(
+            "luxonis/modelconverter-rvc4:test",
+            extra_environment={
+                "MODELCONVERTER_CONVERSION_RUN_ID": "run-123",
+                "LUXONIS_TELEMETRY_ENABLED": "true",
+            },
+        )
+    )
+
+    environment = compose["services"]["modelconverter"]["environment"]
+    assert environment["MODELCONVERTER_CONVERSION_RUN_ID"] == "run-123"
+    assert environment["LUXONIS_TELEMETRY_ENABLED"] == "true"

--- a/tests/test_utils/test_telemetry.py
+++ b/tests/test_utils/test_telemetry.py
@@ -87,7 +87,6 @@ def test_build_conversion_summary_rvc4(tmp_path: Path) -> None:
         "multiple_input_model_formats": False,
         "input_count_bucket": "1",
         "output_count_bucket": "1",
-        "has_calibration": True,
         "calibration_source": "image_directory",
         "disable_calibration": False,
         "keep_intermediate_outputs": False,

--- a/tests/test_utils/test_telemetry.py
+++ b/tests/test_utils/test_telemetry.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 import yaml
 from onnx import checker, helper
 from onnx.onnx_pb import TensorProto
@@ -7,9 +8,11 @@ from onnx.onnx_pb import TensorProto
 from modelconverter.utils.config import Config
 from modelconverter.utils.docker_utils import generate_compose_config
 from modelconverter.utils.telemetry import (
+    MODELCONVERTER_TELEMETRY_DEFAULTS,
     build_conversion_result_properties,
     build_conversion_summary,
     detect_config_source,
+    get_component_telemetry,
 )
 from modelconverter.utils.types import Target
 
@@ -154,3 +157,25 @@ def test_generate_compose_config_includes_extra_environment():
     environment = compose["services"]["modelconverter"]["environment"]
     assert environment["MODELCONVERTER_CONVERSION_RUN_ID"] == "run-123"
     assert environment["LUXONIS_TELEMETRY_ENABLED"] == "true"
+
+
+def test_get_component_telemetry_uses_modelconverter_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LUXONIS_TELEMETRY_BACKEND", raising=False)
+    monkeypatch.delenv("LUXONIS_TELEMETRY_API_KEY", raising=False)
+    monkeypatch.delenv("LUXONIS_TELEMETRY_ENDPOINT", raising=False)
+    monkeypatch.delenv("LUXONIS_TELEMETRY_DEBUG", raising=False)
+
+    telemetry = get_component_telemetry()
+
+    assert (
+        telemetry._config.backend == MODELCONVERTER_TELEMETRY_DEFAULTS.backend
+    )
+    assert (
+        telemetry._config.api_key == MODELCONVERTER_TELEMETRY_DEFAULTS.api_key
+    )
+    assert (
+        telemetry._config.endpoint
+        == MODELCONVERTER_TELEMETRY_DEFAULTS.endpoint
+    )

--- a/tests/test_utils/test_telemetry.py
+++ b/tests/test_utils/test_telemetry.py
@@ -1,3 +1,5 @@
+import json
+import tarfile
 from pathlib import Path
 
 import pytest
@@ -39,6 +41,15 @@ def _create_dummy_onnx(path: Path) -> None:
     checker.check_model(model)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(model.SerializeToString())
+
+
+def _create_dummy_archive(path: Path, model_path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    config_path = path.parent / "config.json"
+    config_path.write_text(json.dumps({}), encoding="utf-8")
+    with tarfile.open(path, "w:xz") as tar:
+        tar.add(str(model_path), arcname=model_path.name)
+        tar.add(str(config_path), arcname="config.json")
 
 
 def test_build_conversion_summary_rvc4(tmp_path: Path) -> None:
@@ -106,14 +117,21 @@ def test_build_conversion_summary_rvc4(tmp_path: Path) -> None:
     }
 
 
-def test_detect_config_source():
+def test_detect_config_source(tmp_path: Path) -> None:
+    model_path = tmp_path / "dummy_model.onnx"
+    archive_path = tmp_path / "archive.tar.xz"
+    _create_dummy_onnx(model_path)
+    _create_dummy_archive(archive_path, model_path)
+
     assert detect_config_source("model.onnx", [], None) == "direct_model_input"
     assert detect_config_source("config.yaml", [], None) == "yaml_config"
     assert (
         detect_config_source(None, ["input_model", "model.onnx"], None)
         == "direct_model_input"
     )
-    assert detect_config_source("archive.tar.xz", [], object()) == "nn_archive"
+    assert (
+        detect_config_source(str(archive_path), [], object()) == "nn_archive"
+    )
     assert (
         detect_config_source("archive_dir", [], object())
         == "archive_directory"


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

- Adds end-to-end telemetry for `modelconverter convert`, split into three events:
  - command-level capture in the launcher for Docker invocation metadata and overall command outcome in [`modelconverter/__main__.py`](https://github.com/luxonis/modelconverter/blob/feat/telementry/modelconverter/__main__.py#L743)
  - configuration capture once the conversion config is resolved in [`modelconverter/__main__.py`](https://github.com/luxonis/modelconverter/blob/feat/telementry/modelconverter/__main__.py#L212)
  - result capture in a `finally` block with duration, upload status, artifact count, and peak RAM in [`modelconverter/__main__.py`](https://github.com/luxonis/modelconverter/blob/feat/telementry/modelconverter/__main__.py#L330)

- Introduces a dedicated telemetry helper module in [`modelconverter/utils/telemetry.py`](https://github.com/luxonis/modelconverter/blob/feat/telementry/modelconverter/utils/telemetry.py):
  - defines PostHog-backed defaults via `luxonis_ml.telemetry`
  - generates/persists a per-run `MODELCONVERTER_CONVERSION_RUN_ID`
  - builds normalized event payloads for command/configuration/result
  - buckets counts and memory usage to avoid sending raw high-cardinality values
  - classifies failures into `user_interrupt`, `config_error`, `upload_error`, `conversion_error`, or generic runtime failure

- Wires telemetry across Docker boundaries:
  - `docker_exec()` now forwards telemetry-related environment variables into the compose config in [`modelconverter/utils/docker_utils.py`](https://github.com/luxonis/modelconverter/blob/feat/telementry/modelconverter/utils/docker_utils.py#L94)
  - `launcher()` skips duplicate outer event capture when already running inside Docker, so one conversion run keeps one shared run id and cleaner telemetry in [`modelconverter/__main__.py`](https://github.com/luxonis/modelconverter/blob/feat/telementry/modelconverter/__main__.py#L797)

- Refactors target version lookup into a standalone helper in [`modelconverter/utils/target_versions.py`](https://github.com/luxonis/modelconverter/blob/feat/telementry/modelconverter/utils/target_versions.py), then re-exports it through [`modelconverter/utils/__init__.py`](https://github.com/luxonis/modelconverter/blob/feat/telementry/modelconverter/utils/__init__.py).

- Updates dependency requirements in [`requirements.txt`](https://github.com/luxonis/modelconverter/blob/feat/telementry/requirements.txt):
  - bumps `luxonis-ml` from `>=0.8.5` to `~=0.9.0`
  - adds the `telemetry` extra
  - switches `nn-archive` extra naming to `nn_archive`

- Disables telemetry in CI by setting `LUXONIS_TELEMETRY_ENABLED: "false"` across workflow files under [`.github/workflows`](https://github.com/luxonis/modelconverter/tree/feat/telementry/.github/workflows), which keeps tests/publish jobs from emitting telemetry.

- Adds focused telemetry tests in [`tests/test_utils/test_telemetry.py`](https://github.com/luxonis/modelconverter/blob/feat/telementry/tests/test_utils/test_telemetry.py):
  - conversion summary generation
  - config-source detection
  - result-property bucketing
  - Docker env propagation
  - telemetry default initialization

- Example of the new event shape:
```python
{
    "flow_name": "modelconverter_conversion_lifecycle",
    "conversion_run_id": "...",
    "flow_step": "result_recorded",
    "target": "rvc4",
    "config_source": "direct_model_input",
    "result": "success",
    "duration_ms": 1234,
    "uploaded_output": True,
    "peak_ram_usage_bucket": "1g_4g",
}
```

**NOTES:**
- This currently depends on https://github.com/luxonis/luxonis-ml/pull/437. Before merge we need to adjust the requirements.txt accordingly 
- To test out telementry use `--dev` flag so docker image gets rebuilt and actually uses the telementry luxonis-ml branch

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced conversion telemetry and detailed run/result reporting, including duration, peak RAM, artifact/output counts, and improved exit-code handling.
  * Extended Docker build images to include `git` where needed.
* **Bug Fixes**
  * Disabled Luxonis telemetry for CI workflows to keep automated runs consistent.
* **Tests**
  * Added unit tests covering telemetry utilities and compose environment injection.
* **Chores**
  * Updated `luxonis-ml` to use the repository version with telemetry extras.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->