### PR TITLE
RVC4 `latest` image uses SNPE 2.41.0

### DIFF
--- a/.github/workflows/rvc4_publish.yaml
+++ b/.github/workflows/rvc4_publish.yaml
@@ -25,4 +25,4 @@ jobs:
     with:
       package: rvc4
       version: ${{ matrix.version }}
-      default: "2.32.6"
+      default: "2.41.0"


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Default version is now SNPE 2.41.0 also for the RVC4 publish workflow

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
