### PR TITLE
Fix issues found reviewing the rootless-conversion branch

### DIFF
--- a/docker/hailo/entrypoint.sh
+++ b/docker/hailo/entrypoint.sh
@@ -28,10 +28,16 @@ trap 'forward_signal TERM' TERM
 trap 'forward_signal INT' INT
 trap 'forward_signal HUP' HUP
 
+# The child runs asynchronously so the traps above stay responsive while it
+# works. Bash then applies two defaults we have to undo: an asynchronous
+# command gets its stdin redirected from /dev/null (hence `<&0`), and, with job
+# control off, its SIGINT/SIGQUIT set to SIG_IGN. SIG_IGN survives execve and
+# CPython only installs its own handler when it inherits SIG_DFL, so without the
+# `trap -` reset a forwarded Ctrl-C would be silently ignored by the converter.
 if [[ $# -eq 0 ]]; then
-    /bin/bash <&0 &
+    ( trap - INT QUIT; exec /bin/bash ) <&0 &
 else
-    modelconverter "$@" &
+    ( trap - INT QUIT; exec modelconverter "$@" ) <&0 &
 fi
 child_pid=$!
 

--- a/docker/rvc2/entrypoint.sh
+++ b/docker/rvc2/entrypoint.sh
@@ -22,10 +22,16 @@ trap 'forward_signal TERM' TERM
 trap 'forward_signal INT' INT
 trap 'forward_signal HUP' HUP
 
+# The child runs asynchronously so the traps above stay responsive while it
+# works. Bash then applies two defaults we have to undo: an asynchronous
+# command gets its stdin redirected from /dev/null (hence `<&0`), and, with job
+# control off, its SIGINT/SIGQUIT set to SIG_IGN. SIG_IGN survives execve and
+# CPython only installs its own handler when it inherits SIG_DFL, so without the
+# `trap -` reset a forwarded Ctrl-C would be silently ignored by the converter.
 if [[ $# -eq 0 ]]; then
-    /bin/bash <&0 &
+    ( trap - INT QUIT; exec /bin/bash ) <&0 &
 else
-    modelconverter "$@" &
+    ( trap - INT QUIT; exec modelconverter "$@" ) <&0 &
 fi
 child_pid=$!
 

--- a/docker/rvc4/entrypoint.sh
+++ b/docker/rvc4/entrypoint.sh
@@ -28,10 +28,16 @@ trap 'forward_signal TERM' TERM
 trap 'forward_signal INT' INT
 trap 'forward_signal HUP' HUP
 
+# The child runs asynchronously so the traps above stay responsive while it
+# works. Bash then applies two defaults we have to undo: an asynchronous
+# command gets its stdin redirected from /dev/null (hence `<&0`), and, with job
+# control off, its SIGINT/SIGQUIT set to SIG_IGN. SIG_IGN survives execve and
+# CPython only installs its own handler when it inherits SIG_DFL, so without the
+# `trap -` reset a forwarded Ctrl-C would be silently ignored by the converter.
 if [[ $# -eq 0 ]]; then
-    /bin/bash <&0 &
+    ( trap - INT QUIT; exec /bin/bash ) <&0 &
 else
-    modelconverter "$@" &
+    ( trap - INT QUIT; exec modelconverter "$@" ) <&0 &
 fi
 child_pid=$!
 

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -51,7 +51,7 @@ from modelconverter.utils.constants import (
     get_cache_dir,
 )
 from modelconverter.utils.general import sanitize_net_name
-from modelconverter.utils.input_staging import stage_inputs
+from modelconverter.utils.input_staging import path_flags_for, stage_inputs
 from modelconverter.utils.nn_archive import generate_archive
 from modelconverter.utils.telemetry import (
     COMMAND_EVENT,
@@ -726,13 +726,21 @@ _CACHE_SUBDIR_DESCRIPTIONS = {
 
 def _dir_stats(path: Path) -> tuple[int, int]:
     """Returns the total size (bytes) and number of files under
-    ``path``."""
+    ``path``.
+
+    Entries that cannot be stat'ed are skipped: a container run killed
+    before its entrypoint could chown the mounts back leaves root-owned
+    files behind, and reporting on the cache must not be what breaks.
+    """
     size = 0
     count = 0
     for f in path.rglob("*"):
-        if f.is_file():
-            size += f.stat().st_size
-            count += 1
+        try:
+            if f.is_file():
+                size += f.stat().st_size
+                count += 1
+        except OSError:
+            continue
     return size, count
 
 
@@ -825,7 +833,21 @@ def cache_clean(
         ):
             console.print("Cache clean cancelled.")
             return
-        shutil.rmtree(root)
+        # Never abort part-way through: files left root-owned by a container
+        # that was killed before its entrypoint could chown the mounts back
+        # would otherwise leave the cache half-deleted.
+        shutil.rmtree(root, ignore_errors=True)
+        if root.exists():
+            remaining, _ = _dir_stats(root)
+            console.print(
+                f"Cleared what could be removed from [cyan]{root}[/] "
+                f"([green]{_human_size(size - remaining)}[/] freed, "
+                f"[yellow]{_human_size(remaining)}[/] left). The remaining "
+                "files are owned by another user, most likely written by a "
+                "container that was killed before it could hand them back. "
+                f"Remove them with [bold]sudo rm -rf {root}[/]."
+            )
+            return
         console.print(
             f":wastebasket:  Cleared cache at [cyan]{root}[/] "
             f"(freed [green]{_human_size(size)}[/])."
@@ -942,7 +964,7 @@ def launcher(
         # Copy user-provided inputs into the hidden cache (which is the only
         # host directory mounted into the container) and rewrite the tokens to
         # their container-side paths.
-        staged_tokens = stage_inputs(list(tokens))
+        staged_tokens = stage_inputs(list(tokens), path_flags_for(command))
 
         docker_exec(
             target.value,

--- a/modelconverter/packages/base_inferer.py
+++ b/modelconverter/packages/base_inferer.py
@@ -8,12 +8,18 @@ import numpy as np
 from loguru import logger
 from typing_extensions import Self
 
-from modelconverter.utils import resolve_path
+from modelconverter.utils import ModelconverterException, resolve_path
 from modelconverter.utils.config import (
     ImageCalibrationConfig,
     SingleStageConfig,
 )
 from modelconverter.utils.types import DataType, Encoding, ResizeMethod
+
+# Marks a directory as holding inference results. `dest` now lives under the
+# host's `./output`, so a rerun may only clear a directory it produced itself;
+# anything else there (a previous conversion's results, say) is not ours to
+# delete.
+RESULTS_MARKER = ".modelconverter_inference"
 
 
 @dataclass
@@ -31,9 +37,18 @@ class Inferer(ABC):
 
     def __post_init__(self):
         if self.dest.exists():
+            if not (self.dest / RESULTS_MARKER).exists() and any(
+                self.dest.iterdir()
+            ):
+                raise ModelconverterException(
+                    f"Refusing to overwrite '{self.dest}': it is not empty "
+                    "and does not hold inference results. Pass a different "
+                    "`--output-dir`."
+                )
             logger.debug(f"Removing existing directory {self.dest}.")
             shutil.rmtree(self.dest)
         self.dest.mkdir(parents=True, exist_ok=True)
+        (self.dest / RESULTS_MARKER).touch()
         self.setup()
 
     @classmethod

--- a/modelconverter/utils/calibration_data.py
+++ b/modelconverter/utils/calibration_data.py
@@ -11,8 +11,8 @@ from .constants import CALIBRATION_DIR, LOADERS
 from .exceptions import ModelconverterException, exit_with
 from .filesystem_utils import (
     download_from_remote,
-    get_input_base,
     get_protocol,
+    resolve_input_path,
 )
 from .image import read_calib_dir
 
@@ -73,7 +73,7 @@ def download_calibration_data(string: str, max_images: int = -1) -> Path:
 
     path = Path(string).expanduser()
     if not path.exists():
-        path = get_input_base() / string
+        path = resolve_input_path(string) or path
     if path.exists():
         if path.is_dir():
             return path

--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import zipfile
 from contextlib import suppress
+from functools import cache
 from pathlib import Path
 from typing import Literal
 from urllib.error import HTTPError, URLError
@@ -32,6 +33,7 @@ from modelconverter.utils.target_versions import (
 from modelconverter.utils.telemetry import telemetry_environment
 
 
+@cache
 def is_rootless_docker() -> bool:
     """Returns whether the active Docker daemon runs in rootless mode.
 
@@ -39,14 +41,22 @@ def is_rootless_docker() -> bool:
     invoking host user, so files written by the container come out owned
     by the host user and must NOT be chowned (doing so would map them to
     an unmapped sub-uid, showing up as ``nobody`` on the host).
+
+    The answer cannot change within a run, so it is cached: this is a
+    round-trip to the daemon on a path that would otherwise take it once
+    per generated compose config.
     """
     try:
         out = subprocess.check_output(
             [docker_bin(), "info", "-f", "{{json .SecurityOptions}}"],
             text=True,
             stderr=subprocess.DEVNULL,
+            # A `DOCKER_HOST` pointing at an unreachable daemon must not hang
+            # the conversion; assuming a rootful daemon is the safe default.
+            timeout=30,
         )
-    except (subprocess.SubprocessError, OSError):
+    # `docker_bin` raises RuntimeError when docker is not installed at all.
+    except (subprocess.SubprocessError, OSError, RuntimeError):
         return False
     return "rootless" in out
 

--- a/modelconverter/utils/filesystem_utils.py
+++ b/modelconverter/utils/filesystem_utils.py
@@ -10,8 +10,9 @@ from modelconverter.utils.constants import SHARED_DIR
 # not exist as-is. It is set to the directory of the active config file while
 # it is being parsed (see `set_input_base`), so that files referenced *inside*
 # a config (calibration data, scripts, encodings, ...) are resolved relative to
-# the config file. Outside of that context it defaults to the cache directory
-# (inside the container) or the current working directory (native runs).
+# the config file. It is tried before -- not instead of -- the default root:
+# the cache directory (inside the container) or the current working directory
+# (native runs). See `get_input_bases`.
 _input_base: ContextVar[Path | None] = ContextVar("input_base", default=None)
 
 
@@ -23,12 +24,30 @@ def set_input_base(base: Path | None) -> None:
     _input_base.set(base)
 
 
-def get_input_base() -> Path:
-    """Returns the base directory for resolving relative local paths."""
+def get_input_bases() -> list[Path]:
+    """Returns the base directories tried, in order, for a relative
+    local path that does not exist as-is.
+
+    The active config's directory comes first, then the default root. The
+    default has to stay as a fallback: a config downloaded from remote
+    storage lands in the cache, so the paths it references relative to the
+    shared root would otherwise stop resolving.
+    """
+    default = SHARED_DIR if "IN_DOCKER" in os.environ else Path.cwd()
     base = _input_base.get()
-    if base is not None:
-        return base
-    return SHARED_DIR if "IN_DOCKER" in os.environ else Path.cwd()
+    if base is None or base == default:
+        return [default]
+    return [base, default]
+
+
+def resolve_input_path(string: str) -> Path | None:
+    """Resolves a relative local path against the input bases, or
+    returns ``None`` if it exists under none of them."""
+    for base in get_input_bases():
+        candidate = base / string
+        if candidate.exists():
+            return candidate
+    return None
 
 
 def resolve_path(string: str, dest: Path) -> Path:
@@ -39,9 +58,10 @@ def resolve_path(string: str, dest: Path) -> Path:
     else:
         path = Path(string).expanduser()
     if not path.exists():
-        path = get_input_base() / string
-    if not path.exists():
-        raise ValueError(f"Path `{string}` does not exist.")
+        resolved = resolve_input_path(string)
+        if resolved is None:
+            raise ValueError(f"Path `{string}` does not exist.")
+        path = resolved
     return path
 
 

--- a/modelconverter/utils/input_staging.py
+++ b/modelconverter/utils/input_staging.py
@@ -12,24 +12,24 @@ then resolves the config's relative references against that copied directory
 (see ``modelconverter.utils.filesystem_utils.set_input_base``).
 """
 
+import atexit
 import errno
 import hashlib
+import inspect
 import os
 import shutil
+import stat as stat_module
 import tempfile
+from collections.abc import Callable, Collection, Iterator
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import yaml
 from loguru import logger
 
 from modelconverter.utils.constants import CONTAINER_SHARED_DIR, get_cache_dir
 from modelconverter.utils.filesystem_utils import get_protocol
-from modelconverter.utils.onnx_compatibility import get_external_data_path
-
-# CLI flags whose following value is a path that should be staged. Values that
-# follow any other flag (e.g. --output-dir, --to) are left untouched.
-_PATH_FLAGS = {"--path", "--config", "--model-path", "--input-path"}
+from modelconverter.utils.onnx_compatibility import get_external_data_paths
 
 # Target names are positional tokens that must not be mistaken for paths.
 _TARGET_NAMES = {"rvc2", "rvc3", "rvc4", "hailo"}
@@ -54,21 +54,62 @@ _KNOWN_EXTS = {
 
 _CONFIG_EXTS = {".yaml", ".yml"}
 
+# Config keys naming an output *destination* rather than an input. Staging one
+# would redirect the results into the throwaway cache directory.
+_DESTINATION_KEYS = {
+    "output_remote_url",
+    "intermediate_outputs_remote_url",
+    "output_dir",
+}
 
-def stage_inputs(tokens: list[str]) -> list[str]:
+# Never copied along when a config's whole parent directory is staged:
+# repository metadata is not a model input and would dominate the copy.
+_IGNORED_DIR_NAMES = {".git"}
+
+
+def path_flags_for(command: Callable[..., Any] | None) -> set[str]:
+    """Returns the CLI flags of ``command`` whose value is a local path.
+
+    Derived from the command signature the launcher has already parsed, so
+    staging follows the CLI rather than duplicating its knowledge: a path
+    option that is added or renamed is picked up without touching this module.
+    """
+    try:
+        parameters = inspect.signature(command).parameters  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return set()
+
+    return {
+        f"--{name.replace('_', '-')}"
+        for name, parameter in parameters.items()
+        if parameter.kind is not parameter.POSITIONAL_ONLY
+        and _is_path_parameter(name, parameter.annotation)
+    }
+
+
+def _is_path_parameter(name: str, annotation: Any) -> bool:
+    return (
+        name in {"path", "config"}
+        or name.endswith("_path")
+        or annotation is Path
+    )
+
+
+def stage_inputs(tokens: list[str], path_flags: Collection[str]) -> list[str]:
     """Copies path arguments among ``tokens`` into the cache and returns
     a new token list with those paths rewritten to their container-side
     locations.
 
-    Non-path tokens, remote URLs and non-existent paths are left
-    untouched.
+    ``path_flags`` are the flags whose value is a path, as returned by
+    L{path_flags_for}. Non-path tokens, remote URLs and non-existent
+    paths are left untouched.
     """
     inputs_dir = get_cache_dir() / "inputs"
     new_tokens: list[str] = []
     prev: str | None = None
 
     for token in tokens:
-        staged = _maybe_stage_token(token, prev, inputs_dir)
+        staged = _maybe_stage_token(token, prev, inputs_dir, path_flags)
         new_tokens.append(staged if staged is not None else token)
         prev = token
 
@@ -76,14 +117,17 @@ def stage_inputs(tokens: list[str]) -> list[str]:
 
 
 def _maybe_stage_token(
-    token: str, prev: str | None, inputs_dir: Path
+    token: str,
+    prev: str | None,
+    inputs_dir: Path,
+    path_flags: Collection[str],
 ) -> str | None:
     """Returns the rewritten token if it should be staged, else
     ``None``."""
     # Handle the ``--flag=value`` form.
     if token.startswith("--") and "=" in token:
         flag, _, value = token.partition("=")
-        if flag in _PATH_FLAGS:
+        if flag in path_flags:
             staged = _stage_value(value, inputs_dir)
             return f"{flag}={staged}" if staged is not None else None
         return None
@@ -92,7 +136,7 @@ def _maybe_stage_token(
         return None
 
     # A value explicitly introduced by a path flag.
-    if prev in _PATH_FLAGS:
+    if prev in path_flags:
         return _stage_value(token, inputs_dir)
 
     # A value introduced by a flag we must not stage, or by an unknown/boolean
@@ -108,6 +152,16 @@ def _maybe_stage_token(
 
 
 def _is_path_like(value: str) -> bool:
+    """Whether a bare positional token should be treated as a local
+    path.
+
+    Bare names are ambiguous: a config-override value such as
+    ``resnet18`` may well collide with a directory of the same name in
+    the current directory, and rewriting it would silently corrupt the
+    override. A token therefore only counts as a path when its *shape*
+    says so, or when it is a file with a known model/config extension.
+    Anything else has to be written with a ``./`` prefix to be staged.
+    """
     if value in _TARGET_NAMES:
         return False
     if get_protocol(value) != "file":
@@ -115,15 +169,11 @@ def _is_path_like(value: str) -> bool:
     p = Path(value).expanduser()
     if not p.exists():
         return False
-    if p.is_dir():
+    if p.is_absolute() or "/" in value or "\\" in value:
         return True
-    has_sep = "/" in value or "\\" in value
-    return (
-        p.is_absolute()
-        or has_sep
-        or value.startswith(("~", "."))
-        or p.suffix.lower() in _KNOWN_EXTS
-    )
+    if value.startswith(("~", ".")):
+        return True
+    return p.is_file() and p.suffix.lower() in _KNOWN_EXTS
 
 
 def _stage_value(value: str, inputs_dir: Path) -> str | None:
@@ -155,8 +205,8 @@ def _stage_value(value: str, inputs_dir: Path) -> str | None:
         dest = _stage_ir_pair(src, inputs_dir)
         return _to_container(dest)
 
-    # ONNX models may store their tensors in a companion file. Preserve the
-    # relative external-data location expected by the model.
+    # ONNX models may store their tensors in companion files. Preserve the
+    # relative external-data locations expected by the model.
     if src.suffix.lower() == ".onnx":
         dest = _stage_onnx(src, inputs_dir)
         return _to_container(dest)
@@ -187,16 +237,15 @@ def _stage_ir_pair(src: Path, inputs_dir: Path) -> Path:
 
 
 def _stage_onnx(src: Path, inputs_dir: Path) -> Path:
-    external_data = get_external_data_path(src)
-    members = [src]
-    if external_data is not None and external_data.exists():
-        members.append(external_data)
+    # A model saved with `all_tensors_to_one_file=False` has one companion
+    # file per tensor, so every location has to be staged, not just the first.
+    external_data = [p for p in get_external_data_paths(src) if p.exists()]
 
-    digest = _hash_files(members)
+    digest = _hash_files([src, *external_data])
     hash_dir = inputs_dir / digest
     destinations = {src: Path(src.name)}
-    if external_data is not None and external_data.exists():
-        destinations[external_data] = external_data.relative_to(src.parent)
+    for data_path in external_data:
+        destinations[data_path] = data_path.relative_to(src.parent)
 
     _stage_file_bundle(destinations, hash_dir)
     return hash_dir / src.name
@@ -278,6 +327,11 @@ def _rewrite_absolute_paths(value: Any, inputs_dir: Path) -> tuple[Any, bool]:
         changed = False
         rewritten = {}
         for key, item in value.items():
+            # An output destination is not an input: staging it would send the
+            # results into the cache instead of where the user asked for them.
+            if key in _DESTINATION_KEYS:
+                rewritten[key] = item
+                continue
             new_item, item_changed = _rewrite_absolute_paths(item, inputs_dir)
             rewritten[key] = new_item
             changed |= item_changed
@@ -306,12 +360,87 @@ def _rewrite_absolute_paths(value: Any, inputs_dir: Path) -> tuple[Any, bool]:
 # that happens to live in a big folder, whose whole parent gets copied).
 _LARGE_DIR_BYTES = 1024**3  # 1 GiB
 
+# Written next to a staged directory to record the source it was copied from,
+# so the previous copy can be dropped once that source changes.
+_SOURCE_MARKER = ".source"
+
+# Written next to a staged directory for as long as this process may be using
+# it, suffixed with the pid so a concurrent run can tell live users from the
+# leftovers of a killed one.
+_IN_USE_PREFIX = ".inuse-"
+
+
+class _InputFile(NamedTuple):
+    relative: str
+    path: Path
+    stat: os.stat_result
+
+
+def _excluded_dirs() -> set[Path]:
+    """Absolute directories that must never be copied into the cache.
+
+    The cache is the copy *destination*, so a source containing it (a
+    config kept in ``$HOME``, say) would otherwise make the copy recurse
+    into its own output. ``./output`` is separately mounted into the
+    container and accumulates the results of every previous run.
+    """
+    return {
+        get_cache_dir().resolve(),
+        (Path.cwd() / "output").resolve(),
+    }
+
+
+def _iter_input_files(src: Path) -> Iterator[_InputFile]:
+    """Yields every file that staging ``src`` copies, with its stat.
+
+    Symlinked sub-directories are followed so that what the container
+    ends up seeing is also what gets fingerprinted; a directory already
+    visited is skipped so a symlink cycle terminates. Anything that is
+    not a regular file (dangling symlink, socket, fifo) is left out.
+    """
+    excluded = _excluded_dirs()
+    visited: set[tuple[int, int]] = set()
+
+    for root, dir_names, file_names in os.walk(src, followlinks=True):
+        root_path = Path(root)
+        dir_names[:] = [
+            name
+            for name in dir_names
+            if name not in _IGNORED_DIR_NAMES
+            and (root_path / name).resolve() not in excluded
+            and _first_visit(root_path / name, visited)
+        ]
+        for name in file_names:
+            path = root_path / name
+            try:
+                file_stat = path.stat()
+            except OSError:
+                continue
+            if stat_module.S_ISREG(file_stat.st_mode):
+                yield _InputFile(
+                    path.relative_to(src).as_posix(), path, file_stat
+                )
+
+
+def _first_visit(directory: Path, visited: set[tuple[int, int]]) -> bool:
+    try:
+        directory_stat = directory.stat()
+    except OSError:
+        return False
+    key = (directory_stat.st_dev, directory_stat.st_ino)
+    if key in visited:
+        return False
+    visited.add(key)
+    return True
+
 
 def _stage_dir(src: Path, inputs_dir: Path) -> Path:
-    digest = _hash_dir(src)
-    dest = inputs_dir / digest / src.name
+    files = sorted(_iter_input_files(src), key=lambda f: f.relative)
+    digest = _hash_dir(src, files)
+    digest_dir = inputs_dir / digest
+    dest = digest_dir / src.name
     if not dest.exists():
-        size = sum(f.stat().st_size for f in src.rglob("*") if f.is_file())
+        size = sum(f.stat.st_size for f in files)
         if size > _LARGE_DIR_BYTES:
             logger.warning(
                 f"Caching a large directory {src} ({_human_size(size)}). "
@@ -321,17 +450,105 @@ def _stage_dir(src: Path, inputs_dir: Path) -> Path:
                 "`modelconverter cache clean` to reclaim space."
             )
         _log_copy(src, size)
-        dest.parent.mkdir(parents=True, exist_ok=True)
+        digest_dir.mkdir(parents=True, exist_ok=True)
         tmp_root = Path(
-            tempfile.mkdtemp(prefix=f".{src.name}.tmp-", dir=dest.parent)
+            tempfile.mkdtemp(prefix=f".{src.name}.tmp-", dir=digest_dir)
         )
         tmp_dest = tmp_root / src.name
         try:
-            shutil.copytree(src, tmp_dest)
+            _copy_input_files(files, tmp_dest)
             _publish_directory(tmp_dest, dest)
         finally:
             shutil.rmtree(tmp_root, ignore_errors=True)
+    _record_source(src, digest_dir)
+    _mark_in_use(digest_dir)
+    _prune_superseded_stagings(src, digest_dir, inputs_dir)
     return dest
+
+
+def _copy_input_files(files: list[_InputFile], dest: Path) -> None:
+    """Copies the enumerated files under ``dest``.
+
+    A config's whole parent directory is staged, so it routinely holds
+    files that have nothing to do with the model -- root-owned leftovers
+    of an earlier container run, for instance. Failing the conversion
+    over one of those would be worse than leaving it out; if it really
+    was an input, the container reports it as missing.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    for file in files:
+        target = dest / file.relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            shutil.copy2(file.path, target)
+        except OSError as exc:
+            logger.warning(f"Skipping unreadable file {file.path}: {exc}")
+
+
+def _record_source(src: Path, digest_dir: Path) -> None:
+    marker = digest_dir / _SOURCE_MARKER
+    if not marker.exists():
+        _atomic_write_text(marker, str(src))
+
+
+def _mark_in_use(digest_dir: Path) -> None:
+    """Claims ``digest_dir`` for the lifetime of this process."""
+    marker = digest_dir / f"{_IN_USE_PREFIX}{os.getpid()}"
+    try:
+        marker.touch()
+    except OSError:
+        return
+    atexit.register(marker.unlink, missing_ok=True)
+
+
+def _is_in_use(entry: Path) -> bool:
+    """Whether a live process has claimed ``entry``.
+
+    The container reads its staged inputs throughout the conversion, so
+    an entry another run is still using must survive even once its
+    source has changed. Claims left behind by a killed process name a
+    pid that no longer exists and are cleaned up here.
+    """
+    in_use = False
+    for marker in entry.glob(f"{_IN_USE_PREFIX}*"):
+        try:
+            pid = int(marker.name.removeprefix(_IN_USE_PREFIX))
+        except ValueError:
+            continue
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            marker.unlink(missing_ok=True)
+        except OSError:
+            # The pid exists but is not ours to signal.
+            in_use = True
+        else:
+            in_use = True
+    return in_use
+
+
+def _prune_superseded_stagings(
+    src: Path, keep: Path, inputs_dir: Path
+) -> None:
+    """Removes staged copies of ``src`` made for older content.
+
+    A directory digest covers file modification times, so editing
+    anything under ``src`` yields a new entry; without this the cache
+    would keep every copy it ever made of that directory.
+    """
+    source = str(src)
+    for entry in inputs_dir.iterdir():
+        if entry == keep or not entry.is_dir():
+            continue
+        try:
+            if (entry / _SOURCE_MARKER).read_text() != source:
+                continue
+        except OSError:
+            continue
+        if _is_in_use(entry):
+            continue
+        logger.debug(f"Removing superseded staged copy of {src} at {entry}")
+        shutil.rmtree(entry, ignore_errors=True)
 
 
 def _to_container(dest: Path) -> str:
@@ -358,16 +575,18 @@ def _hash_files(paths: list[Path]) -> str:
     return h.hexdigest()[:16]
 
 
-def _hash_dir(path: Path) -> str:
+def _hash_dir(path: Path, files: list[_InputFile] | None = None) -> str:
     """Fast content-fingerprint of a directory based on the relative
-    paths, sizes and modification times of its files."""
+    paths, sizes and modification times of the files that are staged."""
+    if files is None:
+        files = sorted(_iter_input_files(path), key=lambda f: f.relative)
     h = hashlib.sha256()
     h.update(path.name.encode())
-    for f in sorted(path.rglob("*")):
-        if f.is_file():
-            stat = f.stat()
-            rel = f.relative_to(path).as_posix()
-            h.update(f"{rel}\0{stat.st_size}\0{stat.st_mtime_ns}".encode())
+    for file in files:
+        h.update(
+            f"{file.relative}\0{file.stat.st_size}\0"
+            f"{file.stat.st_mtime_ns}".encode()
+        )
     return h.hexdigest()[:16]
 
 

--- a/modelconverter/utils/onnx_compatibility.py
+++ b/modelconverter/utils/onnx_compatibility.py
@@ -64,29 +64,49 @@ def save_onnx_model(
 
     onnx.save(model, str(output_path))
 
-def get_external_data_path(model_path: str | Path) -> Path | None:
+
+def get_external_data_paths(model_path: str | Path) -> list[Path]:
+    """Returns every companion file holding the model's external tensor
+    data.
+
+    A model saved with ``all_tensors_to_one_file=False`` keeps one file
+    per tensor, so there is not necessarily just one.
+    """
     model_path = Path(model_path)
     model = onnx.load(str(model_path), load_external_data=False)
     model_dir = model_path.parent.resolve()
 
     tensors = list(model.graph.initializer)
     tensors.extend(
-        sparse_tensor.values for sparse_tensor in model.graph.sparse_initializer
+        sparse_tensor.values
+        for sparse_tensor in model.graph.sparse_initializer
     )
     tensors.extend(
-        sparse_tensor.indices for sparse_tensor in model.graph.sparse_initializer
+        sparse_tensor.indices
+        for sparse_tensor in model.graph.sparse_initializer
     )
+
+    paths: list[Path] = []
     for tensor in tensors:
-        if uses_external_data(tensor):
-            location = ExternalDataInfo(tensor).location
-            if location:
-                candidate = (model_path.parent / location).resolve()
-                try:
-                    candidate.relative_to(model_dir)
-                except ValueError as exc:
-                    raise ValueError(
-                        "ONNX external data location must stay within the "
-                        f"model directory: {location}"
-                    ) from exc
-                return candidate
-    return None
+        if not uses_external_data(tensor):
+            continue
+        location = ExternalDataInfo(tensor).location
+        if not location:
+            continue
+        candidate = (model_path.parent / location).resolve()
+        try:
+            candidate.relative_to(model_dir)
+        except ValueError as exc:
+            raise ValueError(
+                "ONNX external data location must stay within the "
+                f"model directory: {location}"
+            ) from exc
+        if candidate not in paths:
+            paths.append(candidate)
+    return paths
+
+
+def get_external_data_path(model_path: str | Path) -> Path | None:
+    """Returns the first companion file holding external tensor data, if
+    any."""
+    return next(iter(get_external_data_paths(model_path)), None)

--- a/tests/test_utils/test_docker_entrypoint.py
+++ b/tests/test_utils/test_docker_entrypoint.py
@@ -1,12 +1,62 @@
 import os
+import shutil
+import signal
 import subprocess
 import time
 from pathlib import Path
 
+import pytest
 
+ENTRYPOINT = Path(__file__).parents[2] / "docker" / "rvc2" / "entrypoint.sh"
+
+# The entrypoint is a bash script with a `#!/bin/bash` shebang. That path is
+# guaranteed inside the image but not on every developer machine, so the tests
+# invoke it through whichever bash is on PATH instead of relying on the shebang.
+_BASH = shutil.which("bash")
+
+pytestmark = pytest.mark.skipif(_BASH is None, reason="bash is not available")
+
+BASH = _BASH or "bash"
+
+
+def _fake_modelconverter(tmp_path: Path, body: str) -> dict[str, str]:
+    """Puts a fake ``modelconverter`` on PATH and returns the
+    environment to run the entrypoint with."""
+    executable = tmp_path / "modelconverter"
+    executable.write_text(f"#!/usr/bin/env bash\n{body}")
+    executable.chmod(0o755)
+    return {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
+
+
+def _wait_for(path: Path, timeout: float = 5) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def test_entrypoint_gives_the_command_a_real_stdin(tmp_path: Path) -> None:
+    env = _fake_modelconverter(tmp_path, 'read -r line\nexit "$line"\n')
+
+    result = subprocess.run(
+        [BASH, str(ENTRYPOINT), "convert", "rvc2"],
+        input="7\n",
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 7
+
+
+@pytest.mark.skipif(
+    not Path("/bin/bash").exists(), reason="/bin/bash is not available"
+)
 def test_entrypoint_keeps_interactive_shell_stdin() -> None:
     result = subprocess.run(
-        ["docker/rvc2/entrypoint.sh"],
+        [BASH, str(ENTRYPOINT)],
         input="exit 7\n",
         text=True,
         check=False,
@@ -15,39 +65,34 @@ def test_entrypoint_keeps_interactive_shell_stdin() -> None:
     assert result.returncode == 7
 
 
-def test_entrypoint_forwards_sigterm_and_waits_for_child_cleanup(
-    tmp_path: Path,
+@pytest.mark.parametrize(
+    ("sent", "exit_code"), [(signal.SIGTERM, 42), (signal.SIGINT, 130)]
+)
+def test_entrypoint_forwards_signals_and_waits_for_child_cleanup(
+    tmp_path: Path, sent: signal.Signals, exit_code: int
 ) -> None:
+    signal_name = sent.name.removeprefix("SIG")
     signal_file = tmp_path / "signal"
     ready_file = tmp_path / "ready"
-    executable = tmp_path / "modelconverter"
-    executable.write_text(
-        "#!/bin/bash\n"
-        "trap 'printf TERM > \"$SIGNAL_FILE\"; exit 42' TERM\n"
+    env = _fake_modelconverter(
+        tmp_path,
+        f"trap 'printf {signal_name} > \"$SIGNAL_FILE\"; exit {exit_code}' "
+        f"{signal_name}\n"
         'printf ready > "$READY_FILE"\n'
-        "while true; do sleep 0.05; done\n"
+        "while true; do sleep 0.05; done\n",
     )
-    executable.chmod(0o755)
-    env = {
-        **os.environ,
-        "PATH": f"{tmp_path}:{os.environ['PATH']}",
-        "READY_FILE": str(ready_file),
-        "SIGNAL_FILE": str(signal_file),
-    }
+    env |= {"READY_FILE": str(ready_file), "SIGNAL_FILE": str(signal_file)}
 
     process = subprocess.Popen(
-        ["docker/rvc2/entrypoint.sh", "convert", "rvc2"],
+        [BASH, str(ENTRYPOINT), "convert", "rvc2"],
         env=env,
     )
     try:
-        deadline = time.monotonic() + 5
-        while not ready_file.exists() and time.monotonic() < deadline:
-            time.sleep(0.01)
-        assert ready_file.exists()
+        assert _wait_for(ready_file)
 
-        process.terminate()
-        assert process.wait(timeout=5) == 42
-        assert signal_file.read_text() == "TERM"
+        process.send_signal(sent)
+        assert process.wait(timeout=5) == exit_code
+        assert signal_file.read_text() == signal_name
     finally:
         if process.poll() is None:
             process.kill()

--- a/tests/test_utils/test_input_staging.py
+++ b/tests/test_utils/test_input_staging.py
@@ -1,4 +1,6 @@
 import shutil
+import subprocess
+import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -36,6 +38,29 @@ def _external_onnx(path: Path) -> Path:
     return external_data
 
 
+def _multi_file_external_onnx(path: Path) -> list[Path]:
+    """Saves a model whose tensors each land in their own companion
+    file."""
+    tensors = [
+        numpy_helper.from_array(
+            np.asarray([1.0, 2.0], dtype=np.float32), name="first"
+        ),
+        numpy_helper.from_array(
+            np.asarray([3.0, 4.0], dtype=np.float32), name="second"
+        ),
+    ]
+    graph = helper.make_graph([], "external", [], [], tensors)
+    model = helper.make_model(graph)
+    onnx.save_model(
+        model,
+        path,
+        save_as_external_data=True,
+        all_tensors_to_one_file=False,
+        size_threshold=0,
+    )
+    return sorted(p for p in path.parent.iterdir() if p != path)
+
+
 def test_stages_onnx_external_data(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -46,7 +71,7 @@ def test_stages_onnx_external_data(
     monkeypatch.setattr(input_staging, "get_cache_dir", lambda: cache_dir)
 
     staged_tokens = input_staging.stage_inputs(
-        ["--model-path", str(model_path)]
+        ["--model-path", str(model_path)], {"--model-path"}
     )
 
     staged_model = _host_staged_path(staged_tokens[1], cache_dir)
@@ -54,6 +79,27 @@ def test_stages_onnx_external_data(
     assert staged_model.with_name(external_data.name).read_bytes() == (
         external_data.read_bytes()
     )
+
+
+def test_stages_every_external_data_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_dir = tmp_path / "cache"
+    model_path = tmp_path / "models" / "model.onnx"
+    model_path.parent.mkdir()
+    external_data = _multi_file_external_onnx(model_path)
+    assert len(external_data) > 1
+    monkeypatch.setattr(input_staging, "get_cache_dir", lambda: cache_dir)
+
+    staged_tokens = input_staging.stage_inputs(
+        ["--model-path", str(model_path)], {"--model-path"}
+    )
+
+    staged_model = _host_staged_path(staged_tokens[1], cache_dir)
+    for data_path in external_data:
+        assert staged_model.with_name(data_path.name).read_bytes() == (
+            data_path.read_bytes()
+        )
 
 
 def test_stages_and_rewrites_absolute_config_paths(
@@ -92,7 +138,9 @@ def test_stages_and_rewrites_absolute_config_paths(
     )
     monkeypatch.setattr(input_staging, "get_cache_dir", lambda: cache_dir)
 
-    staged_tokens = input_staging.stage_inputs(["--config", str(config_path)])
+    staged_tokens = input_staging.stage_inputs(
+        ["--config", str(config_path)], {"--config"}
+    )
 
     staged_config = _host_staged_path(staged_tokens[1], cache_dir)
     rewritten = yaml.safe_load(staged_config.read_text())
@@ -110,6 +158,226 @@ def test_stages_and_rewrites_absolute_config_paths(
         staged_config.with_name(relative_model.name).read_bytes()
         == b"relative"
     )
+
+
+def test_output_destinations_are_left_alone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_dir = tmp_path / "cache"
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    destination = tmp_path / "nas"
+    destination.mkdir()
+    model = tmp_path / "models" / "model.onnx"
+    model.parent.mkdir()
+    model.write_bytes(b"model")
+
+    config_path = config_dir / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "input_model": str(model),
+                "output_remote_url": str(destination),
+                "intermediate_outputs_remote_url": str(destination),
+            }
+        )
+    )
+    monkeypatch.setattr(input_staging, "get_cache_dir", lambda: cache_dir)
+
+    staged_tokens = input_staging.stage_inputs(
+        ["--config", str(config_path)], {"--config"}
+    )
+
+    rewritten = yaml.safe_load(
+        _host_staged_path(staged_tokens[1], cache_dir).read_text()
+    )
+    assert rewritten["input_model"].startswith(
+        f"{CONTAINER_SHARED_DIR}/inputs/"
+    )
+    assert rewritten["output_remote_url"] == str(destination)
+    assert rewritten["intermediate_outputs_remote_url"] == str(destination)
+
+
+def test_bare_names_are_not_mistaken_for_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(input_staging, "get_cache_dir", lambda: cache_dir)
+    monkeypatch.chdir(tmp_path)
+    # Both a config-override value and the subcommand itself collide with a
+    # directory in the working directory.
+    (tmp_path / "resnet18").mkdir()
+    (tmp_path / "convert").mkdir()
+    tokens = ["convert", "rvc4", "name", "resnet18"]
+
+    assert input_staging.stage_inputs(tokens, {"--path"}) == tokens
+    assert not cache_dir.exists()
+
+
+def test_relative_paths_are_still_staged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(input_staging, "get_cache_dir", lambda: cache_dir)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "calibration").mkdir()
+    (tmp_path / "calibration" / "image.jpg").write_bytes(b"image")
+
+    staged_tokens = input_staging.stage_inputs(
+        ["convert", "rvc4", "calibration.path", "./calibration"], {"--path"}
+    )
+
+    assert staged_tokens[3].startswith(f"{CONTAINER_SHARED_DIR}/inputs/")
+
+
+def test_staging_a_config_next_to_the_cache_does_not_recurse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    cache_dir = home / ".cache" / "modelconverter"
+    # An earlier run already populated the cache that now sits inside the
+    # directory being staged.
+    (cache_dir / "inputs" / "old").mkdir(parents=True)
+    (cache_dir / "inputs" / "old" / "junk.bin").write_bytes(b"junk")
+    monkeypatch.setattr(input_staging, "get_cache_dir", lambda: cache_dir)
+
+    (home / "model.onnx").write_bytes(b"model")
+    config_path = home / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"input_model": "model.onnx"}))
+
+    staged_tokens = input_staging.stage_inputs(
+        ["--path", str(config_path)], {"--path"}
+    )
+
+    staged_config = _host_staged_path(staged_tokens[1], cache_dir)
+    assert (staged_config.parent / "model.onnx").read_bytes() == b"model"
+    assert not (staged_config.parent / ".cache").exists()
+
+
+def test_unusable_files_do_not_abort_staging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_dir = tmp_path / "cache"
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    (config_dir / "model.onnx").write_bytes(b"model")
+    (config_dir / "dangling").symlink_to(tmp_path / "nowhere")
+    config_path = config_dir / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"input_model": "model.onnx"}))
+    monkeypatch.setattr(input_staging, "get_cache_dir", lambda: cache_dir)
+
+    staged_tokens = input_staging.stage_inputs(
+        ["--path", str(config_path)], {"--path"}
+    )
+
+    staged_config = _host_staged_path(staged_tokens[1], cache_dir)
+    assert (staged_config.parent / "model.onnx").read_bytes() == b"model"
+    assert not (staged_config.parent / "dangling").exists()
+
+
+def test_directory_digest_covers_symlinked_subdirectories(
+    tmp_path: Path,
+) -> None:
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "image.jpg").write_bytes(b"first")
+    src = tmp_path / "configs"
+    src.mkdir()
+    (src / "data").symlink_to(data, target_is_directory=True)
+
+    before = input_staging._hash_dir(src)
+    (data / "image.jpg").write_bytes(b"second version")
+    after = input_staging._hash_dir(src)
+
+    assert before != after
+
+
+def test_restaging_a_changed_directory_replaces_the_previous_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_dir = tmp_path / "cache"
+    inputs_dir = cache_dir / "inputs"
+    monkeypatch.setattr(input_staging, "get_cache_dir", lambda: cache_dir)
+    src = tmp_path / "calibration"
+    src.mkdir()
+    (src / "image.jpg").write_bytes(b"first")
+
+    first = input_staging._stage_dir(src, inputs_dir)
+    # The run that staged the first copy has exited, dropping its claim.
+    for marker in first.parent.glob(f"{input_staging._IN_USE_PREFIX}*"):
+        marker.unlink()
+
+    (src / "image.jpg").write_bytes(b"second version")
+    second = input_staging._stage_dir(src, inputs_dir)
+
+    assert first != second
+    assert not first.exists()
+    assert (second / "image.jpg").read_bytes() == b"second version"
+    assert [entry.name for entry in inputs_dir.iterdir()] == [
+        second.parent.name
+    ]
+
+
+def test_staged_copies_still_in_use_are_not_pruned(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_dir = tmp_path / "cache"
+    inputs_dir = cache_dir / "inputs"
+    monkeypatch.setattr(input_staging, "get_cache_dir", lambda: cache_dir)
+    src = tmp_path / "calibration"
+    src.mkdir()
+    (src / "image.jpg").write_bytes(b"first")
+
+    first = input_staging._stage_dir(src, inputs_dir)
+    # Stand in for a container still reading the first copy: this process
+    # claimed it, and `_stage_dir` registers that claim under its own pid.
+    assert list(first.parent.glob(f"{input_staging._IN_USE_PREFIX}*"))
+
+    (src / "image.jpg").write_bytes(b"second version")
+    second = input_staging._stage_dir(src, inputs_dir)
+
+    assert first != second
+    assert (first / "image.jpg").read_bytes() == b"first"
+    assert (second / "image.jpg").read_bytes() == b"second version"
+
+
+def test_staged_copies_claimed_by_dead_processes_are_pruned(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_dir = tmp_path / "cache"
+    inputs_dir = cache_dir / "inputs"
+    monkeypatch.setattr(input_staging, "get_cache_dir", lambda: cache_dir)
+    src = tmp_path / "calibration"
+    src.mkdir()
+    (src / "image.jpg").write_bytes(b"first")
+
+    first = input_staging._stage_dir(src, inputs_dir)
+    # Re-stamp the claim with a pid that is guaranteed not to be running.
+    dead_pid = subprocess.Popen([sys.executable, "-c", ""])
+    dead_pid.wait()
+    for marker in first.parent.glob(f"{input_staging._IN_USE_PREFIX}*"):
+        marker.unlink()
+    (first.parent / f"{input_staging._IN_USE_PREFIX}{dead_pid.pid}").touch()
+
+    (src / "image.jpg").write_bytes(b"second version")
+    second = input_staging._stage_dir(src, inputs_dir)
+
+    assert first != second
+    assert not first.exists()
+    assert (second / "image.jpg").read_bytes() == b"second version"
+
+
+def test_path_flags_come_from_the_command_signature() -> None:
+    from modelconverter.__main__ import convert, infer
+
+    assert input_staging.path_flags_for(convert) == {"--path"}
+    assert input_staging.path_flags_for(infer) == {
+        "--config",
+        "--input-path",
+        "--model-path",
+        "--path",
+    }
 
 
 def test_interrupted_file_copy_does_not_publish_partial_cache_entry(
@@ -171,12 +439,14 @@ def test_interrupted_directory_copy_does_not_publish_partial_entry(
     inputs_dir = tmp_path / "cache" / "inputs"
     expected = inputs_dir / input_staging._hash_dir(src) / src.name
 
-    def interrupt_copytree(source: Path, dest: Path) -> None:
-        Path(dest).mkdir()
-        (Path(dest) / "image.jpg").write_bytes(b"partial")
+    def interrupt_copy(
+        files: list[input_staging._InputFile], dest: Path
+    ) -> None:
+        dest.mkdir(parents=True)
+        (dest / "image.jpg").write_bytes(b"partial")
         raise KeyboardInterrupt
 
-    monkeypatch.setattr(shutil, "copytree", interrupt_copytree)
+    monkeypatch.setattr(input_staging, "_copy_input_files", interrupt_copy)
 
     with pytest.raises(KeyboardInterrupt):
         input_staging._stage_dir(src, inputs_dir)
@@ -194,13 +464,15 @@ def test_concurrent_directory_staging_publishes_one_complete_entry(
     (src / "two.jpg").write_bytes(b"two")
     inputs_dir = tmp_path / "cache" / "inputs"
     barrier = threading.Barrier(2)
-    real_copytree = shutil.copytree
+    real_copy = input_staging._copy_input_files
 
-    def synchronized_copytree(source: Path, dest: Path) -> Path:
+    def synchronized_copy(
+        files: list[input_staging._InputFile], dest: Path
+    ) -> None:
         barrier.wait(timeout=5)
-        return real_copytree(source, dest)
+        real_copy(files, dest)
 
-    monkeypatch.setattr(shutil, "copytree", synchronized_copytree)
+    monkeypatch.setattr(input_staging, "_copy_input_files", synchronized_copy)
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         results = list(


### PR DESCRIPTION
Applies the 15 verified findings from an `xhigh` code review of `feat/no-root` (vs `main`). Targets `feat/no-root` so it can be folded in before that branch merges.

## Input staging (`modelconverter/utils/input_staging.py`)

| Problem | Fix |
| --- | --- |
| Any bare token naming an existing directory was treated as a path, so a config-override value like `resnet18` — or the `convert` subcommand itself — was silently rewritten to a cache path | Bare names now need a `./` prefix; shape or a known extension decides |
| `_PATH_FLAGS` re-encoded, as a literal set, what the parsed CLI signature already knows | Derived from the command signature via `path_flags_for(command)` |
| `copytree` recursed into its own output when the source contained the cache (config kept in `$HOME`) | Files are enumerated once and copied explicitly; the cache is excluded |
| A dangling symlink or unreadable leftover aborted the whole conversion | Non-regular files are skipped; unreadable ones are warned about, not fatal |
| `_hash_dir` used `rglob`, which does not follow symlinked sub-dirs, while `copytree` dereferenced them — so swapping calibration data behind a symlink silently reused the stale copy | Hash and copy share one enumeration that follows symlinks (with a cycle guard) |
| Cache grew by one copy of the project per run (mtime-keyed digest + the `./output` results dir being copied) | `./output`, `.git` and the cache are excluded; superseded copies of a source are pruned |
| `output_remote_url` and friends were rewritten into the cache, so results went to the throwaway dir | Destination keys are left alone |
| Only the first ONNX external-data file was staged | All of them (`get_external_data_paths`) |

Pruning skips any copy claimed by a **live** process, so a concurrent conversion cannot lose its inputs mid-run.

## Entrypoints (rvc2, rvc4, hailo)

Both regressions come from swapping `exec modelconverter` for a backgrounded child:

- **stdin** — bash points an async command's stdin at `/dev/null`, so `modelconverter shell` read EOF and exited instead of opening a shell. Fixed with `<&0` (the zero-arg branch already had it; the argument branch did not).
- **SIGINT** — bash sets SIGINT/SIGQUIT to `SIG_IGN` for async commands when job control is off, and `SIG_IGN` survives `execve`, so CPython never installed its handler and Ctrl-C was ignored; the entrypoint then spun in `wait` until Docker SIGKILLed it. Fixed by resetting the traps in a subshell that then `exec`s.

Verified empirically — `SigIgn` goes `0x6` → `0x0`, and the child now dies on a forwarded SIGINT.

## Elsewhere

- `infer` writes to the host's `./output` now, and `Inferer.__post_init__` rmtree'd it — an inference run could delete a previous conversion's model and logs. It now refuses to clear a directory that does not hold inference results.
- Relative paths inside a config downloaded from remote storage stopped resolving against the shared root; the default root is a fallback again.
- `cache clean` aborted part-way (leaving the cache half-deleted) and `cache info` raised on root-owned leftovers — the two commands documented as the recovery path.
- `docker info` gained a timeout, catches the "not installed" `RuntimeError`, and is cached.

## Tests

The two entrypoint tests added on this branch were **red on any host without `/bin/bash`** (e.g. NixOS) and when pytest ran from another directory. They now go through `bash` at an absolute path, and cover the stdin and SIGINT regressions the previous versions missed — both fail against the pre-fix entrypoint (stdin returns 2 instead of 7; SIGINT times out).

`tests/test_utils`: **114 passed, 1 skipped** (the skip is the `/bin/bash`-only interactive case). `pre-commit run --all-files` clean; pyright unchanged from base (76 pre-existing, 0 new).

`tests/test_packages` / `tests/test_benchmark` were not usable as a signal here — they shell out to the `modelconverter` console script, which on this machine resolves to a different worktree, and they fail identically on the unmodified base at `docker_build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)