### PR TITLE
docs: document LDF calibration data support

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,11 @@ The `modelconverter` CLI is available inside the container as well.
 Calibration data can be a mix of images (`.jpg`, `.png`, `.jpeg`) and `.npy`, `.raw` files.
 Image files will be loaded and converted to the format specified in the config.
 
+LDF datasets are also supported as calibration data by setting `calibration.path` to `<dataset_name>:<split>`, or `<dataset_name>:<split>:<loader_plugin>` when using a custom loader.
+
+> [!NOTE]
+> Multi-input LDF datasets are not currently supported for calibration data.
+
 > [!IMPORTANT]
 > No conversion is performed for `.npy` or `.raw` files, the files are used as provided.
 


### PR DESCRIPTION
## Summary

- Document LDF calibration data support and the available path formats.
- Note that multi-input LDF datasets are not currently supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using LDF datasets as calibration data.
  * Documented support for custom loader plugins.
  * Noted that multi-input LDF datasets are not currently supported for calibration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->