### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,14 +80,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: ${{ inputs.modelconv_ref && 'Luxonis/modelconverter' || github.repository }}
           ref: ${{ inputs.modelconv_ref || github.head_ref || github.ref }}
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: "3.10"
           cache: pip
@@ -152,7 +152,7 @@ jobs:
       include: ${{ steps.resolve.outputs.include }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: ${{ inputs.modelconv_ref && 'Luxonis/modelconverter' || github.repository }}
           ref: ${{ inputs.modelconv_ref || github.head_ref || github.ref }}
@@ -206,17 +206,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: ${{ inputs.modelconv_ref && 'Luxonis/modelconverter' || github.repository }}
           ref: ${{ inputs.modelconv_ref || github.head_ref || github.ref }}
           persist-credentials: false
 
       - name: Set up Docker
-        uses: crazy-max/ghaction-setup-docker@6d7cfa65f60a9dda7b46e5513fa982536f3c9877
+        uses: crazy-max/ghaction-setup-docker@77e84dbf09b47d1e29270283c22f16145aa85ca1
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: "3.10"
           cache: pip
@@ -319,7 +319,7 @@ jobs:
       # Required by codecov-action, it builds the path-fixing file network
       # from the checked out repository.
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: ${{ inputs.modelconv_ref && 'Luxonis/modelconverter' || github.repository }}
           ref: ${{ inputs.modelconv_ref || github.head_ref || github.ref }}

--- a/.github/workflows/update-cov-report.yaml
+++ b/.github/workflows/update-cov-report.yaml
@@ -24,7 +24,7 @@ jobs:
       # Required by codecov-action, it builds the path-fixing file network
       # from the checked out repository.
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** added a new **[commit](https://github.com/actions/setup-python/commit/5fda3b95a4ea91299a34e894583c3862153e4b97)** to **[v7.0.0](https://github.com/actions/setup-python/releases/tag/v7.0.0)** Tag on 2026-07-20T03:02:03Z
* **[actions/checkout](https://github.com/actions/checkout)** added a new **[commit](https://github.com/actions/checkout/commit/3d3c42e5aac5ba805825da76410c181273ba90b1)** to **[v7.0.1](https://github.com/actions/checkout/releases/tag/v7.0.1)** Tag on 2026-07-17T18:45:11Z
* **[crazy-max/ghaction-setup-docker](https://github.com/crazy-max/ghaction-setup-docker)** added a new **[commit](https://github.com/docker/setup-docker-action/commit/77e84dbf09b47d1e29270283c22f16145aa85ca1)** to **[v5.4.0](https://github.com/docker/setup-docker-action/releases/tag/v5.4.0)** Tag on 2026-07-22T12:43:24Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the versions of automated build and coverage-reporting tools.
  * Maintained existing workflow behavior and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->