### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/update-cov-report.yaml
+++ b/.github/workflows/update-cov-report.yaml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Download coverage artifacts
         if: ${{ steps.ci-run.outputs.upload == 'true' }}
-        uses: dawidd6/action-download-artifact@57aa996fc1713cc1579039614f4645a7f4841fd4
+        uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7
         with:
           run_id: ${{ steps.ci-run.outputs.run-id }}
           name: coverage-.*


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[dawidd6/action-download-artifact](https://github.com/dawidd6/action-download-artifact)** added a new **[commit](https://github.com/dawidd6/action-download-artifact/commit/d63b86af1b34672e53c440b1b83979861906bad7)** to **[v24](https://github.com/dawidd6/action-download-artifact/releases/tag/v24)** Tag on 2026-08-21T07:16:15Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the coverage-report workflow’s artifact download action to a newer pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->