### PR TITLE
Remove the semver check and tighten the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ If you prefer not to share your models with the cloud, you can run the conversio
 
 ### Official Docker Images
 
-We provide official Docker images only for RVC2 and RVC3 platforms.
-Images for Hailo and RVC4 need to be built manually, as described in the [Build Instructions](#build-instructions) section.
+We provide official Docker images for `RVC2`, `RVC3` and `RVC4` platforms.
+Images for Hailo need to be built manually, as described in the [Build Instructions](#build-instructions) section.
 
 The following images are available on [Luxonis GitHub Container Registry](https://github.com/orgs/luxonis/packages?tab=packages&q=modelconverter):
 
@@ -162,7 +162,27 @@ The following images are available on [Luxonis GitHub Container Registry](https:
 
 - `ghcr.io/luxonis/modelconverter-rvc3:2022.3.0-latest`
 
+**RVC4**
+
+- `ghcr.io/luxonis/modelconverter-rvc4:2.32.6-latest`
+- `ghcr.io/luxonis/modelconverter-rvc4:2.41.0-latest`
+
+Using these prebuilt official images is the recommended way to get started with local conversions. Running a command like the one below will automatically download the latest versions of the default images:
+
+```bash
+modelconverter convert rvc4 --path <config_or_archive>
+```
+
+or if you want specific publicly available tool version:
+
+```bash
+modelconverter convert rvc4 --tool-version 2.41.0 --path <config_or_archive>
+```
+
 ### Build Instructions
+
+> [!NOTE]
+> Build locally only when the [official Docker images](#official-docker-images) do not meet your requirements.
 
 #### Prerequisites
 
@@ -173,7 +193,7 @@ Otherwise, follow the installation instructions for your OS from the [official w
 
 In order for the images to be build successfully, you need to download additional packages depending on the selected target and the desired version of the underlying conversion tools.
 
-**RVC2**
+##### RVC2
 
 Requires `openvino-<version>.tar.gz` to be present in `docker/extra_packages/`.
 
@@ -183,11 +203,11 @@ Requires `openvino-<version>.tar.gz` to be present in `docker/extra_packages/`.
 
 You only need to rename the archive to either `openvino-2022.3.0.tar.gz` or `openvino-2021.4.0.tar.gz` and place it in the `docker/extra_packages` directory.
 
-**RVC3**
+##### RVC3
 
 Only the version `2022.3.0` of `OpenVino` is supported for `RVC3`. Follow the same instructions as for `RVC2` to use the correct archive.
 
-**RVC4**
+##### RVC4
 
 Requires `snpe-<version>.zip` archive to be present in `docker/extra_packages`. When building locally via the CLI, the tool will attempt to download the archive automatically if it is missing, but only when a **full SNPE build version** is provided (e.g. `2.41.0.251128`) and that version exists in the Qualcomm catalog. If you pass only the short version (e.g. `2.41.0`), the CLI expects either the image or archive to already be present. After the first download though you can use the local image with the short or long version.
 You can also download different SNPE versions manually from [here](https://softwarecenter.qualcomm.com/catalog/item/Qualcomm_AI_Runtime_Community). After downloading, rename the archive according to the version number and place it in the `docker/extra_packages` directory.
@@ -206,7 +226,7 @@ Example (short version, assumes archive or image already present):
 modelconverter convert rvc4 --tool-version 2.41.0 --path <config_or_archive>
 ```
 
-**HAILO**
+##### HAILO
 
 Requires `hailo_ai_sw_suite_<version>:1` docker image to be present on the system. You can obtain the image by following the instructions on [Hailo website](https://developer.hailo.ai/developer-zone/sw-downloads/).
 

--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -13,7 +13,6 @@ from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 import psutil
-import semver
 import yaml
 from docker.utils import parse_repository_tag
 from loguru import logger
@@ -240,7 +239,7 @@ def prepare_build_environemnt(
 
 
 def download_snpe_archive(version: str, dest: Path) -> Path:
-    archive_path = dest / f"snpe-{semver.finalize_version(version)}.zip"
+    archive_path = dest / f"snpe-{version}.zip"
     if archive_path.exists():
         return archive_path
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Removes extra semver check which caused issues with commands like `modelconverter convert rvc4 --tool-version 2.48.40.260702 --path ...`
- Tightens the README by making it more clear that official images should be used instead of manual building

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added official RVC4 Docker image options and usage examples.
  * Documented optional tool-version selection for RVC4.
  * Clarified when local Docker builds are necessary.
  * Improved Markdown headings for supported targets.

* **Bug Fixes**
  * Corrected SNPE archive version handling to use the supplied version exactly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->