### PR TITLE
Added latency info to DAI RVC2 and RVC4 benchmarks

### DIFF
--- a/modelconverter/packages/base_benchmark.py
+++ b/modelconverter/packages/base_benchmark.py
@@ -136,7 +136,7 @@ class Benchmark(ABC):
                 if latency > 100
                 else "green"
             )
-            yield f"[{latency_color}]{latency:.5f}"
+            yield f"[{latency_color}]{latency:.2f}"
 
     def _extra_header(
         self,

--- a/modelconverter/packages/rvc2/benchmark.py
+++ b/modelconverter/packages/rvc2/benchmark.py
@@ -6,6 +6,10 @@ import numpy as np
 
 from modelconverter.packages.base_benchmark import Benchmark, Configuration
 from modelconverter.utils import create_progress_handler, environ
+from modelconverter.utils.log_latency import (
+    RVC2_INFERENCE_LATENCY_RE,
+    parse_inference_latency,
+)
 
 
 class RVC2Benchmark(Benchmark):
@@ -88,58 +92,71 @@ class RVC2Benchmark(Benchmark):
             )
             inputData.addTensor(name, img)
 
-        with dai.Pipeline(device) as pipeline:
-            benchmarkOut = pipeline.create(dai.node.BenchmarkOut)
-            benchmarkOut.setRunOnHost(False)
-            benchmarkOut.setFps(-1)
+        latencies: list[float] = []
 
