### PR TITLE
Add Hailo 2025.07 and remove 2025.01

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -37,13 +37,13 @@
   },
   {
     "package": "hailo",
-    "version": "2025.01",
+    "version": "2025.04",
     "default": "2025.04",
     "os": "ubuntu-22.04-4core"
   },
   {
     "package": "hailo",
-    "version": "2025.04",
+    "version": "2025.07",
     "default": "2025.04",
     "os": "ubuntu-22.04-4core"
   }

--- a/modelconverter/platforms/hailo/exporter.py
+++ b/modelconverter/platforms/hailo/exporter.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from pathlib import Path
 
@@ -51,12 +52,15 @@ class HailoExporter(Exporter):
 
         logger.info("Translating model to Hailo IR.")
         if self._is_tflite:
+            translate_kwargs = {
+                "net_name": self._model_name,
+                "start_node_names": start_nodes,
+                "end_node_names": list(self._outputs.keys()),
+            }
+            if _supports_tf_tensor_shapes():
+                translate_kwargs["tensor_shapes"] = net_input_shapes
             runner.translate_tf_model(
-                str(self._input_model),
-                net_name=self._model_name,
-                start_node_names=start_nodes,
-                tensor_shapes=net_input_shapes,
-                end_node_names=list(self._outputs.keys()),
+                str(self._input_model), **translate_kwargs
             )
         else:
             runner.translate_onnx_model(
@@ -265,3 +269,23 @@ class HailoExporter(Exporter):
             "compression_level": self._compression_level,
             "alls": self._alls,
         }
+
+
+def _supports_tf_tensor_shapes() -> bool:
+    """Whether the Hailo DFC accepts tensor shapes for TFLite inputs.
+
+    The image Dockerfile turns its build argument into ``VERSION`` (for
+    example, ``2025.07`` becomes ``2025-07``). Hailo removed the option in
+    2025.07, so retain it for older or unknown installations.
+    """
+    version = os.environ.get("VERSION")
+    if version is None:
+        return True
+
+    try:
+        year, release = (
+            int(part) for part in version.replace("-", ".").split(".")[:2]
+        )
+    except ValueError:
+        return True
+    return (year, release) < (2025, 7)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Added Hailo 2025.07 since it is actually used internally
  - Also added `hailo-2025.07.tar.gz` to GCS
- Removed 2025.01 since it is not internally used
- Kept 2025.04 as default for now

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported Hailo package versions in the build configuration.
  * Aligned the default package version and advanced the subsequent supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->