### PR TITLE
Install luxonis-ml before the NumPy pin returns

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -264,11 +264,19 @@ jobs:
             # a C extension that reads garbage under the 2.x ABI. A plain
             # `--force-reinstall` of luxonis-ml pulls NumPy 2.x in and
             # corrupts the conversion.
-            ML_INSTALL_COMMAND="python -c \"import numpy; open('/tmp/numpy-constraint.txt', 'w').write('numpy==' + numpy.__version__)\" && \
+            #
+            # luxonis-ml requires NumPy 2.x, so pip cannot satisfy the pin
+            # and that requirement at the same time. The image build has the
+            # same conflict. It installs the packages first, then it puts
+            # the pinned NumPy back. The commands below do the same. A wheel
+            # that is built against NumPy 2.x also runs with NumPy 1.x, so
+            # the downgrade keeps the environment usable.
+            ML_INSTALL_COMMAND="python -c \"import numpy; open('/tmp/numpy-pin.txt', 'w').write('numpy==' + numpy.__version__)\" && \
               pip uninstall luxonis-ml -y && \
-              PIP_CONSTRAINT=/tmp/numpy-constraint.txt pip install \
+              pip install \
               \"luxonis-ml[data,nn-archive] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}\" \
-              --upgrade --force-reinstall &&"
+              --upgrade --force-reinstall && \
+              pip install -r /tmp/numpy-pin.txt &&"
           else
             ML_INSTALL_COMMAND=""
           fi


### PR DESCRIPTION
## Purpose

The `Test Modelconverter / rvc4 2.32.6` job fails in LuxonisML PR
[#486](https://github.com/luxonis/luxonis-ml/pull/486)
([run](https://github.com/luxonis/luxonis-ml/actions/runs/31813865339/job/94811716818)).
The `Run integration tests` step stops before the first test:

```
ERROR: Cannot install luxonis-ml[data,nn-archive]==0.10.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    luxonis-ml[data,nn-archive] 0.10.0 depends on numpy~=2.2; extra == "data"
    The user requested (constraint) numpy==1.26.4

ERROR: ResolutionImpossible
```

The root cause is the `PIP_CONSTRAINT` that #277 added. The RVC4 image
holds NumPy 1.x, because the SNPE tools read garbage under the 2.x ABI.
The constraint file gave pip that pin, and luxonis-ml asks for NumPy
2.x. pip cannot satisfy both rules at the same time, so the resolution
fails.

## Specification

The install now runs in two steps:

1. `pip install` luxonis-ml with no constraint. pip pulls NumPy 2.x in.
2. `pip install -r /tmp/numpy-pin.txt` puts the image's NumPy back.

The RVC4 image build has the same conflict and solves it in the same
way: `docker/rvc4/Dockerfile` installs `requirements.txt` first, then it
applies `numpy<2` from `modelconverter/packages/rvc4/requirements.txt`.
This change makes the CI install agree with the image build.

The downgrade is safe. A wheel that is built against NumPy 2.x also runs
with NumPy 1.x, because NumPy 2.0 keeps backward binary compatibility.

## Dependencies & Potential Impact

No runtime dependency additions. The change touches CI only.

Two follow-ups stay open:

- LuxonisML `release/v0.10.0` pins the reusable workflow at
  `Luxonis/modelconverter/.github/workflows/ci.yaml@673f11c`. That pin
  needs the SHA of this fix after the merge.
- `requirements.txt` still pins `luxonis-ml[...]~=0.9.0`. PyPI has 0.9.1
  as the newest release, so the pin stays as it is. It needs a bump
  after v0.10.0 goes to PyPI.

## Testing & Validation

- Reproduced the RVC4 image state in a `python:3.10-slim` container:
  `luxonis-ml[data,nn_archive]~=0.9.0`, then `numpy<2` on top. NumPy
  became 1.26.4, which matches the CI log.
- Ran the new install command against
  `luxonis-ml @ git+...@release/v0.10.0` in that container. NumPy went
  1.26.4 → 2.2.6 → 1.26.4. `luxonis_ml.__version__` reported 0.10.0 and
  `cv2.__version__` reported 4.14.0.
- Imported all 20 luxonis-ml names that modelconverter uses
  (`LuxonisDataset`, `LuxonisLoader`, `ArchiveGenerator`, `is_nn_archive`,
  `Config`, `CONFIG_VERSION`, `PreprocessingBlock`, `BaseModelExtraForbid`,
  `PathType`, `Params`, `Environ`, `LuxonisConfig`, `LuxonisFileSystem`,
  `PUT_FILE_REGISTRY`, `environ`, `setup_logging`, `Registry`, and the
  telemetry names) under NumPy 1.26.4. All imports passed.
- Ran the step script with a stub CLI. The nested quoting produces the
  intended command inside the container.
- `pre-commit run --files .github/workflows/ci.yaml`: 8 hooks passed, 9
  skipped, 0 failed.
- The `Test Modelconverter / Unit tests` job of the same LuxonisML run
  passed against `release/v0.10.0`, so the library API needs no change.

## AI Usage

Assisted-by: Claude Code:claude-opus-5 docker pre-commit

Submitted code was reviewed by a human: NO

The author is taking the responsibility for the contribution: YES

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test environment setup by preserving the existing NumPy version during package installation.
  * Removed persistent pip constraint usage to make dependency handling more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->