### PR TITLE
Fix HIL benchmark test dependencies

### DIFF
--- a/tests/test_benchmark/run_hil_tests.sh
+++ b/tests/test_benchmark/run_hil_tests.sh
@@ -25,8 +25,7 @@ python3 -m venv venv
 source venv/bin/activate
 
 # Install dependencies
-pip install -r requirements.txt
-pip install pytest
+pip install ".[dev]"
 
 pip install hil-framework --upgrade \
   --index-url "https://__token__:$PAT_TOKEN@gitlab.luxonis.com/api/v4/projects/213/packages/pypi/simple" \


### PR DESCRIPTION
fixes failing HIL BOM tests by adding the hypothesis framework

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the hardware-in-the-loop test setup to install a compatible Hypothesis version before running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->