### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/update-cov-report.yaml
+++ b/.github/workflows/update-cov-report.yaml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Download coverage artifacts
         if: ${{ steps.ci-run.outputs.upload == 'true' }}
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
+        uses: dawidd6/action-download-artifact@57aa996fc1713cc1579039614f4645a7f4841fd4
         with:
           run_id: ${{ steps.ci-run.outputs.run-id }}
           name: coverage-.*


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[dawidd6/action-download-artifact](https://github.com/dawidd6/action-download-artifact)** added a new **[commit](https://github.com/dawidd6/action-download-artifact/commit/57aa996fc1713cc1579039614f4645a7f4841fd4)** to **[v23](https://github.com/dawidd6/action-download-artifact/releases/tag/v23)** Tag on 2026-08-15T16:18:24Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated coverage-report workflow to use a newer pinned action version.
  * No changes to workflow behavior or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->