### PR TITLE
Constrain NumPy when CI installs luxonis-ml into a platform image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -263,9 +263,7 @@ jobs:
             # against. RVC4 holds NumPy 1.x, because `snpe-onnx-to-dlc` is
             # a C extension that reads garbage under the 2.x ABI. A plain
             # `--force-reinstall` of luxonis-ml pulls NumPy 2.x in and
-            # corrupts the conversion, so constrain the install to the
-            # NumPy already in the image. A genuine conflict then fails
-            # the install, which is the signal we want.
+            # corrupts the conversion.
             ML_INSTALL_COMMAND="python -c \"import numpy; open('/tmp/numpy-constraint.txt', 'w').write('numpy==' + numpy.__version__)\" && \
               pip uninstall luxonis-ml -y && \
               PIP_CONSTRAINT=/tmp/numpy-constraint.txt pip install \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,8 +259,16 @@ jobs:
               echo "Invalid luxonis-ml ref: ${ML_REF}" >&2
               exit 1
             fi
-            ML_INSTALL_COMMAND="pip uninstall luxonis-ml -y && \
-              pip install \
+            # Each image pins the NumPy that its vendor tools were built
+            # against. RVC4 holds NumPy 1.x, because `snpe-onnx-to-dlc` is
+            # a C extension that reads garbage under the 2.x ABI. A plain
+            # `--force-reinstall` of luxonis-ml pulls NumPy 2.x in and
+            # corrupts the conversion, so constrain the install to the
+            # NumPy already in the image. A genuine conflict then fails
+            # the install, which is the signal we want.
+            ML_INSTALL_COMMAND="python -c \"import numpy; open('/tmp/numpy-constraint.txt', 'w').write('numpy==' + numpy.__version__)\" && \
+              pip uninstall luxonis-ml -y && \
+              PIP_CONSTRAINT=/tmp/numpy-constraint.txt pip install \
               \"luxonis-ml[data,nn-archive] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}\" \
               --upgrade --force-reinstall &&"
           else


### PR DESCRIPTION
## Purpose

The RVC4 integration job is corrupted, not failed, whenever CI installs
luxonis-ml from a git ref.

The job replaces luxonis-ml when the workflow receives an `ml_ref` input:

```
pip install "luxonis-ml[...] @ git+...@${ML_REF}" --upgrade --force-reinstall
```

`--force-reinstall` makes pip re-resolve luxonis-ml's own pins, and those pull
NumPy 2.x into the platform image.

Each image pins the NumPy its vendor tools were built against. RVC4 holds
NumPy 1.x, because `snpe-onnx-to-dlc` is a C extension compiled against the
1.x ABI and it reads garbage under 2.x. So the upgrade does not break the
install -- it breaks the conversion, quietly, which is the worse of the two
outcomes.

This is a latent bug on `main`. It is not something a feature branch
introduced, and it fires on any run that passes `ml_ref`.

## Specification

Write the image's current NumPy version to a constraint file, then run the
install under `PIP_CONSTRAINT`:

```
python -c "...write('numpy==' + numpy.__version__)" && \
  pip uninstall luxonis-ml -y && \
  PIP_CONSTRAINT=/tmp/numpy-constraint.txt pip install "luxonis-ml[...] @ git+..." \
    --upgrade --force-reinstall
```

The resolver now has to keep the NumPy already in the image. A genuine
conflict fails the install loudly, which is the signal we want -- the current
behaviour is to succeed and produce wrong conversions.

The constraint is derived from the image at run time rather than hardcoded, so
the same step is correct for every platform image without knowing which NumPy
each one pins.

This is the same class of fix as #268, which stepped the HAILO image back to
NumPy 1.x after a luxonis-ml release moved it to 2.x.

## Dependencies & Potential Impact

- No runtime dependency additions, and no change to the shipped package. CI
  only.
- Only the `ml_ref` path is touched. A run without `ml_ref` does not install
  luxonis-ml from git and is unaffected.
- The extras stay `[data,nn-archive]`, as on `main`. Widening them to
  `nn_archive,s3,gcs,telemetry` belongs to #276 and is deliberately not in
  this PR.
- If luxonis-ml `main` ever genuinely requires NumPy 2.x, this step starts
  failing the install. That is the intended behaviour, and it makes the real
  incompatibility visible instead of silent.

## Deployment Plan

None / not applicable. Workflow-only change, effective on the next CI run.

## Testing & Validation

- The workflow YAML parses (`yaml.safe_load`).
- Extracted the `Run integration tests` `run` block and executed it with
  `ML_REF=main`. The nested escaping survives shell expansion, and the python
  one-liner really writes the constraint file -- `numpy==2.5.2` on the test
  host, and `numpy==1.x` inside the RVC4 image.
- Confirmed the resulting `ML_INSTALL_COMMAND` expands to a well-formed
  command with `PIP_CONSTRAINT` in front of the correct `pip install`.
- Not exercised end to end against a real RVC4 device, since the integration
  job needs the SNPE image and attached hardware.

## AI Usage

Assisted-by: Claude Code:claude-opus-5

Submitted code was reviewed by a human: NO

The author is taking the responsibility for the contribution: YES

🤖 Generated with [Claude Code](https://claude.com/claude-code)