-            neuralNetwork = pipeline.create(dai.node.NeuralNetwork)
-            if isinstance(model_path, str) or str(model_path).endswith(
-                ".tar.xz"
-            ):
-                neuralNetwork.setNNArchive(modelArhive)
-            elif str(model_path).endswith(".blob"):
-                neuralNetwork.setBlobPath(modelPath)
-            neuralNetwork.setNumInferenceThreads(num_threads)
-
-            benchmarkIn = pipeline.create(dai.node.BenchmarkIn)
-            benchmarkIn.setRunOnHost(False)
-            benchmarkIn.sendReportEveryNMessages(num_messages)
-            benchmarkIn.logReportsAsWarnings(False)
-
-            benchmarkOut.out.link(neuralNetwork.input)
-            neuralNetwork.out.link(benchmarkIn.input)
-
-            outputQueue = benchmarkIn.report.createOutputQueue()
-            inputQueue = benchmarkOut.input.createInputQueue()
-
-            pipeline.start()
-            inputQueue.send(inputData)
-
-            progress, on_tick, should_continue = create_progress_handler(
-                benchmark_time, repetitions
+        def on_log_message(log_message: dai.LogMessage) -> None:
+            latency = parse_inference_latency(
+                log_message, RVC2_INFERENCE_LATENCY_RE
             )
+            if latency is not None:
+                latencies.append(latency)
 
-            fps_list = []
-            avg_latency_list = []
+        callback_id = device.addLogCallback(on_log_message)
+        # RVC2 reports per-inference latency at TRACE level.  Keep TRACE logs
+        # out of stdout; the callback still receives the messages.
+        device.setLogLevel(dai.LogLevel.TRACE)
+        device.setLogOutputLevel(dai.LogLevel.WARN)
 
-            with progress:
-                while pipeline.isRunning() and should_continue():
-                    benchmarkReport = outputQueue.get()
-                    if not isinstance(benchmarkReport, dai.BenchmarkReport):
-                        raise TypeError(
-                            f"Expected BenchmarkReport, got {type(benchmarkReport)}"
-                        )
+        fps_list = []
+        try:
+            with dai.Pipeline(device) as pipeline:
+                benchmarkOut = pipeline.create(dai.node.BenchmarkOut)
+                benchmarkOut.setRunOnHost(False)
+                benchmarkOut.setFps(-1)
 
-                    fps_list.append(benchmarkReport.fps)
-                    avg_latency_list.append(
-                        benchmarkReport.averageLatency * 1000
-                    )
+                neuralNetwork = pipeline.create(dai.node.NeuralNetwork)
+                if isinstance(model_path, str) or str(model_path).endswith(
+                    ".tar.xz"
+                ):
+                    neuralNetwork.setNNArchive(modelArhive)
+                elif str(model_path).endswith(".blob"):
+                    neuralNetwork.setBlobPath(modelPath)
+                neuralNetwork.setNumInferenceThreads(num_threads)
 
-                    on_tick()
+                benchmarkIn = pipeline.create(dai.node.BenchmarkIn)
+                benchmarkIn.setRunOnHost(False)
+                benchmarkIn.sendReportEveryNMessages(num_messages)
+                benchmarkIn.logReportsAsWarnings(False)
 
-            # Currently, the latency measurement is not supported on RVC2 by the depthai library.
-            return {
-                "fps": float(np.mean(fps_list)),
-                "latency": "N/A",
-            }
+                benchmarkOut.out.link(neuralNetwork.input)
+                neuralNetwork.out.link(benchmarkIn.input)
+
+                outputQueue = benchmarkIn.report.createOutputQueue()
+                inputQueue = benchmarkOut.input.createInputQueue()
+
+                pipeline.start()
+                inputQueue.send(inputData)
+
+                progress, on_tick, should_continue = create_progress_handler(
+                    benchmark_time, repetitions
+                )
+
+                with progress:
+                    while pipeline.isRunning() and should_continue():
+                        benchmarkReport = outputQueue.get()
+                        if not isinstance(
+                            benchmarkReport, dai.BenchmarkReport
+                        ):
+                            raise TypeError(
+                                f"Expected BenchmarkReport, got {type(benchmarkReport)}"
+                            )
+
+                        fps_list.append(benchmarkReport.fps)
+                        on_tick()
+        finally:
+            device.removeLogCallback(callback_id)
+
+        return {
+            "fps": float(np.mean(fps_list)),
+            "latency": float(np.mean(latencies)) if latencies else "N/A",
+        }

--- a/modelconverter/packages/rvc4/benchmark.py
+++ b/modelconverter/packages/rvc4/benchmark.py
@@ -27,6 +27,10 @@ from modelconverter.utils import (
     subprocess_run,
 )
 from modelconverter.utils.config import OutputConfig
+from modelconverter.utils.log_latency import (
+    RVC4_INFERENCE_LATENCY_RE,
+    parse_inference_latency,
+)
 
 
 class InputSpec(OutputConfig):
@@ -524,61 +528,77 @@ class RVC4Benchmark(Benchmark):
         if self.monitor is not None:
             self.monitor.start()
 
-        with dai.Pipeline(device) as pipeline:
-            benchmark_out = pipeline.create(dai.node.BenchmarkOut)
-            benchmark_out.setRunOnHost(False)
-            benchmark_out.setFps(-1)
+        latencies: list[float] = []
 
-            neural_network = pipeline.create(dai.node.NeuralNetwork)
-            neural_network.setNNArchive(model_archive)
-
-            neural_network.setBackendProperties(
-                {
-                    "runtime": runtime,
-                    "performance_profile": profile,
-                }
+        def on_log_message(log_message: dai.LogMessage) -> None:
+            latency = parse_inference_latency(
+                log_message, RVC4_INFERENCE_LATENCY_RE
             )
+            if latency is not None:
+                latencies.append(latency)
 
-            neural_network.setNumInferenceThreads(num_threads)
+        callback_id = device.addLogCallback(on_log_message)
+        # RVC4 reports per-inference latency at DEBUG level.  Suppress the
+        # verbose device output while retaining callback delivery.
+        device.setLogLevel(dai.LogLevel.DEBUG)
+        device.setLogOutputLevel(dai.LogLevel.WARN)
 
-            benchmark_in = pipeline.create(dai.node.BenchmarkIn)
-            benchmark_in.setRunOnHost(False)
-            benchmark_in.sendReportEveryNMessages(num_messages)
-            benchmark_in.logReportsAsWarnings(False)
+        fps_list = []
+        try:
+            with dai.Pipeline(device) as pipeline:
+                benchmark_out = pipeline.create(dai.node.BenchmarkOut)
+                benchmark_out.setRunOnHost(False)
+                benchmark_out.setFps(-1)
 
-            benchmark_out.out.link(neural_network.input)
-            neural_network.out.link(benchmark_in.input)
+                neural_network = pipeline.create(dai.node.NeuralNetwork)
+                neural_network.setNNArchive(model_archive)
 
-            output_queue = benchmark_in.report.createOutputQueue()
-            input_queue = benchmark_out.input.createInputQueue()
+                neural_network.setBackendProperties(
+                    {
+                        "runtime": runtime,
+                        "performance_profile": profile,
+                    }
+                )
 
-            pipeline.start()
-            input_queue.send(input_data_packet)
+                neural_network.setNumInferenceThreads(num_threads)
 
-            progress, on_tick, should_continue = create_progress_handler(
-                benchmark_time, repetitions
-            )
+                benchmark_in = pipeline.create(dai.node.BenchmarkIn)
+                benchmark_in.setRunOnHost(False)
+                benchmark_in.sendReportEveryNMessages(num_messages)
+                benchmark_in.logReportsAsWarnings(False)
 
-            fps_list = []
-            avg_latency_list = []
+                benchmark_out.out.link(neural_network.input)
+                neural_network.out.link(benchmark_in.input)
 
-            with progress:
-                while pipeline.isRunning() and should_continue():
-                    benchmark_report = output_queue.get()
-                    if not isinstance(benchmark_report, dai.BenchmarkReport):
-                        raise TypeError(
-                            f"Expected BenchmarkReport, got {type(benchmark_report)}"
-                        )
+                output_queue = benchmark_in.report.createOutputQueue()
+                input_queue = benchmark_out.input.createInputQueue()
 
-                    fps_list.append(benchmark_report.fps)
-                    avg_latency_list.append(
-                        benchmark_report.averageLatency * 1000
-                    )
+                pipeline.start()
+                input_queue.send(input_data_packet)
 
-                    on_tick()
+                progress, on_tick, should_continue = create_progress_handler(
+                    benchmark_time, repetitions
+                )
 
-            # Currently, the latency measurement is only supported on RVC4 when using ImgFrame as the input to the BenchmarkOut which we don't do here.
-            return {"fps": float(np.mean(fps_list)), "latency": "N/A"}
+                with progress:
+                    while pipeline.isRunning() and should_continue():
+                        benchmark_report = output_queue.get()
+                        if not isinstance(
+                            benchmark_report, dai.BenchmarkReport
+                        ):
+                            raise TypeError(
+                                f"Expected BenchmarkReport, got {type(benchmark_report)}"
+                            )
+
+                        fps_list.append(benchmark_report.fps)
+                        on_tick()
+        finally:
+            device.removeLogCallback(callback_id)
+
+        return {
+            "fps": float(np.mean(fps_list)),
+            "latency": float(np.mean(latencies)) if latencies else "N/A",
+        }
 
     def _extra_header(
         self,

--- a/modelconverter/utils/log_latency.py
+++ b/modelconverter/utils/log_latency.py
@@ -1,0 +1,23 @@
+import re
+
+import depthai as dai
+
+RVC2_INFERENCE_LATENCY_RE = re.compile(
+    r"NeuralNetwork inference took\s+'(?P<latency_ms>[0-9]+(?:\.[0-9]+)?)'\s+ms"
+)
+RVC4_INFERENCE_LATENCY_RE = re.compile(
+    r"Executing the model took:\s*(?P<latency_ms>[0-9]+(?:\.[0-9]+)?)\s*ms"
+)
+
+
+def parse_inference_latency(
+    log_message: dai.LogMessage, pattern: re.Pattern[str]
+) -> float | None:
+    """Extract an inference duration in milliseconds from a device log
+    message."""
+    payload = log_message.payload
+    if isinstance(payload, bytes):
+        payload = payload.decode(errors="replace")
+
+    match = pattern.search(str(payload))
+    return float(match.group("latency_ms")) if match else None

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -779,7 +779,7 @@ def test_incorrect_type(key: str, value: str):
         ),
     ],
 )
