### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/modelconverter_test.yaml
+++ b/.github/workflows/modelconverter_test.yaml
@@ -43,7 +43,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker
-        uses: crazy-max/ghaction-setup-docker@0234bb73ccb40f0c430b795634f9247e2b5c2d23
+        uses: crazy-max/ghaction-setup-docker@6d7cfa65f60a9dda7b46e5513fa982536f3c9877
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,14 +62,14 @@ jobs:
           token_format: access_token
 
       - name: Docker login to GAR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.google-auth.outputs.access_token }}
 
       - name: Docker login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/login-action](https://github.com/docker/login-action)** added a new **[commit](https://github.com/docker/login-action/commit/af1e73f918a031802d376d3c8bbc3fe56130a9b0)** to **[v4.4.0](https://github.com/docker/login-action/releases/tag/v4.4.0)** Tag on 2026-07-03T13:02:31Z
* **[crazy-max/ghaction-setup-docker](https://github.com/crazy-max/ghaction-setup-docker)** added a new **[commit](https://github.com/docker/setup-docker-action/commit/6d7cfa65f60a9dda7b46e5513fa982536f3c9877)** to **[v5.3.0](https://github.com/docker/setup-docker-action/releases/tag/v5.3.0)** Tag on 2026-07-01T13:38:07Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI and release workflows to use newer, pinned Docker-related action versions.
  * No changes to build, test, or publish behavior were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->