### PR TITLE
Migrate the test docs to Google docstyle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,9 +134,7 @@ unfixable = ["B905", "PLC0208"]
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-# The tests move to the Google style in the stacked PR; keep them out of
-# the docstring gate until then.
-"tests/*" = ["ANN201", "D"]
+"tests/*" = ["ANN201", "D103"]
 "__main__.py" = ["ANN201"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,9 @@
+"""Test suite for modelconverter.
+
+Importing the package configures logging, so that a failing test shows
+the same output a real conversion would.
+"""
+
 from luxonis_ml.utils import setup_logging
 
 setup_logging()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,12 @@
+"""Suite-wide pytest configuration.
+
+Disables telemetry, sets up logging, pins the Hypothesis profile so that
+property tests are reproducible, applies the ``unit`` marker during
+collection, and deselects the other platforms' conversion tests inside
+a platform Docker image. The per-platform markers themselves are
+applied at parametrization, in `tests.helpers.platforms`.
+"""
+
 import os
 
 import pytest

--- a/tests/conversion/__init__.py
+++ b/tests/conversion/__init__.py
@@ -1,0 +1,6 @@
+"""Conversion tests, run inside the per-backend Docker images.
+
+Each test converts a model for one target and checks the result, so a
+module here only runs where that target's toolchain is available. Select
+a target with its marker, e.g. ``pytest -m rvc2``.
+"""

--- a/tests/conversion/test_conversion.py
+++ b/tests/conversion/test_conversion.py
@@ -31,6 +31,8 @@ IR_MODELS = f"{GS}/models"
 
 @dataclass(frozen=True)
 class Scenario:
+    """One end-to-end conversion the suite runs."""
+
     id: str
     # An NN archive (.tar.xz), a config (.yaml) or an OpenVINO IR.
     path: str

--- a/tests/conversion/test_model_evaluation.py
+++ b/tests/conversion/test_model_evaluation.py
@@ -1,4 +1,4 @@
-"""Task-metric regression tests for real public HubAI source models.
+r"""Task-metric regression tests for real public HubAI source models.
 
 Unlike ``test_precision``, these score predictions against labelled images.
 Luxonis Eval is used purely as a test library -- modelconverter still does the
@@ -37,7 +37,9 @@ if TYPE_CHECKING:
 class Metric(Protocol):
     """The slice of a Luxonis Eval metric that the scoring needs."""
 
-    def compute(self) -> Mapping[str, SupportsFloat]: ...
+    def compute(self) -> Mapping[str, SupportsFloat]:
+        """Return the metric values accumulated so far, keyed by name."""
+        ...
 
 
 COCO_SAMPLE = "gs://luxonis-test-bucket/luxonis-ml-test-data/coco_sample.zip"
@@ -67,6 +69,8 @@ def run_script(outputs):
 
 @dataclass(frozen=True)
 class EvaluationCase:
+    """One HubAI source model scored against labelled images."""
+
     id: str
     # An immutable HubAI source instance, not a mutable model slug.
     instance_id: str
@@ -159,7 +163,7 @@ def coco_sample(
 
 
 def _calibration_images() -> list[Path]:
-    """The images materialized by modelconverter's LDF loader."""
+    """Return the images materialized by modelconverter's LDF loader."""
     directory = CALIBRATION_DIR / DATASET_NAME
     paths = sorted(directory.glob("*.png"), key=lambda path: int(path.stem))
     assert paths, f"no calibration images under {directory}"
@@ -167,7 +171,9 @@ def _calibration_images() -> list[Path]:
 
 
 def _link_options(stage: str, post_stage: str, inputs: list[str]) -> list[str]:
-    """Overrides wiring yolov8-seg's postprocessor to its upstream stage."""
+    """Build the overrides wiring yolov8-seg's postprocessor to its
+    upstream stage.
+    """
     prototypes = inputs.index("prototypes")
     coeffs = inputs.index("coeffs")
     prefix = f"stages.{post_stage}.inputs"

--- a/tests/conversion/test_precision.py
+++ b/tests/conversion/test_precision.py
@@ -39,6 +39,8 @@ DEFAULT_THRESHOLD: Final[float] = 0.8
 
 @dataclass(frozen=True)
 class PrecisionCase:
+    """One model whose converted outputs are compared to the ONNX."""
+
     id: str
     # A config (or archive) whose `input_model` is the reference ONNX.
     config: str

--- a/tests/conversion/test_toy_integration.py
+++ b/tests/conversion/test_toy_integration.py
@@ -54,6 +54,8 @@ _THRESHOLD = 0.9
 
 @dataclass(frozen=True)
 class Precision:
+    """One precision the toy net is converted at."""
+
     name: str
     opts: tuple[str, ...] = ()
     # Reason, if this precision is a known failure for the platform.
@@ -185,7 +187,7 @@ def frozen_toy_config(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 @pytest.fixture(scope="module")
 def constant_image(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """A constant-valued image matching the calibration constant."""
+    """Create a constant-valued image matching the calibration constant."""
     path = tmp_path_factory.mktemp("toy_const") / "const.png"
     cv2.imwrite(
         str(path), np.full((_SIZE, _SIZE, 3), _CALIB_VALUE, dtype=np.uint8)

--- a/tests/conversion/test_toy_multistage.py
+++ b/tests/conversion/test_toy_multistage.py
@@ -1,4 +1,4 @@
-"""Toy multistage conversion + correctness tests.
+r"""Toy multistage conversion + correctness tests.
 
 A small, fully-controllable multistage net built from the toy pieces::
 

--- a/tests/conversion/test_toy_precision.py
+++ b/tests/conversion/test_toy_precision.py
@@ -65,8 +65,11 @@ def constant_image(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 def _to_nchw(arr: np.ndarray, platform_name: str) -> np.ndarray:
-    """The Hailo inferer returns spatial outputs channels-last; the others, and
-    the golden reference, are already NCHW."""
+    """Normalize a platform's spatial output to NCHW.
+
+    The Hailo inferer returns spatial outputs channels-last; the others,
+    and the golden reference, are already NCHW.
+    """
     arr = np.asarray(arr)
     if arr.ndim == 3 and platform_name == "hailo":
         return arr.transpose(2, 0, 1)[np.newaxis]

--- a/tests/conversion/test_toy_tflite.py
+++ b/tests/conversion/test_toy_tflite.py
@@ -54,7 +54,7 @@ def toy_tflite(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 @pytest.fixture(scope="module")
 def solid_image(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """An 8x8 image with a distinct constant value per channel."""
+    """Create an 8x8 image with a distinct constant value per channel."""
     path = tmp_path_factory.mktemp("toy_tflite_img") / "solid.png"
     cv2.imwrite(str(path), np.full((8, 8, 3), _CHANNEL_VALUES, dtype=np.uint8))
     return path

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,5 @@
+"""Shared fixtures, factories and assertions for the test suite.
+
+Holds the dummy-model factories, the ONNX reference inferer and the
+platform marker helpers used by both the unit and the conversion tests.
+"""

--- a/tests/helpers/archive_factory.py
+++ b/tests/helpers/archive_factory.py
@@ -1,5 +1,6 @@
 """Helpers for building NN-archive config JSON and packing ``.tar``
-archives for the host-side conversion tests."""
+archives for the host-side conversion tests.
+"""
 
 import json
 import tarfile
@@ -11,11 +12,16 @@ from luxonis_ml.typing import Params, ParamValue, PathType
 
 
 def default_archive_config(*, heads: Sequence[ParamValue] = ()) -> Params:
-    """A minimal, valid NN-archive ``config.json`` dict matching the
-    standard two-input dummy ONNX model.
+    """Build a minimal, valid NN-archive ``config.json`` dict.
 
-    @param heads: Parser heads to declare on the model. Empty by
-        default.
+    Matches the standard two-input dummy ONNX model.
+
+    Args:
+        heads: Parser heads to declare on the model. Empty by default.
+
+    Returns:
+        The archive configuration.
+
     """
     return {
         "config_version": "1.0",
@@ -66,13 +72,22 @@ def pack_archive(
     extra_files: dict[str, PathType] | None = None,
     mode: Literal["w", "w:xz", "w:gz", "w:bz2"] = "w",
 ) -> Path:
-    """Packs ``model_path`` + ``config.json`` (+ optional extras) into a
+    """Pack ``model_path`` + ``config.json`` (+ optional extras) into a
     tar archive.
 
-    @param config: config dict, serialized to ``config.json`` next to the
-        archive.
-    @param extra_files: mapping of ``arcname -> file path`` for extra
-        members (e.g. ``encodings.json``, a postprocessor ONNX).
+    Args:
+        tar_path: Path of the archive to create.
+        model_path: Path of the model file to add to the archive.
+        config: Config dict, serialized to ``config.json`` next to the
+            archive.
+        extra_files: Mapping of ``arcname -> file path`` for extra
+            members (e.g. ``encodings.json``, a postprocessor ONNX).
+        mode: Mode the tar archive is opened with, selecting the
+            compression.
+
+    Returns:
+        Path to the created archive.
+
     """
     tar_path = Path(tar_path)
     model_path = Path(model_path)

--- a/tests/helpers/conversion.py
+++ b/tests/helpers/conversion.py
@@ -53,8 +53,10 @@ def assert_produced_suffix(output_name: str, suffix: str) -> None:
 
 
 def toy_net_image_inputs(calib: dict, *, size: int = 64) -> list[dict]:
-    """The toy integration net's ``bgr``/``rgb``/``gray`` inputs, each with its
-    own mean/scale/encoding and all sharing one ``calib`` spec.
+    """Build the toy integration net's image inputs.
+
+    The ``bgr``/``rgb``/``gray`` inputs each carry their own
+    mean/scale/encoding and all share one ``calib`` spec.
 
     Shared by the toy-integration and toy-multistage tests, which differ only in
     the calibration (a random constant vs. an image directory).

--- a/tests/helpers/onnx_factory.py
+++ b/tests/helpers/onnx_factory.py
@@ -50,7 +50,7 @@ def build_onnx(
     inputs: list[tuple[str, list[int], int]],
     outputs: list[tuple[str, list[int], int]],
 ) -> Path:
-    """A minimal valid model with the given inputs/outputs.
+    """Build a minimal valid model with the given inputs/outputs.
 
     Each output comes off an ``Identity`` node fed from an input, so the graph
     is structurally valid whatever the declared shapes.
@@ -78,7 +78,7 @@ def build_onnx(
 def build_toy_integration_onnx(
     path: PathType, *, size: int = 64, with_flag: bool = False
 ) -> Path:
-    """A tiny multi-input net covering the whole preprocessing surface.
+    """Build a tiny multi-input net covering the whole preprocessing surface.
 
     Three image inputs, each meant to carry different mean/scale + encoding in
     the config: ``bgr`` (``BGR`` -> ``BGR``, no reversal), ``rgb`` (``RGB`` ->
@@ -159,7 +159,7 @@ def build_toy_integration_onnx(
 
 
 def build_toy_aggregator_onnx(path: PathType, *, size: int = 64) -> Path:
-    """The final stage of the toy multistage net.
+    """Build the final stage of the toy multistage net.
 
     Two ``[1, 3, size, size]`` inputs -- fed from two upstream toy stages via
     linked calibration -- combined as ``from_first * from_second + bias``. The
@@ -191,7 +191,7 @@ def build_toy_conv_onnx(
     out_channels: int = 4,
     external_data: bool = False,
 ) -> Path:
-    """A tiny single-input conv net for the numeric-fidelity tests.
+    """Build a tiny single-input conv net for the numeric-fidelity tests.
 
     ``build_toy_integration_onnx`` is a poor fidelity subject -- its output is
     essentially the preprocessed input, and its per-input scale spread is too
@@ -235,7 +235,7 @@ def build_toy_conv_onnx(
 def weights_only_external_onnx(
     path: PathType, *, single_file: bool = True
 ) -> list[Path]:
-    """A model that is nothing but externally stored weights.
+    """Build a model that is nothing but externally stored weights.
 
     Returns the companion files, in sorted order. Anything walking a
     model's external data has to find every one of them, so
@@ -282,7 +282,7 @@ def weights_only_external_onnx(
 
 
 def build_relu_onnx(path: PathType, shape: list[int]) -> Path:
-    """A shape-preserving ``Relu`` over a single input of the given shape.
+    """Build a shape-preserving ``Relu`` over a single input of the given shape.
 
     Used for conversions of shapes the usual 4D ``NCHW`` models never produce:
     a rank-3 ``HWC`` (channels-last, no batch dim) input, or a rank-3
@@ -296,7 +296,7 @@ def build_relu_onnx(path: PathType, shape: list[int]) -> Path:
 
 
 def split_concat_onnx(path: PathType) -> Path:
-    """A ``Split`` whose two branches a ``Concat`` rejoins.
+    """Build a ``Split`` whose two branches a ``Concat`` rejoins.
 
     The Concat produces a graph output, so nothing consumes it. The
     Split-Concat fusion walks forward from the Concat to find a ``Conv``,
@@ -313,7 +313,7 @@ def split_concat_onnx(path: PathType) -> Path:
 
 
 def standard_dummy_onnx(path: PathType) -> Path:
-    """The canonical two-in/two-out model used across the config tests."""
+    """Build the canonical two-in/two-out model used across the config tests."""
     inputs = [
         helper.make_tensor_value_info(
             "input0", TensorProto.FLOAT, [1, 3, 64, 64]
@@ -352,7 +352,7 @@ def single_io_onnx(
     output_name: str = "output0",
     output_shape: list[int] | None = None,
 ) -> Path:
-    """A single-input / single-output model."""
+    """Build a single-input / single-output model."""
     return build_onnx(
         path,
         inputs=[(name, shape or [1, 3, 64, 64], dtype)],
@@ -372,7 +372,8 @@ def dynamic_batch_onnx(path: PathType) -> Path:
 
 def intermediate_info_onnx(path: PathType) -> Path:
     """Model with one intermediate tensor described in ``value_info`` and one
-    that is not, for the ONNX introspection helpers in config.py."""
+    that is not, for the ONNX introspection helpers in config.py.
+    """
     inp = helper.make_tensor_value_info(
         "input0", TensorProto.FLOAT, [1, 3, 64, 64]
     )
@@ -401,12 +402,12 @@ def intermediate_info_onnx(path: PathType) -> Path:
 
 
 def multi_file_external_onnx(path: PathType) -> list[Path]:
-    """A conv model whose weight and bias each live in their own file.
+    """Build a conv model whose weight and bias each live in their own file.
 
     Returns the companion files, in sorted order. This is the layout
     ``all_tensors_to_one_file=False`` produces; two initializers are the
     smallest model that tells "copies the external data" apart from
-    "copies *all* of it". Unlike L{weights_only_external_onnx} the graph
+    "copies *all* of it". Unlike `weights_only_external_onnx` the graph
     has real inputs and outputs, so it can be put through a conversion.
     """
     path = Path(path)

--- a/tests/helpers/onnx_reference.py
+++ b/tests/helpers/onnx_reference.py
@@ -34,6 +34,14 @@ class ONNXReferenceInferer:
     """
 
     def __init__(self, model_path: Path, stage: SingleStageConfig) -> None:
+        """Open an ONNX session for the stage's model.
+
+        Args:
+            model_path: Path to the ONNX model to run.
+            stage: Stage config whose preprocessing is applied to the
+                inputs before inference.
+
+        """
         self.stage = stage
         self.session = ort.InferenceSession(
             str(model_path), providers=["CPUExecutionProvider"]
@@ -43,6 +51,15 @@ class ONNXReferenceInferer:
 
     @classmethod
     def from_stage(cls, stage: SingleStageConfig) -> "ONNXReferenceInferer":
+        """Build an inferer for the stage's own input model.
+
+        Args:
+            stage: Stage config to take the model and preprocessing from.
+
+        Returns:
+            An inferer for that stage.
+
+        """
         # `get_configs` downloads `input_model` and rewrites it to a local path.
         return cls(Path(stage.input_model), stage)
 
@@ -85,6 +102,16 @@ class ONNXReferenceInferer:
         return arr[np.newaxis, ...]
 
     def infer(self, image_path: PathType) -> dict[str, np.ndarray]:
+        """Run the model on one image, preprocessed per the config.
+
+        Args:
+            image_path: Path to the image to run on. It is fed to every
+                input, each preprocessed with that input's own settings.
+
+        Returns:
+            Mapping of output name to output array.
+
+        """
         # Config inputs pair with the session inputs positionally.
         feed = {
             name: self._preprocess(inp, image_path)

--- a/tests/helpers/platforms.py
+++ b/tests/helpers/platforms.py
@@ -12,7 +12,7 @@ ALL_PLATFORMS = ("rvc2", "rvc3", "rvc4", "hailo")
 def platform_marks(
     platform: str, xfail: str | None = None, skip: str | None = None
 ) -> list:
-    """The platform marker, plus an xfail or a skip when given a reason.
+    """Build the platform marker, plus an xfail or a skip when given a reason.
 
     A failing conversion exits rather than raising, hence ``raises=SystemExit``
     on the xfail. ``skip`` is for cases the current tool version will not run --
@@ -34,7 +34,8 @@ def platform_params(
     xfails: dict[str, str] | None = None,
 ) -> list:
     """One ``pytest.param`` per platform name, for a ``"platform_name"``
-    parametrization."""
+    parametrization.
+    """
     return [
         pytest.param(
             platform,

--- a/tests/helpers/precision.py
+++ b/tests/helpers/precision.py
@@ -69,7 +69,7 @@ def golden_reference_outputs(
 
 
 def locate_converted_model(output_dir: Path, platform: str) -> Path:
-    """The converted model a vendor inferer should load.
+    """Locate the converted model a vendor inferer should load.
 
     Prefers the final artifact directly in ``output_dir`` -- running an
     intermediate DLC would test the un-quantized graph -- and falls back to a

--- a/tests/helpers/strategies.py
+++ b/tests/helpers/strategies.py
@@ -49,7 +49,7 @@ def shapes(
 def shape_permutations(
     draw: st.DrawFn, min_rank: int = 1, max_rank: int = MAX_RANK
 ) -> tuple[list[int], list[int]]:
-    """A shape together with a permutation of it.
+    """Draw a shape together with a permutation of it.
 
     Drawing the pair as a unit is what makes ``guess_new_layout``
     testable: it rejects any new shape that is not a rearrangement of
@@ -93,7 +93,7 @@ _SCALAR_FIELDS = {
 def encoding_items(
     draw: st.DrawFn, *, vector_length: int | None = None
 ) -> Params:
-    """A single raw quantization-encoding entry.
+    """Draw a single raw quantization-encoding entry.
 
     Values are valid for ``QuantizationOverridesItem``, so one strategy drives
     both the private normalisation helpers and the public ``parse_encodings``.
@@ -122,7 +122,7 @@ def encoding_items(
 
 @st.composite
 def encoding_groups(draw: st.DrawFn) -> dict[str, list[Params]]:
-    """A ``{tensor_name: [entry, ...]}`` encoding group."""
+    """Draw a ``{tensor_name: [entry, ...]}`` encoding group."""
     names = draw(st.lists(tensor_names, min_size=1, max_size=3, unique=True))
     return {
         name: draw(

--- a/tests/test_benchmark/__init__.py
+++ b/tests/test_benchmark/__init__.py
@@ -1,0 +1,6 @@
+"""Hardware-in-the-loop benchmark regression tests.
+
+Runs on a real device through the HIL testbed and compares the measured
+throughput against recorded targets, so it needs hardware and is not part
+of the host-side test run.
+"""

--- a/tests/test_benchmark/conftest.py
+++ b/tests/test_benchmark/conftest.py
@@ -1,3 +1,10 @@
+"""Fixtures and options for the hardware-in-the-loop benchmarks.
+
+Adds the ``--benchmark-*`` command line options and exposes the HIL
+testbed, the device under test and the InfluxDB bucket the results are
+reported to.
+"""
+
 import os
 
 import pytest

--- a/tests/test_benchmark/test_benchmark_regression.py
+++ b/tests/test_benchmark/test_benchmark_regression.py
@@ -1,3 +1,9 @@
+"""Check measured device throughput against the recorded targets.
+
+Benchmarks each model in ``benchmark_targets.json`` on a real device and
+fails when the measured FPS regresses against the recorded value.
+"""
+
 import json
 import platform
 from collections.abc import Mapping
@@ -21,24 +27,38 @@ class BenchmarkCamera(Protocol):
     """The part of the HIL framework camera API that this suite uses."""
 
     @property
-    def name(self) -> str: ...
+    def name(self) -> str:
+        """Name the framework reserved the camera under."""
+        ...
 
     @property
-    def mxid(self) -> str: ...
+    def mxid(self) -> str:
+        """Unique ID of the device."""
+        ...
 
     @property
-    def model(self) -> str: ...
+    def model(self) -> str:
+        """Model of the device, such as ``OAK4-D``."""
+        ...
 
     @property
-    def revision(self) -> str: ...
+    def revision(self) -> str:
+        """Hardware revision of the device."""
+        ...
 
     @property
-    def hostname(self) -> str: ...
+    def hostname(self) -> str:
+        """Host name the device is reachable at."""
+        ...
 
     @property
-    def platform(self) -> str: ...
+    def platform(self) -> str:
+        """Platform of the device, such as ``RVC4``."""
+        ...
 
-    def get_os_version(self) -> str: ...
+    def get_os_version(self) -> str:
+        """Return the version of the OS running on the device."""
+        ...
 
 
 def _model_slugs(benchmark_platform: str) -> list[str]:
@@ -47,7 +67,8 @@ def _model_slugs(benchmark_platform: str) -> list[str]:
 
 def _model_id(slug: str) -> str:
     """Take out the `luxonis` and use the remainder of the slug to name
-    the test."""
+    the test.
+    """
     return slug.rsplit("/", 1)[-1]
 
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,5 @@
+"""Host-side unit tests.
+
+These need neither Docker nor a device, and are the tests that run on
+every push.
+"""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -65,7 +65,7 @@ def _isolate_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 @pytest.fixture
 def work_dir(tmp_path: Path) -> Path:
-    """The isolated working directory (same as cwd for the test)."""
+    """Return the isolated working directory (same as cwd for the test)."""
     return tmp_path
 
 

--- a/tests/unit/test_base_benchmark.py
+++ b/tests/unit/test_base_benchmark.py
@@ -1,3 +1,5 @@
+"""Tests for the shared benchmark scaffolding."""
+
 from pathlib import Path
 
 import pytest

--- a/tests/unit/test_base_exporter.py
+++ b/tests/unit/test_base_exporter.py
@@ -23,9 +23,11 @@ class StubExporter(Exporter):
     platform = Platform.RVC2
 
     def exporter_buildinfo(self) -> dict:
+        """Return empty build info."""
         return {}
 
     def export(self) -> Path:
+        """Return the input model unchanged."""
         return self._input_model
 
 

--- a/tests/unit/test_cache_budget.py
+++ b/tests/unit/test_cache_budget.py
@@ -58,7 +58,7 @@ def _age(entry: Path, used: float) -> None:
 
 
 def _model(tmp_path: Path, name: str, size: int) -> Path:
-    """A file of exactly ``size`` bytes, distinct from every other one.
+    """Create a file of exactly ``size`` bytes, distinct from every other one.
 
     Entries are keyed by content, so two models of the same size have to
     differ in their bytes to be two entries at all.
@@ -87,7 +87,8 @@ def test_eviction_stops_once_the_cache_fits(
     tmp_path: Path, cache_dir: Path, budget: SetBudget
 ) -> None:
     """The budget is a ceiling, not a target: everything that still fits
-    under it is kept, however old it is."""
+    under it is kept, however old it is.
+    """
     entries = []
     for index in range(4):
         entry = _stage(_model(tmp_path, f"{index}.tflite", 1024), cache_dir)
@@ -119,7 +120,8 @@ def test_entries_staged_by_this_run_survive(
     tmp_path: Path, cache_dir: Path, budget: SetBudget
 ) -> None:
     """The conversion about to start needs exactly what it just staged,
-    even when the claim is somehow missing."""
+    even when the claim is somehow missing.
+    """
     entry = _stage(_model(tmp_path, "model.tflite", 4096), cache_dir)
     budget("1KiB")
 
@@ -144,7 +146,8 @@ def test_an_unreadable_budget_is_ignored(
     tmp_path: Path, cache_dir: Path, budget: SetBudget
 ) -> None:
     """A typo in the environment must not start deleting models, nor
-    stop the conversion."""
+    stop the conversion.
+    """
     entry = _stage(_model(tmp_path, "model.tflite", 4096), cache_dir)
     _age(entry, 1000.0)
     budget("as much as it takes")
@@ -158,7 +161,8 @@ def test_downloads_are_evicted_alongside_staged_inputs(
     cache_dir: Path, budget: SetBudget
 ) -> None:
     """The container downloads remote models straight into the cache,
-    and those are the entries nothing host-side ever staged."""
+    and those are the entries nothing host-side ever staged.
+    """
     download = cache_dir / "models" / "hub-model.onnx"
     download.parent.mkdir(parents=True)
     download.write_bytes(b"x" * 4096)
@@ -175,7 +179,8 @@ def test_downloads_survive_while_another_conversion_runs(
 ) -> None:
     """A download has no claim of its own -- the container writes it
     under the launcher's claim on the cache root -- so nothing may be
-    taken from underneath a run in another terminal."""
+    taken from underneath a run in another terminal.
+    """
     download = cache_dir / "models" / "hub-model.onnx"
     download.parent.mkdir(parents=True)
     download.write_bytes(b"x" * 4096)
@@ -205,7 +210,8 @@ def test_the_digest_memo_is_neither_counted_nor_evicted(
     cache_dir: Path, budget: SetBudget
 ) -> None:
     """Rebuilding it means re-reading every staged model, which costs
-    more than the handful of bytes it holds."""
+    more than the handful of bytes it holds.
+    """
     memo = cache_dir / "digests"
     memo.mkdir(parents=True)
     (memo / "abcdef").write_text("0123456789abcdef")
@@ -221,7 +227,8 @@ def test_an_entry_claimed_mid_sweep_is_put_back(
 ) -> None:
     """The window between deciding to evict and deleting is real: a
     staging that reused the entry claims it in between, and the claim is
-    on the entry wherever it has been renamed to."""
+    on the entry wherever it has been renamed to.
+    """
     src = _model(tmp_path, "model.tflite", 4096)
     entry = _stage(src, cache_dir)
 
@@ -238,7 +245,8 @@ def test_the_leftovers_of_a_killed_sweep_are_cleaned_up(
     cache_dir: Path, budget: SetBudget
 ) -> None:
     """A sweep killed between renaming an entry aside and deleting it
-    would otherwise leave a full-sized entry nothing ever looks at."""
+    would otherwise leave a full-sized entry nothing ever looks at.
+    """
     dead = subprocess.Popen([sys.executable, "-c", ""])
     dead.wait()
     inputs = cache_dir / "inputs"
@@ -256,7 +264,8 @@ def test_a_running_sweep_keeps_its_own_trash(
     cache_dir: Path, budget: SetBudget
 ) -> None:
     """Another sweep is mid-eviction; its leftovers are not ours to
-    delete."""
+    delete.
+    """
     inputs = cache_dir / "inputs"
     trash = inputs / f"{input_staging._TRASH_PREFIX}{os.getpid()}-abcdef"
     trash.mkdir(parents=True)
@@ -273,7 +282,8 @@ def test_staging_trims_the_cache_it_just_added_to(
 ) -> None:
     """The sweep runs as part of staging, which is the only moment the
     launcher knows what the conversion needs and the container has not
-    started reading it yet."""
+    started reading it yet.
+    """
     stale = _stage(_model(tmp_path, "stale.tflite", 4096), cache_dir)
     _age(stale, 1000.0)
     needed = _model(tmp_path, "needed.tflite", 4096)

--- a/tests/unit/test_cache_cli.py
+++ b/tests/unit/test_cache_cli.py
@@ -1,3 +1,9 @@
+"""Tests for the ``modelconverter cache`` commands.
+
+Covers reporting and clearing the hidden cache, including the cases where
+it is in use by a running conversion or cannot be read at all.
+"""
+
 import os
 import subprocess
 import sys
@@ -12,8 +18,9 @@ from modelconverter.utils import input_staging
 
 @pytest.fixture
 def cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """A non-empty cache that both the CLI and input staging resolve
-    to."""
+    """Create a non-empty cache that both the CLI and input staging
+    resolve to.
+    """
     cache = tmp_path / "modelconverter"
     cache.mkdir()
     (cache / "entry").write_bytes(b"cached")
@@ -44,8 +51,9 @@ def test_cache_clean_confirmed_removes_cache(
 
 
 def _deny_listing(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Makes the cache root unlistable, as a container that was killed
-    before it could hand the mounts back leaves it."""
+    """Make the cache root unlistable, as a container that was killed
+    before it could hand the mounts back leaves it.
+    """
 
     def denied(_self: Path) -> NoReturn:
         raise PermissionError(13, "Permission denied")
@@ -90,8 +98,10 @@ def test_cache_clean_yes_skips_confirmation(
 
 
 def _claimed_by(cache: Path, pid: int) -> Path:
-    """A staged input entry claimed by ``pid``, as a launcher marks the
-    ones its container has open."""
+    """Create a staged input entry claimed by ``pid``.
+
+    Mirrors how a launcher marks the ones its container has open.
+    """
     entry = cache / "inputs" / "digest"
     entry.mkdir(parents=True)
     (entry / "image.jpg").write_bytes(b"calibration image")
@@ -104,7 +114,8 @@ def test_cache_clean_spares_inputs_a_running_conversion_holds(
 ) -> None:
     """The cache is bind-mounted into every running container, so
     emptying it pulls the staged inputs out from under a conversion that
-    is still reading them."""
+    is still reading them.
+    """
     entry = _claimed_by(cache, os.getpid())
 
     cli.cache_clean(yes=True)
@@ -116,7 +127,8 @@ def test_cache_clean_ignores_a_claim_from_a_dead_process(
     cache: Path,
 ) -> None:
     """A run that was killed leaves its marker behind; refusing forever
-    on account of it would make the cache impossible to clear."""
+    on account of it would make the cache impossible to clear.
+    """
     dead = subprocess.Popen([sys.executable, "-c", ""])
     dead.wait()
     _claimed_by(cache, dead.pid)
@@ -131,7 +143,8 @@ def test_cache_clean_declines_when_stdin_cannot_answer(
 ) -> None:
     """Piped or closed stdin makes the prompt raise ``EOFError``. Nothing
     in this command group runs inside ``catch_exceptions``, and a
-    destructive command must not read silence as consent either."""
+    destructive command must not read silence as consent either.
+    """
 
     def no_stdin(*_args: object, **_kwargs: object) -> NoReturn:
         raise EOFError
@@ -148,7 +161,8 @@ def test_cache_clean_spares_a_cache_claimed_for_downloads(
 ) -> None:
     """The container downloads remote inputs straight into the cache
     mount, so the launcher's whole-cache claim must hold ``cache clean``
-    off even when nothing was staged host-side."""
+    off even when nothing was staged host-side.
+    """
     input_staging.claim_cache()
 
     cli.cache_clean(yes=True)
@@ -160,7 +174,8 @@ def test_cache_clean_rechecks_claims_after_the_prompt(
     cache: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A conversion may start while the confirmation prompt sits
-    unanswered; the answer must not license deleting its inputs."""
+    unanswered; the answer must not license deleting its inputs.
+    """
 
     def stage_and_confirm(*_args: object, **_kwargs: object) -> bool:
         _claimed_by(cache, os.getpid())

--- a/tests/unit/test_calibration_data.py
+++ b/tests/unit/test_calibration_data.py
@@ -28,7 +28,7 @@ def _touch_img(directory: Path, name: str = "img.png") -> Path:
 
 
 def _img_dir(root: Path, count: int) -> Path:
-    """A directory holding ``count`` (empty) calibration images."""
+    """Create a directory holding ``count`` (empty) calibration images."""
     directory = root / "imgs"
     directory.mkdir(exist_ok=True)
     for path in directory.iterdir():

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -60,7 +60,8 @@ def test_output_dir_refuses_a_directory_it_did_not_produce():
     """`OUTPUTS_DIR` is the user's `./output`, so a name that already
     holds something else -- notes, a previous run's inference results --
     must not be deleted just because it was passed to
-    `--output-dir`."""
+    `--output-dir`.
+    """
     foreign = OUTPUTS_DIR / "notes"
     foreign.mkdir(parents=True, exist_ok=True)
     (foreign / "keep.txt").write_text("mine")
@@ -73,7 +74,8 @@ def test_output_dir_refuses_a_directory_it_did_not_produce():
 def test_output_dir_refuses_a_path_that_is_not_a_directory():
     """A rerun clears the directory a previous conversion produced. A
     file of the same name is not that, and deleting it would take the
-    user's data with it."""
+    user's data with it.
+    """
     OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
     taken = OUTPUTS_DIR / "taken"
     taken.write_text("mine")
@@ -89,7 +91,8 @@ def test_output_dir_must_stay_under_outputs_dir_in_docker(
 ):
     """Only `./output` is mounted into the container: an absolute or
     upward path would be written somewhere the host never sees, and an
-    empty one names `./output` itself."""
+    empty one names `./output` itself.
+    """
     monkeypatch.setenv("IN_DOCKER", "1")
     with pytest.raises(
         ModelconverterException, match="Invalid `--output-dir`"
@@ -99,7 +102,8 @@ def test_output_dir_must_stay_under_outputs_dir_in_docker(
 
 def test_output_dir_accepts_any_path_natively(tmp_path: Path):
     """A native run has no mount an absolute path could escape, so the
-    user's path is written to as given."""
+    user's path is written to as given.
+    """
     dest = tmp_path / "elsewhere" / "results"
 
     assert get_output_dir_name(Platform.RVC2, "model", str(dest)) == dest

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -67,8 +67,10 @@ def _rvc4_config(**data: ParamValue) -> RVC4Config:
 
 
 def _models_dir() -> Path:
-    """The models directory of the cache, re-rooted into the temp dir by
-    ``_isolate_cwd``."""
+    """Return the models directory of the cache.
+
+    Re-rooted into the temp dir by ``_isolate_cwd``.
+    """
     return MODELS_DIR
 
 
@@ -82,7 +84,7 @@ def _single_stage(config: Config) -> SingleStageConfig:
 
 
 def _named_node_onnx(path: Path) -> Path:
-    """A model whose node *name* differs from its output *tensor* name.
+    """Build a model whose node *name* differs from its output *tensor* name.
 
     ``mynode`` produces tensor ``y`` (described in ``value_info``), so a
     lookup by node name misses the tensor search and falls through to
@@ -114,7 +116,8 @@ def _pt_model() -> Path:
 
 def test_flat_config_wrapped_and_renamed():
     """A flat single-stage config is wrapped and the ``default_stage``
-    placeholder is renamed to the input-model stem."""
+    placeholder is renamed to the input-model stem.
+    """
     dummy = _dummy()
     config = Config.get_config(None, {"input_model": str(dummy)})
     assert config.name == dummy.stem
@@ -134,14 +137,16 @@ def test_flat_config_with_explicit_name_kept():
 
 def test_stage_name_must_be_a_string():
     """A single-stage config takes its stage name from `name`, which
-    then keys the stage dictionary."""
+    then keys the stage dictionary.
+    """
     with pytest.raises(TypeError, match="`name` must be a string"):
         Config.get_config(None, {"name": 123, "input_model": "model.onnx"})
 
 
 def test_multistage_extras_fanned_into_each_stage():
     """Top-level extras are distributed to stages missing them, and the
-    derived name joins the stage keys."""
+    derived name joins the stage keys.
+    """
     dummy = _dummy()
     config = Config.get_config(
         None,
@@ -224,7 +229,8 @@ def test_onnx_path_resolved_absolute():
 
 def test_ir_path_extracts_bin_and_xml(monkeypatch: pytest.MonkeyPatch):
     """The IR branch splits the ``.xml``/``.bin`` pair; ``get_metadata``
-    is stubbed so no OpenVINO runtime is needed."""
+    is stubbed so no OpenVINO runtime is needed.
+    """
     xml = (_models_dir() / "model.xml").resolve()
     bin_ = (_models_dir() / "model.bin").resolve()
     xml.write_text("<net/>")
@@ -329,7 +335,8 @@ def test_output_explicit_layout_uppercased():
 
 def test_layout_must_be_a_string():
     """`layout` reaches the validator as raw input, so a caller can put
-    anything there."""
+    anything there.
+    """
     with pytest.raises(TypeError, match="`layout` must be a string"):
         OutputConfig(name="o", shape=[1, 10], layout=5)  # type: ignore[arg-type]
 
@@ -797,7 +804,8 @@ def test_input_without_name_raises():
 
 def test_custom_output_with_shape_and_dtype():
     """Output not present in metadata but given a shape/dtype hits the
-    ``None, None`` branch (no ONNX lookup)."""
+    ``None, None`` branch (no ONNX lookup).
+    """
     config = Config.get_config(
         None,
         {

--- a/tests/unit/test_conversion_helpers.py
+++ b/tests/unit/test_conversion_helpers.py
@@ -1,3 +1,9 @@
+"""Tests for the per-target conversion option helpers.
+
+Covers the target-specific CLI options and the conditions under which the
+superblob option is skipped.
+"""
+
 import pytest
 
 from modelconverter.utils.types import Platform

--- a/tests/unit/test_docker_entrypoint.py
+++ b/tests/unit/test_docker_entrypoint.py
@@ -42,7 +42,8 @@ TIMEOUT = 5
 @pytest.fixture
 def entrypoint(tmp_path: Path) -> Path:
     """Lays the entrypoint out the way the image does, with the shared
-    part next to it."""
+    part next to it.
+    """
     app = tmp_path / "app"
     app.mkdir()
     shutil.copy(DOCKER_DIR / "rvc2" / "entrypoint.sh", app / "entrypoint.sh")
@@ -53,8 +54,9 @@ def entrypoint(tmp_path: Path) -> Path:
 
 
 def _entrypoint_env(tmp_path: Path, body: str) -> dict[str, str]:
-    """Puts a fake ``modelconverter`` on PATH and returns the
-    environment to run the entrypoint with."""
+    """Put a fake ``modelconverter`` on PATH and return the
+    environment to run the entrypoint with.
+    """
     executable = tmp_path / "modelconverter"
     executable.write_text(f"#!/usr/bin/env bash\n{body}")
     executable.chmod(0o755)
@@ -74,7 +76,7 @@ def _entrypoint_process(
     env: dict[str, str],
     stdin: bool = False,
 ) -> Generator[subprocess.Popen, None, None]:
-    """Runs the entrypoint and leaves nothing of it behind.
+    """Run the entrypoint and leaves nothing of it behind.
 
     The entrypoint runs the converter as a background child, so killing
     the entrypoint alone -- all a timeout does -- would leave that child
@@ -165,7 +167,7 @@ def test_entrypoint_forwards_signals_and_waits_for_child_cleanup(
 
 @pytest.fixture
 def mounts(tmp_path: Path) -> Path:
-    """An ``APP_ROOT`` laid out the way the container's mounts are."""
+    """Create an ``APP_ROOT`` laid out the way the container's mounts are."""
     app = tmp_path / "app_root"
     (app / "output").mkdir(parents=True)
     cache = app / "shared_with_container"
@@ -175,7 +177,7 @@ def mounts(tmp_path: Path) -> Path:
 
 
 def _recording_chown(tmp_path: Path) -> Path:
-    """Puts a ``chown`` that only records its arguments on PATH."""
+    """Put a ``chown`` that only records its arguments on PATH."""
     recorder = tmp_path / "chown"
     recorder.write_text(
         '#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$CHOWN_LOG"\n'
@@ -224,7 +226,8 @@ def test_entrypoint_hands_back_the_dev_mounts_it_finds(
 ) -> None:
     """A dev container mounts the host checkout over the installed
     package and the suite over the image's, and running as root leaves
-    ``__pycache__`` in both."""
+    ``__pycache__`` in both.
+    """
     (mounts / "tests").mkdir()
     (mounts / "modelconverter").mkdir()
     log = _recording_chown(tmp_path)
@@ -241,7 +244,8 @@ def test_entrypoint_leaves_ownership_alone_without_a_host_identity(
 ) -> None:
     """Under a rootless or user-namespaced daemon the launcher passes no
     identity, and chowning anyway would hand the files to an unmapped
-    sub-uid."""
+    sub-uid.
+    """
     log = _recording_chown(tmp_path)
     env = _handover_env(tmp_path, mounts, log)
     del env["HOST_UID"]
@@ -255,7 +259,8 @@ def test_wait_for_gives_up_on_a_path_that_never_appears(
     tmp_path: Path,
 ) -> None:
     """The helper bounds every wait, so a step the entrypoint never
-    reaches fails the test instead of hanging the run."""
+    reaches fails the test instead of hanging the run.
+    """
     assert _wait_for(tmp_path / "never", timeout=0.05) is False
 
 

--- a/tests/unit/test_doctests.py
+++ b/tests/unit/test_doctests.py
@@ -1,0 +1,79 @@
+"""Run the doctests in the package's own docstrings.
+
+``--doctest-modules`` cannot be turned on wholesale here the way it is in
+``luxonis-ml``: importing every module of the package would pull in the
+vendor toolchains, which only exist inside a target's Docker image. The
+package is walked instead, and a module that will not import on the host
+is reported as skipped rather than passed.
+"""
+
+import doctest
+import importlib
+import pkgutil
+from contextlib import suppress
+
+import pytest
+from loguru import logger
+
+import modelconverter
+
+# The toolchains that only exist inside a target's Docker image.
+_VENDOR_MODULES = frozenset({"hailo_sdk_client", "openvino", "plotly"})
+
+
+def _module_names() -> list[str]:
+    return sorted(
+        module.name
+        for module in pkgutil.walk_packages(
+            modelconverter.__path__, f"{modelconverter.__name__}."
+        )
+        # `__main__` builds the CLI app at import time.
+        if not module.name.endswith(".__main__")
+    )
+
+
+def _find_doctests(module_name: str) -> list[doctest.DocTest]:
+    module = importlib.import_module(module_name)
+    return doctest.DocTestFinder().find(module, module_name)
+
+
+@pytest.mark.parametrize("module_name", _module_names())
+def test_doctests(module_name: str) -> None:
+    try:
+        tests = _find_doctests(module_name)
+    except ImportError as e:
+        # Only a missing vendor toolchain is an expected failure. Any
+        # other import error is a regression, so let it fail the test.
+        if e.name not in _VENDOR_MODULES:
+            raise
+        pytest.skip(f"needs the {e.name} toolchain")
+
+    runner = doctest.DocTestRunner()
+    # The log goes to stdout, which is what doctest compares against.
+    logger.disable("modelconverter")
+    try:
+        for test in tests:
+            runner.run(test)
+    finally:
+        logger.enable("modelconverter")
+
+    assert runner.failures == 0, (
+        f"{runner.failures} of {runner.tries} doctest examples failed "
+        f"in {module_name}"
+    )
+
+
+def test_doctests_are_collected() -> None:
+    """Guard the skip above from hiding every doctest.
+
+    A packaging change that broke the host imports would otherwise turn
+    this whole module green while running nothing.
+    """
+    found = 0
+    for module_name in _module_names():
+        with suppress(ImportError):
+            found += sum(
+                len(test.examples) for test in _find_doctests(module_name)
+            )
+
+    assert found, "no doctest examples are reachable on the host"

--- a/tests/unit/test_general.py
+++ b/tests/unit/test_general.py
@@ -142,7 +142,8 @@ def test_parse_size_reads_the_units_human_size_writes(
     value: str, expected: int
 ):
     """The two are read and written by the same people, so a size shown
-    by `cache info` has to be one the budget accepts back."""
+    by `cache info` has to be one the budget accepts back.
+    """
     assert parse_size(value) == expected
 
 
@@ -156,7 +157,8 @@ def test_parse_size_rejects_what_is_not_a_size(value: str):
 
 def test_human_size_stops_at_the_unit_parse_size_reads_back():
     """`cache info` shows a size the user may hand back as a budget, so
-    the largest unit written has to be one that is also read."""
+    the largest unit written has to be one that is also read.
+    """
     shown = human_size(1024**4)
     assert shown == "1.0 TiB"
     assert parse_size(shown) == 1024**4

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -38,7 +38,8 @@ def _make_img(
     color: tuple[int, int, int] = (10, 20, 30),
 ) -> Path:
     """Write a solid-color RGB image (``size`` is ``(width,
-    height)``)."""
+    height)``).
+    """
     Image.new("RGB", size, color).save(path)
     return path
 
@@ -261,7 +262,8 @@ def test_output_geometry_matches_the_requested_shape(
     transpose: bool,
 ):
     """Whatever the source size, the sample has the shape the model
-    asked for."""
+    asked for.
+    """
     src = _make_img(work_dir / "src.png", size=source)
     height, width = target
     encoding = Encoding.GRAY if channels == 1 else Encoding.RGB

--- a/tests/unit/test_inferer_from_config.py
+++ b/tests/unit/test_inferer_from_config.py
@@ -22,7 +22,8 @@ from tests.helpers.onnx_factory import single_io_onnx
 
 class _StubInferer(Inferer):
     """The smallest concrete ``Inferer``; ``from_config`` needs no
-    more."""
+    more.
+    """
 
     def setup(self) -> None: ...
 
@@ -102,5 +103,6 @@ def test_shapes_and_dtypes_are_mapped(work_dir: Path):
 
 def test_the_stand_in_reports_no_outputs(work_dir: Path):
     """The stand-in has no vendor runtime, so its forward pass produces
-    nothing; `from_config` needs no more than that."""
+    nothing; `from_config` needs no more than that.
+    """
     assert _build(work_dir, [1, 3, 64, 64]).infer({}) == {}

--- a/tests/unit/test_inferer_output_dir.py
+++ b/tests/unit/test_inferer_output_dir.py
@@ -22,7 +22,8 @@ from modelconverter.utils.constants import INFERENCE_MARKER
 
 class _StubInferer(Inferer):
     """The smallest concrete ``Inferer``; the destination handling runs
-    before anything vendor-specific would."""
+    before anything vendor-specific would.
+    """
 
     def setup(self) -> None: ...
 
@@ -56,7 +57,8 @@ def test_missing_destination_is_created_and_marked(work_dir: Path):
 def test_empty_destination_is_accepted(work_dir: Path):
     """An empty directory holds nothing that could be lost, so the
     missing marker must not block it -- the user may well have created
-    the directory themselves."""
+    the directory themselves.
+    """
     dest = work_dir / "output" / "results"
     dest.mkdir(parents=True)
 
@@ -67,7 +69,8 @@ def test_empty_destination_is_accepted(work_dir: Path):
 
 def test_own_results_are_replaced(work_dir: Path):
     """A rerun starts from a clean directory, so stale outputs from the
-    previous run cannot be mistaken for this run's."""
+    previous run cannot be mistaken for this run's.
+    """
     dest = work_dir / "output" / "results"
     dest.mkdir(parents=True)
     (dest / INFERENCE_MARKER).touch()
@@ -84,7 +87,8 @@ def test_own_results_are_replaced(work_dir: Path):
 def test_foreign_directory_is_refused(work_dir: Path):
     """``output/`` also holds the conversion results, so an
     ``--output-dir`` that collides with one must fail instead of
-    deleting it."""
+    deleting it.
+    """
     dest = work_dir / "output" / "mnist_to_rvc4_2026_01_01_00_00_00"
     dest.mkdir(parents=True)
     converted = dest / "mnist.dlc"
@@ -110,5 +114,6 @@ def test_file_destination_is_refused(work_dir: Path):
 def test_the_stand_in_reports_no_outputs(work_dir: Path):
     """`Inferer` is abstract; the stand-in exists so the destination
     handling can run, and its forward pass has no vendor runtime to
-    produce anything with."""
+    produce anything with.
+    """
     assert _infer_into(work_dir / "dest").infer({}) == {}

--- a/tests/unit/test_input_staging.py
+++ b/tests/unit/test_input_staging.py
@@ -1,3 +1,10 @@
+"""Tests for staging user inputs into the hidden cache.
+
+Covers which paths are copied and rewritten to their container-side
+locations, how staged entries are keyed, claimed and evicted, and the
+budget that bounds the cache.
+"""
+
 import ast
 import errno
 import os
@@ -559,7 +566,8 @@ def test_restaging_a_changed_model_replaces_the_previous_bundle(
     tmp_path: Path, cache_dir: Path
 ) -> None:
     """An ONNX model and its external data are one entry, superseded as
-    one."""
+    one.
+    """
     inputs_dir = cache_dir / "inputs"
     model_path = tmp_path / "models" / "model.onnx"
     model_path.parent.mkdir()
@@ -581,7 +589,8 @@ def test_restaging_a_changed_config_replaces_the_previous_copy(
     tmp_path: Path, cache_dir: Path
 ) -> None:
     """The rewritten config is keyed by its own text, so every edit used
-    to leave the previous one behind for good."""
+    to leave the previous one behind for good.
+    """
     inputs_dir = cache_dir / "inputs"
     model = tmp_path / "model.onnx"
     model.write_bytes(b"model")
@@ -868,7 +877,8 @@ def test_stages_the_quantization_overrides_file(
     tmp_path: Path, cache_dir: Path
 ) -> None:
     """`rvc4.snpe_onnx_to_dlc_args` is a raw argument list, but the value
-    after `--quantization_overrides` is a file the config opens."""
+    after `--quantization_overrides` is a file the config opens.
+    """
     config_dir = tmp_path / "configs"
     config_dir.mkdir()
     overrides = config_dir / "encodings.json"
@@ -911,7 +921,8 @@ def test_stages_the_transformations_config(
     tmp_path: Path, cache_dir: Path
 ) -> None:
     """`--transformations_config` names a file the model optimizer opens,
-    so it is staged like any other input the container has to read."""
+    so it is staged like any other input the container has to read.
+    """
     config_dir = tmp_path / "configs"
     config_dir.mkdir()
     transformations = config_dir / "custom.json"
@@ -952,7 +963,8 @@ def test_stages_the_compile_tool_config(
     tmp_path: Path, cache_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """`compile_tool -c` names a configuration file, which the exporter
-    writes itself only when the user has not supplied one."""
+    writes itself only when the user has not supplied one.
+    """
     monkeypatch.chdir(tmp_path)
     compile_config = tmp_path / "compile.conf"
     compile_config.write_text("MYRIAD_NUMBER_OF_SHAVES 4")
@@ -981,7 +993,8 @@ def test_sibling_symlinks_to_one_directory_are_both_staged(
     tmp_path: Path, cache_dir: Path
 ) -> None:
     """The inferer expects one directory per input, and two of them may
-    well be the same images under different names."""
+    well be the same images under different names.
+    """
     shared = tmp_path / "images"
     shared.mkdir()
     (shared / "image.raw").write_bytes(b"image")
@@ -1003,7 +1016,8 @@ def test_a_symlink_pointing_back_up_is_not_followed(
     tmp_path: Path, cache_dir: Path
 ) -> None:
     """A convenience link such as `calib/all -> ..` would otherwise copy
-    the whole surrounding tree into the cache."""
+    the whole surrounding tree into the cache.
+    """
     (tmp_path / "unrelated.bin").write_bytes(b"unrelated")
     calib = tmp_path / "calib"
     calib.mkdir()
@@ -1025,7 +1039,8 @@ def test_an_output_destination_override_is_left_alone(
     tmp_path: Path, cache_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Rewriting a destination would upload the converted model into the
-    cache instead of where the user asked for it."""
+    cache instead of where the user asked for it.
+    """
     monkeypatch.chdir(tmp_path)
     (tmp_path / "nas").mkdir()
     tokens = ["convert", "rvc4", "output_remote_url", "./nas"]
@@ -1037,7 +1052,8 @@ def test_a_bare_directory_name_is_staged_for_a_path_override(
     tmp_path: Path, cache_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The config schema says the value is a path, which beats guessing
-    from a shape that a bare name does not have."""
+    from a shape that a bare name does not have.
+    """
     monkeypatch.chdir(tmp_path)
     (tmp_path / "calib").mkdir()
     (tmp_path / "calib" / "image.raw").write_bytes(b"image")
@@ -1055,7 +1071,8 @@ def test_a_single_dash_flag_value_is_not_staged(
     tmp_path: Path, cache_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """`-c` takes a shell command, not an input path; only long options
-    were recognised as introducing a value."""
+    were recognised as introducing a value.
+    """
     monkeypatch.chdir(tmp_path)
     (tmp_path / "script.py").write_bytes(b"print()")
     tokens = ["shell", "rvc4", "-c", "./script.py"]
@@ -1100,7 +1117,7 @@ def test_replacing_directory_content_in_place_restages_it(
 def _fabricated_file(
     path: Path, **stat_fields: int
 ) -> "input_staging._InputFile":
-    """An enumerated file with a stat this test controls.
+    """Build an enumerated file with a stat this test controls.
 
     Two filesystems cannot be mounted from a unit test, so the one
     property that distinguishes them -- `st_dev` -- has to be supplied.
@@ -1195,7 +1212,8 @@ def test_a_dotted_output_destination_override_is_left_alone(
     tmp_path: Path, cache_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A destination field keeps naming a destination when it is reached
-    through a stage prefix."""
+    through a stage prefix.
+    """
     monkeypatch.chdir(tmp_path)
     (tmp_path / "exported").mkdir()
     tokens = [
@@ -1214,7 +1232,8 @@ def test_stages_the_flag_equals_value_quantization_overrides(
     tmp_path: Path, cache_dir: Path
 ) -> None:
     """`--quantization_overrides=file` names the same file as the
-    two-token spelling and has to reach the container all the same."""
+    two-token spelling and has to reach the container all the same.
+    """
     config_dir = tmp_path / "configs"
     config_dir.mkdir()
     overrides = config_dir / "encodings.json"
@@ -1256,7 +1275,8 @@ def test_a_negative_decimal_is_not_mistaken_for_a_flag(
     tmp_path: Path, cache_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """`-.5` is an override value; treating it as an option would exempt
-    whatever comes after it from staging."""
+    whatever comes after it from staging.
+    """
     monkeypatch.chdir(tmp_path)
     model = tmp_path / "model.onnx"
     single_io_onnx(model)
@@ -1275,7 +1295,8 @@ def test_staged_files_are_claimed_while_the_process_lives(
 ) -> None:
     """`cache clean` consults the claims, so a conversion whose staged
     inputs are plain files needs them no less than one that staged a
-    directory."""
+    directory.
+    """
     monkeypatch.chdir(tmp_path)
     model = tmp_path / "model.onnx"
     single_io_onnx(model)
@@ -1289,7 +1310,8 @@ def test_staged_files_are_claimed_while_the_process_lives(
 def test_a_claim_from_a_recycled_pid_is_ignored(tmp_path: Path) -> None:
     """A killed run leaves its marker behind, and its pid may since have
     been handed to an unrelated long-lived process; the recorded creation
-    time is what tells the two apart."""
+    time is what tells the two apart.
+    """
     entry = tmp_path / "digest"
     entry.mkdir()
     marker = entry / f"{input_staging._IN_USE_PREFIX}{os.getpid()}"
@@ -1302,13 +1324,15 @@ def test_a_claim_from_a_recycled_pid_is_ignored(tmp_path: Path) -> None:
 
 def test_path_flags_of_no_command() -> None:
     """The launcher parses the command before staging; when it has none
-    there is nothing whose signature could name a path."""
+    there is nothing whose signature could name a path.
+    """
     assert input_staging.path_flags_for(None) == set()
 
 
 def test_path_flags_of_an_uninspectable_command() -> None:
     """Staging follows the command signature, so a command it cannot
-    read leaves every token alone rather than guessing."""
+    read leaves every token alone rather than guessing.
+    """
     assert input_staging.path_flags_for(object()) == set()  # type: ignore[arg-type]
 
 
@@ -1316,7 +1340,8 @@ def test_stages_a_path_joined_to_its_flag(
     tmp_path: Path, cache_dir: Path
 ) -> None:
     """`--model-path=<path>` carries the path in the same token as the
-    flag, so the token has to be rewritten around it."""
+    flag, so the token has to be rewritten around it.
+    """
     model = tmp_path / "model.dlc"
     model.write_bytes(b"dlc")
 
@@ -1337,7 +1362,8 @@ def test_leaves_a_joined_value_of_another_flag_alone(cache_dir: Path) -> None:
 
 def test_arg_list_override_that_is_not_a_list(tmp_path: Path) -> None:
     """The override is read the way `LuxonisConfig` reads it, and a
-    value that is not a list holds no arguments to rewrite."""
+    value that is not a list holds no arguments to rewrite.
+    """
     assert (
         input_staging._stage_arg_list_token(
             "42", "snpe_onnx_to_dlc_args", tmp_path
@@ -1354,7 +1380,8 @@ def test_a_dot_prefixed_name_is_path_like(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A leading `.` says the user meant a path, so the name is staged
-    even without a known extension."""
+    even without a known extension.
+    """
     monkeypatch.chdir(tmp_path)
     (tmp_path / ".hidden").write_text("x")
 
@@ -1363,7 +1390,8 @@ def test_a_dot_prefixed_name_is_path_like(
 
 def test_a_value_naming_no_home_is_not_a_path() -> None:
     """`~` for a user that does not exist is not something `Path` can
-    represent."""
+    represent.
+    """
     assert input_staging._as_path("~nosuchuser4242/model.onnx") is None
 
 
@@ -1375,7 +1403,8 @@ def test_publishing_reraises_an_unexpected_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Losing the rename race is normal and accepted; anything else is
-    not staging's to swallow."""
+    not staging's to swallow.
+    """
 
     def refuse_rename(self: Path, target: Path) -> Path:
         raise OSError(errno.EACCES, "denied")
@@ -1390,7 +1419,8 @@ def test_an_unreadable_config_is_staged_verbatim(
     tmp_path: Path, cache_dir: Path
 ) -> None:
     """Staging must not be what reports a broken config: the container
-    validates it and says something useful."""
+    validates it and says something useful.
+    """
     config = tmp_path / "broken.yaml"
     config.write_text("a: [1, 2\n")
 
@@ -1414,7 +1444,8 @@ def test_a_config_reference_that_is_not_a_path_is_left_alone(
     tmp_path: Path,
 ) -> None:
     """`calibration.script` may hold the script itself rather than a
-    path to one."""
+    path to one.
+    """
     assert (
         input_staging._stage_config_reference(
             "~nosuchuser4242/x", tmp_path, tmp_path
@@ -1447,7 +1478,7 @@ def test_staging_a_directory_skips_metadata_and_special_files(
 
 
 def _break_stat(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
-    """Makes ``Path.stat`` fail for the file called ``name``."""
+    """Make ``Path.stat`` fail for the file called ``name``."""
     real_stat = Path.stat
 
     def failing_stat(self: Path, **kwargs: bool) -> os.stat_result:
@@ -1463,7 +1494,8 @@ def test_a_directory_that_cannot_be_stat_ed_has_no_identity(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The identity is what a symlink cycle repeats; without one the
-    directory is simply skipped."""
+    directory is simply skipped.
+    """
     _break_stat(monkeypatch, "unstattable")
 
     assert input_staging._dir_key(tmp_path / "unstattable") is None
@@ -1473,7 +1505,8 @@ def test_a_claim_that_cannot_be_written_is_not_fatal(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A read-only cache still has to let the conversion run; the claim
-    is an optimisation, not a precondition."""
+    is an optimisation, not a precondition.
+    """
 
     def refuse_write(dest: Path, content: str) -> None:
         raise OSError("read-only file system")
@@ -1508,7 +1541,8 @@ def test_a_claim_that_cannot_be_inspected_still_holds(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The pid exists but belongs to another user, so the entry may
-    still be in use and must not be evicted."""
+    still be in use and must not be evicted.
+    """
     marker = tmp_path / f"{input_staging._IN_USE_PREFIX}{os.getpid()}"
     marker.write_text("0.0")
 
@@ -1540,7 +1574,8 @@ def test_claiming_an_unwritable_cache_is_not_fatal(
 
 def test_trash_without_a_pid_in_its_name_is_kept(tmp_path: Path) -> None:
     """The name records the sweep that made it; one that carries no pid
-    cannot be shown to be stale."""
+    cannot be shown to be stale.
+    """
     trash = tmp_path / f"{input_staging._TRASH_PREFIX}notapid-entry"
     trash.mkdir()
 
@@ -1553,7 +1588,8 @@ def test_an_uninspectable_process_starts_now(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The start time only protects what this run staged; falling back
-    to now keeps that protection rather than dropping it."""
+    to now keeps that protection rather than dropping it.
+    """
 
     def refuse_inspection() -> psutil.Process:
         raise psutil.AccessDenied(0)
@@ -1583,7 +1619,8 @@ def test_an_entry_claimed_mid_eviction_that_cannot_be_put_back(
 ) -> None:
     """A claim that landed between the check and the rename normally
     puts the entry back. When even that fails the copy is dropped, which
-    costs a re-staging rather than leaving it under a trash name."""
+    costs a re-staging rather than leaving it under a trash name.
+    """
     entry = tmp_path / "entry"
     entry.mkdir()
     (entry / f"{input_staging._IN_USE_PREFIX}{os.getpid()}").write_text(
@@ -1609,7 +1646,8 @@ def test_a_file_that_cannot_be_stat_ed_is_hashed_directly(
     tmp_path: Path, cache_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The memo is keyed on the stat fingerprint; without one the
-    digest is still a description of the bytes."""
+    digest is still a description of the bytes.
+    """
     path = tmp_path / "model.dlc"
     path.write_bytes(b"payload")
     expected = input_staging._hash_file(path)

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -35,7 +35,7 @@ VENDOR_SUFFIXES = [
 
 
 def _assert_standard_io(meta: Metadata, output_dtype: DataType) -> None:
-    """The single-in/single-out shapes + dtypes the DLC CSV fixtures share."""
+    """Assert the single-in/single-out shapes + dtypes the DLC CSV fixtures share."""
     assert meta.input_shapes == {"input0": [1, 3, 64, 64]}
     assert meta.output_shapes == {"output0": [1, 10]}
     assert meta.input_dtypes["input0"] is DataType.FLOAT32
@@ -163,7 +163,8 @@ def test_output_section_runs_to_end_without_trailer(work_dir: Path):
 
 def test_missing_input_section_raises(work_dir: Path):
     """A CSV with no ``Input Name`` section is skipped, leaving the
-    inputs unset -- ``Metadata`` then rejects the partial result."""
+    inputs unset -- ``Metadata`` then rejects the partial result.
+    """
     csv = 'Output Name,Dimensions,Type\noutput0,"1,10",Float_32\n'
     path = work_dir / "no_inputs.csv"
     path.write_text(csv)
@@ -240,7 +241,8 @@ def test_tflite_missing_subgraph_raises(
 
 def test_read_tflite_tensor_without_a_tensor_raises():
     """A subgraph indexes its tensors, and an index it does not hold
-    says the model is malformed rather than empty."""
+    says the model is malformed rather than empty.
+    """
     subgraph = Mock()
     subgraph.Tensors.return_value = None
 
@@ -250,7 +252,8 @@ def test_read_tflite_tensor_without_a_tensor_raises():
 
 def test_read_tflite_tensor_without_a_name_raises():
     """The name keys the shape and dtype dictionaries, so a tensor
-    without one cannot be recorded."""
+    without one cannot be recorded.
+    """
     tensor = Mock()
     tensor.Name.return_value = None
     subgraph = Mock()

--- a/tests/unit/test_multistage_calibration.py
+++ b/tests/unit/test_multistage_calibration.py
@@ -48,6 +48,13 @@ class StubExporter:
     """The slice of ``Exporter`` that ``MultiStageExporter`` uses."""
 
     def __init__(self, config: SingleStageConfig, output_dir: Path) -> None:
+        """Record the attributes ``MultiStageExporter`` reads.
+
+        Args:
+            config: Config of the stage being exported.
+            output_dir: Directory the stage writes its outputs to.
+
+        """
         self.config = config
         self.output_dir = output_dir
         self.inputs = {inp.name: inp for inp in config.inputs}
@@ -58,9 +65,20 @@ class StubExporter:
 class StubInferer(Inferer):
     """A real ``Inferer`` with the vendor runtime replaced by ones."""
 
-    def setup(self) -> None: ...
+    def setup(self) -> None:
+        """Do nothing -- there is no vendor runtime to set up."""
 
     def infer(self, inputs: dict[str, Path]) -> dict[str, np.ndarray]:
+        """Return an array of ones for every output.
+
+        Args:
+            inputs: Mapping of input name to input file. Ignored, the
+                outputs do not depend on them.
+
+        Returns:
+            Mapping of output name to an array of ones of that shape.
+
+        """
         return {
             name: np.ones(shape, dtype=np.float32)
             for name, shape in self.out_shapes.items()
@@ -69,7 +87,7 @@ class StubInferer(Inferer):
 
 @pytest.fixture
 def calibration_dir(work_dir: Path) -> Path:
-    """A directory of images, never decoded -- ``infer`` is stubbed."""
+    """Create a directory of images, never decoded -- ``infer`` is stubbed."""
     path = work_dir / "calibration"
     path.mkdir()
     for i in range(N_CALIBRATION_IMAGES):
@@ -146,7 +164,8 @@ def test_script_calibration_uses_only_the_output_dirs(
 ):
     """The inferer marks its destination with a file that sits next to
     the per-output directories; feeding that file to the script as if it
-    were an output directory fails the whole conversion."""
+    were an output directory fails the whole conversion.
+    """
     exporter._produce_calibration_data(exporter.exporters["second"])
 
     path = _resolved_calibration(config).path
@@ -158,7 +177,8 @@ def test_script_calibration_uses_only_the_output_dirs(
 
 def test_inference_results_are_marked(exporter: MultiStageExporter):
     """The marker is what lets a rerun clear its own results, so it has
-    to be there even though the linking code skips it."""
+    to be there even though the linking code skips it.
+    """
     exporter._produce_calibration_data(exporter.exporters["second"])
 
     results_dir = (
@@ -175,7 +195,8 @@ def test_linked_output_calibration_points_at_the_output_dir(
     exporter: MultiStageExporter, config: Config
 ):
     """The ``output`` form of a link names one output directory
-    directly, so the marker never enters the picture."""
+    directly, so the marker never enters the picture.
+    """
     second = config.stages["second"]
     second.inputs[0].calibration = LinkCalibrationConfig(
         stage="first", output="output0"

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -65,8 +65,10 @@ def _single_input_archive_config(
     dtype: str = "float32",
     model_name: str = "model.onnx",
 ) -> Params:
-    """A one-input / one-output NN-archive ``config.json`` dict whose
-    single input's ``preprocessing`` block is fully controllable."""
+    """Build a one-input / one-output NN-archive ``config.json`` dict.
+
+    The single input's ``preprocessing`` block is fully controllable.
+    """
     return {
         "config_version": "1.0",
         "model": {
@@ -100,8 +102,9 @@ def _pack_single_input(
     grayscale: bool = False,
     input_type: str = "image",
 ) -> Path:
-    """Builds a matching dummy ONNX + single-input archive and returns
-    the ``.tar`` path."""
+    """Build a matching dummy ONNX + single-input archive and return
+    the ``.tar`` path.
+    """
     model_path = work_dir / "model.onnx"
     shape = None
     if grayscale:
@@ -417,7 +420,8 @@ def _config_to_nn(
     platform: Platform = Platform.RVC4,
 ) -> NNArchiveConfig:
     """``modelconverter_config_to_nn`` with the fixed test boilerplate (output
-    name + model path) filled in, exposing only what tests vary."""
+    name + model path) filled in, exposing only what tests vary.
+    """
     return modelconverter_config_to_nn(
         config,
         Path("out.onnx"),

--- a/tests/unit/test_onnx_compatibility.py
+++ b/tests/unit/test_onnx_compatibility.py
@@ -38,7 +38,8 @@ def test_external_data_paths_find_the_companion_file(tmp_path: Path):
 def test_has_external_data_is_false_without_external_data(tmp_path: Path):
     """Several callers branch on this to decide whether to re-save as
     external data at all, so an embedded model has to answer
-    ``False``."""
+    ``False``.
+    """
     model_path = single_io_onnx(tmp_path / "model.onnx")
 
     assert get_external_data_paths(model_path) == []

--- a/tests/unit/test_rootless_workflow.py
+++ b/tests/unit/test_rootless_workflow.py
@@ -18,14 +18,13 @@ _IMAGE = "luxonis/modelconverter-rvc4:test"
 
 
 def _mapping(value: ParamValue) -> Params:
-    """The value as the mapping the compose file is known to hold."""
+    """Return the value as the mapping the compose file holds."""
     assert isinstance(value, dict)
     return value
 
 
 def _strings(value: ParamValue) -> list[str]:
-    """The value as the list of strings the compose file is known to
-    hold."""
+    """Return the value as the list of strings the compose file holds."""
     assert isinstance(value, list)
     strings = [item for item in value if isinstance(item, str)]
     assert len(strings) == len(value)
@@ -222,7 +221,8 @@ def test_the_repository_is_only_mounted_into_dev_images(
 ):
     """The entrypoint hands every mount back to the invoking user, so a
     `tests/` that merely happens to sit in the working directory must not
-    be mounted -- let alone chowned -- by a plain conversion."""
+    be mounted -- let alone chowned -- by a plain conversion.
+    """
     config = _project(work_dir)
     (work_dir / "tests").mkdir()
     (work_dir / "modelconverter").mkdir()
@@ -238,7 +238,8 @@ def test_the_repository_is_mounted_into_a_dev_image(
     work_dir: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """A dev container runs the suite and the host source over the
-    installed package, which is what those mounts are for."""
+    installed package, which is what those mounts are for.
+    """
     config = _project(work_dir)
     (work_dir / "tests").mkdir()
     (work_dir / "modelconverter").mkdir()
@@ -256,7 +257,8 @@ def test_a_serialized_argument_list_reaches_the_container_staged(
 ):
     """The config-file form of this list is rewritten by the config
     walker; the CLI form has to come out the same way, since the
-    container opens the file either way."""
+    container opens the file either way.
+    """
     config = _project(work_dir)
     encodings = work_dir / "encodings.json"
     encodings.write_text('{"activation_encodings": {}, "param_encodings": {}}')
@@ -285,7 +287,8 @@ def test_the_memory_limit_reaches_compose_as_bytes(
     work_dir: Path, monkeypatch: pytest.MonkeyPatch, spelling: str
 ):
     """Every spelling of the same limit has to reach Compose as the same
-    number, which is what handing it over already parsed buys."""
+    number, which is what handing it over already parsed buys.
+    """
     config = _project(work_dir)
 
     launch = _launch(config, monkeypatch, extra=["--memory", spelling])
@@ -297,7 +300,8 @@ def test_the_memory_limit_reaches_compose_as_bytes(
 
 def test_a_memory_limit_that_is_not_a_size_is_rejected(work_dir: Path):
     """The launcher fails on the spot rather than handing Compose
-    something it will reject much later."""
+    something it will reject much later.
+    """
     config = _project(work_dir)
 
     with pytest.raises(ValueError, match="not a valid size"):

--- a/tests/unit/test_rvc4_exporter.py
+++ b/tests/unit/test_rvc4_exporter.py
@@ -1,3 +1,5 @@
+"""Tests for the RVC4 exporter."""
+
 from pathlib import Path
 
 import pytest

--- a/tests/unit/test_subprocess.py
+++ b/tests/unit/test_subprocess.py
@@ -21,7 +21,7 @@ def _command(code: str) -> list[str]:
 
 
 def _attached(process: Mock) -> SubprocessHandle:
-    """A handle whose psutil process is the given mock."""
+    """Create a handle whose psutil process is the given mock."""
     handle = SubprocessHandle(["command"])
     handle._ps_proc = process
     return handle

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -247,7 +247,8 @@ class _FakeTensorType:
 @pytest.fixture
 def fake_tflite(monkeypatch: pytest.MonkeyPatch) -> None:
     """Inject a fake ``tflite`` package so the import inside
-    ``from_tensorflow_dtype`` resolves without the real dependency."""
+    ``from_tensorflow_dtype`` resolves without the real dependency.
+    """
     tflite = ModuleType("tflite")
     tensor_type = ModuleType("tflite.TensorType")
     tensor_type.TensorType = _FakeTensorType  # type: ignore[attr-defined]
@@ -426,7 +427,7 @@ def test_as_nn_archive_dtype_all(dtype: DataType, expected: str):
 
 
 def _width(value: str) -> str:
-    """The trailing bit-width digits of a dtype name, if any."""
+    """Return the trailing bit-width digits of a dtype name, if any."""
     match = re.search(r"\d+$", value)
     return match.group() if match else ""
 


### PR DESCRIPTION
## Purpose

PR #274 went above 100 changed files. CodeRabbit does not review a diff that large. The test-suite migration moves to this stacked PR, so each PR stays under the limit.

## Specification

- Restores the Google-style docstring migration for the 46 test files that #274 defers.
- Turns the ruff `D` docstring gate back on for `tests/*`; only `D103` stays ignored.
- The tip tree is identical to the pre-split tip of #274 (`a1baf7d`). No content changed; it only moved.

## Dependencies & Potential Impact

No runtime dependency additions. The diff touches only `tests/` and two `pyproject.toml` lines.

## Deployment Plan

None / not applicable.

## Testing & Validation

- The full stack equals the verified tip `a1baf7d`: `pytest tests/unit -n auto` gives 924 passed, 6 skipped.
- The base without this PR was validated separately: main's test suite against the converted package gives 873 passed, 2 skipped. `prek run --all-files` and `ruff` are clean. The pyright profile matches the tip.
- Note: CI does not run on a PR whose base is not `main`. It runs when this PR retargets to `main` after #274 merges.

## AI Usage

Assisted-by: Claude Code:claude-fable-5

Submitted code was reviewed by a human: NO

The author is taking the responsibility for the contribution: YES

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhTizdLYx2W6YzR3p1mx6o