-def test_modified_onnx(keys: list[str], values: list[str]):
+def test_modified_onnx(keys: list[str], values: list[str], tmp_path: Path):
     overrides: Params = {keys[i]: values[i] for i in range(len(keys))}
     overrides["input_model"] = str(DATA_DIR / "dummy_model.onnx")
     config = Config.get_config(
@@ -791,7 +791,7 @@ def test_modified_onnx(keys: list[str], values: list[str]):
 
     modified_onnx_path = onnx_attach_normalization_to_inputs(
         DATA_DIR / "dummy_model.onnx",
-        DATA_DIR / "dummy_model_modified.onnx",
+        tmp_path / "dummy_model_modified.onnx",
         input_configs,
         reverse_only=False,
     )
@@ -852,9 +852,9 @@ def test_modified_onnx(keys: list[str], values: list[str]):
             assert input_configs[inp].scale_values is None or [1, 1, 1]
 
 
-def test_modified_onnx_noop_returns_original_model():
+def test_modified_onnx_noop_returns_original_model(tmp_path: Path):
     model_path = DATA_DIR / "dummy_model.onnx"
-    modified_path = DATA_DIR / "dummy_model_noop_modified.onnx"
+    modified_path = tmp_path / "dummy_model_noop_modified.onnx"
     config = Config.get_config(
         None,
         {
@@ -1706,9 +1706,7 @@ def test_rvc4_quantization_overrides_accepts_aimet_format():
         },
     )
 
-    assert (
-        config.get("stages.dummy_model.rvc4.snpe_onnx_to_dlc_args") == []
-    )
+    assert config.get("stages.dummy_model.rvc4.snpe_onnx_to_dlc_args") == []
     assert config.get("stages.dummy_model.rvc4.encodings").model_dump(
         mode="json", exclude_none=True
     ) == {

--- a/tests/test_utils/test_modifier.py
+++ b/tests/test_utils/test_modifier.py
@@ -204,7 +204,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     metafunc.parametrize("onnx_file", params)
 
 
-def test_onnx_model(onnx_file: Path):
+def test_onnx_model(onnx_file: Path, tmp_path: Path):
     skip_optimization = onnx_file.stem in EXCEMPT_OPTIMIZATION
     nn_config = onnx_file.parent / f"{onnx_file.stem}_config.json"
     cfg, main_stage_key = get_config(nn_config)
@@ -216,13 +216,14 @@ def test_onnx_model(onnx_file: Path):
     for input_config in input_configs.values():
         input_config.layout = "NCHW"
 
-    modified_onnx = onnx_file.parent / f"{onnx_file.stem}_modified.onnx"
-    onnx_attach_normalization_to_inputs(
-        onnx_file, modified_onnx, input_configs
+    modified_onnx = onnx_attach_normalization_to_inputs(
+        onnx_file,
+        tmp_path / f"{onnx_file.stem}_modified.onnx",
+        input_configs,
     )
 
     modified_optimized_onnx = (
-        onnx_file.parent / f"{onnx_file.stem}_modified_optimized.onnx"
+        tmp_path / f"{onnx_file.stem}_modified_optimized.onnx"
     )
     onnx_modifier = ONNXModifier(
         model_path=modified_onnx,


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

- Capture per-inference latency through DepthAI log callbacks.
- Parse RVC2 TRACE and RVC4 DEBUG inference timing messages.
- Report average latency alongside FPS in benchmark results.
- Display latency values to two decimal places in the CLI.
- Add shared DepthAI log-latency parsing utilities.

Example output from running: `modelconverter benchmark rvc2 --model-path luxonis/yolov6-nano:r2-coco-512x288
`<img width="298" height="205" alt="image" src="https://github.com/user-attachments/assets/43603295-3fa9-4cfa-a745-9239788ef4ec" />


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Benchmark results now report measured average inference latency for RVC2 and RVC4 devices when available.
  * Latency values are displayed with improved readability using two decimal places.

* **Bug Fixes**
  * More accurately captures per-inference latency from device logs.
  * Reports “N/A” when latency data cannot be collected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->