### PR TITLE
Tjb increase top limit

### DIFF
--- a/tests/test_benchmark/benchmark_targets.json
+++ b/tests/test_benchmark/benchmark_targets.json
@@ -1,9 +1,9 @@
 {
   "rvc4": {
     "luxonis/yolov6-nano:r2-coco-512x288": {
-      "expected_fps": 1072.70,
+      "expected_fps": 1100.00,
       "tolerance_low": 0.10,
-      "tolerance_high": 0.30
+      "tolerance_high": 0.10
     },
     "luxonis/yolov8-instance-segmentation-nano:coco-512x288": {
       "expected_fps": 554.68,

--- a/tests/test_benchmark/benchmark_targets.json
+++ b/tests/test_benchmark/benchmark_targets.json
@@ -1,7 +1,7 @@
 {
   "rvc4": {
     "luxonis/yolov6-nano:r2-coco-512x288": {
-      "expected_fps": 750.00,
+      "expected_fps": 1072.70,
       "tolerance_low": 0.10,
       "tolerance_high": 0.30
     },


### PR DESCRIPTION
Recent tests of luxonis/yolov6-nano:r2-coco-512x288 | All are failing because the upper limit is set to low. This fixes that.

<img width="487" height="378" alt="image" src="https://github.com/user-attachments/assets/1fd343b5-9d8b-4f25-9eb7-6e9f19338d7f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated benchmark expectations for the YOLOv6 Nano model to reflect improved performance.
  * Tightened the acceptable upper performance tolerance while keeping the lower tolerance unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->