### PR TITLE
Fix for a missing device handler in RVC4 benchmark

### DIFF
--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -122,7 +122,10 @@ class RVC4Benchmark(Benchmark):
             )
             content = csv_path.read_text()
             csv_path.unlink()
-        elif self.handler.shell("snpe-dlc-info -h", check=False)[0] == 0:
+        elif (
+            self.handler is not None
+            and self.handler.shell("snpe-dlc-info -h", check=False)[0] == 0
+        ):
             self.handler.shell(f"mkdir -p {self.device_pwd}")
             self.handler.push(model_path, self.device_pwd / "model.dlc")
             device_csv_path = self.device_pwd / "info.csv"
@@ -162,6 +165,12 @@ class RVC4Benchmark(Benchmark):
     def _prepare_raw_inputs(
         self, input_specs: list[InputSpec], num_images: int
     ) -> None:
+        if self.handler is None:
+            raise RuntimeError(
+                "Device handler is not initialized. "
+                "Cannot prepare raw inputs on the device."
+            )
+
         if num_images < 1:
             raise ValueError("num_images must be at least 1.")
 
@@ -286,13 +295,15 @@ class RVC4Benchmark(Benchmark):
         )
         if device_monitor or not dai_benchmark:
             self.handler = create_handler(device_ip, device_adb_id)
+        else:
+            self.handler = None
 
         configuration["device_ip"] = device_ip
         self.device_pwd = Path("/", "data", "modelconverter", self.model_name)
 
         self.monitor = None
         idle_measurements = {}
-        if device_monitor:
+        if device_monitor and self.handler is not None:
             self.monitor = DeviceMonitor(self.handler)
             idle_measurements = self.monitor.get_idle_measurements()
 
@@ -328,7 +339,7 @@ class RVC4Benchmark(Benchmark):
         finally:
             if self.monitor:
                 self.monitor.stop()
-            if not dai_benchmark:
+            if not dai_benchmark and self.handler is not None:
                 # so we don't delete the wrong directory
                 # if `model_name` gets unset for any reason
                 if not self.model_name:
@@ -393,6 +404,10 @@ class RVC4Benchmark(Benchmark):
         )
         logger.info(f"Moving model '{dlc_path.name}' to the device.")
 
+        if self.handler is None:
+            raise RuntimeError(
+                "Handler is not initialized. Cannot benchmark over ADB."
+            )
         self.handler.shell(f"mkdir -p {self.device_pwd}")
         self.handler.push(str(dlc_path), f"{self.device_pwd}/model.dlc")
         self._prepare_raw_inputs(input_specs, num_images)
@@ -570,7 +585,7 @@ class RVC4Benchmark(Benchmark):
         results: list[tuple[Configuration, dict[str, Any]]],
     ) -> list[str]:
         heads = []
-        if self.monitor:
+        if self.monitor is not None:
             heads.append("power_sys (W)")
             heads.append("power_core (W)")
             heads.append("dsp (%)")
@@ -589,7 +604,7 @@ class RVC4Benchmark(Benchmark):
         memory = result.get("ram_used")
         cpu = result.get("cpu_utilization")
 
-        if self.monitor:
+        if self.monitor is not None:
             yield f"{power_sys:.2f}" if power_sys else "[orange3]N/A"
             yield f"{power_core:.2f}" if power_core else "[orange3]N/A"
             yield f"{dsp:.2f}" if dsp else "[orange3]N/A"

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -332,12 +332,12 @@ class RVC4Benchmark(Benchmark):
                 logger.info("Running SNPE benchmark directly on the device...")
                 result = self._benchmark_snpe(self.model_path, **configuration)
 
-            if self.monitor:
+            if self.monitor is not None:
                 result |= self.monitor.get_stats()
                 result |= idle_measurements
             return result
         finally:
-            if self.monitor:
+            if self.monitor is not None:
                 self.monitor.stop()
             if not dai_benchmark and self.handler is not None:
                 # so we don't delete the wrong directory
@@ -414,7 +414,7 @@ class RVC4Benchmark(Benchmark):
 
         logger.info("Starting SNPE benchmark...")
 
-        if self.monitor:
+        if self.monitor is not None:
             self.monitor.start()
 
         try:
@@ -521,7 +521,7 @@ class RVC4Benchmark(Benchmark):
             f"Using {device.getPlatformAsString()} device on IP {device.getDeviceInfo().name}."
         )
 
-        if self.monitor:
+        if self.monitor is not None:
             self.monitor.start()
 
         with dai.Pipeline(device) as pipeline:

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -168,7 +168,7 @@ class RVC4Benchmark(Benchmark):
         if self.handler is None:
             raise RuntimeError(
                 "Device handler is not initialized. "
-                "Cannot prepare raw inputs on the device."
+                "Cannot prepare `.raw` inputs on the device."
             )
 
         if num_images < 1:
@@ -329,7 +329,7 @@ class RVC4Benchmark(Benchmark):
                     "device_monitor",
                 ]:
                     configuration.pop(key, None)
-                logger.info("Running SNPE benchmark over ADB")
+                logger.info("Running SNPE benchmark directly on the device...")
                 result = self._benchmark_snpe(self.model_path, **configuration)
 
             if self.monitor:
@@ -406,7 +406,7 @@ class RVC4Benchmark(Benchmark):
 
         if self.handler is None:
             raise RuntimeError(
-                "Handler is not initialized. Cannot benchmark over ADB."
+                "Handler is not initialized. Cannot benchmark directly on the device."
             )
         self.handler.shell(f"mkdir -p {self.device_pwd}")
         self.handler.push(str(dlc_path), f"{self.device_pwd}/model.dlc")


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Fixes confusing logs and failures when working directly on the device. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Improved logs
- Explicitly checking that the device is initialized before use

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Hardened benchmarking so device-monitor and SNPE operations only run when device access is actually available.
  - Added explicit safeguards and clearer runtime errors for direct-on-device benchmarking without a ready device handler.
  - Fixed benchmark reporting so monitor stats display correctly even if monitor objects are falsy.
  - Improved start/stop and cleanup behavior to avoid attempting remote extraction or on-device preparation when unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->