### PR TITLE
Fix exported model path in Docker logs

### DIFF
--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -21,6 +21,7 @@ from rich.prompt import Confirm
 from rich.table import Table
 
 from modelconverter.cli import (
+    display_output_path,
     extract_preprocessing,
     get_configs,
     get_output_dir_name,
@@ -301,6 +302,10 @@ def convert(
                     archive_name=archive_name,
                 )
             ]
+
+        for model_path in out_models:
+            logger.info(f"Model exported to {display_output_path(model_path)}")
+
         output_artifact_count = len(out_models)
 
         if isinstance(exporter.config, SingleStageConfig):

--- a/modelconverter/cli/__init__.py
+++ b/modelconverter/cli/__init__.py
@@ -1,4 +1,5 @@
 from .utils import (
+    display_output_path,
     extract_preprocessing,
     get_configs,
     get_output_dir_name,
@@ -7,6 +8,7 @@ from .utils import (
 )
 
 __all__ = [
+    "display_output_path",
     "extract_preprocessing",
     "get_configs",
     "get_output_dir_name",

--- a/modelconverter/cli/utils.py
+++ b/modelconverter/cli/utils.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -19,6 +20,7 @@ from modelconverter.utils.constants import (
     CALIBRATION_DIR,
     CONFIGS_DIR,
     CONVERSION_MARKER,
+    HOST_OUTPUT_DIR_ENV_VAR,
     MISC_DIR,
     MODELS_DIR,
     OUTPUTS_DIR,
@@ -48,6 +50,22 @@ def resolve_output_dir(output_dir: str) -> Path:
             "without `..`."
         )
     return OUTPUTS_DIR / relative
+
+
+def display_output_path(path: Path) -> str:
+    host_output_dir = os.environ.get(HOST_OUTPUT_DIR_ENV_VAR)
+    if not in_docker() or not host_output_dir:
+        return str(path)
+
+    try:
+        relative = path.relative_to(OUTPUTS_DIR)
+    except ValueError:
+        return str(path)
+
+    if ".." in relative.parts:
+        return str(path)
+
+    return _join_display_path(host_output_dir, relative)
 
 
 def get_output_dir_name(
@@ -182,3 +200,19 @@ def extract_preprocessing(
         inp.encoding.to = Encoding.NONE
 
     return cfg, preprocessing
+
+
+def _join_display_path(root: str, relative: Path) -> str:
+    relative_display = relative.as_posix()
+    if relative_display == ".":
+        return root
+
+    use_backslash = "\\" in root and "/" not in root
+    separator = "\\" if use_backslash else "/"
+    if use_backslash:
+        relative_display = relative_display.replace("/", separator)
+
+    clean_root = root.rstrip("/\\")
+    if not clean_root:
+        return f"{separator}{relative_display}"
+    return f"{clean_root}{separator}{relative_display}"

--- a/modelconverter/utils/constants.py
+++ b/modelconverter/utils/constants.py
@@ -54,6 +54,7 @@ MODELS_DIR: Final[Path] = SHARED_DIR / "models"
 # on purpose: an inference rerun must not wipe a conversion's output either.
 CONVERSION_MARKER: Final[str] = ".modelconverter_output"
 INFERENCE_MARKER: Final[str] = ".modelconverter_inference"
+HOST_OUTPUT_DIR_ENV_VAR: Final[str] = "MODELCONVERTER_HOST_OUTPUT_DIR"
 
 LOADERS = Registry(name="loaders")
 
@@ -62,6 +63,7 @@ __all__ = [
     "CONFIGS_DIR",
     "CONTAINER_SHARED_DIR",
     "CONVERSION_MARKER",
+    "HOST_OUTPUT_DIR_ENV_VAR",
     "INFERENCE_MARKER",
     "MISC_DIR",
     "MODELS_DIR",

--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -26,6 +26,7 @@ import docker
 from modelconverter import __version__
 from modelconverter.utils.constants import (
     CONTAINER_SHARED_DIR,
+    HOST_OUTPUT_DIR_ENV_VAR,
     get_cache_dir,
     in_docker,
 )
@@ -150,9 +151,11 @@ def generate_compose_config(
         environment.update(extra_environment)
 
     cwd = Path.cwd().absolute()
+    host_output_dir = cwd / "output"
+    environment[HOST_OUTPUT_DIR_ENV_VAR] = str(host_output_dir)
     volumes = [
         f"{get_cache_dir()}:{CONTAINER_SHARED_DIR}",
-        f"{cwd / 'output'}:/app/output",
+        f"{host_output_dir}:/app/output",
     ]
     is_dev = image.endswith("-dev")
     # Mount the test suite (excluded from the image via .dockerignore) so a

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -1,4 +1,5 @@
 import json
+import os
 import tarfile
 from itertools import pairwise
 from pathlib import Path
@@ -23,7 +24,12 @@ from modelconverter.utils.config import (
     InputConfig,
     PlatformConfig,
 )
-from modelconverter.utils.constants import MISC_DIR
+from modelconverter.utils.constants import (
+    HOST_OUTPUT_DIR_ENV_VAR,
+    MISC_DIR,
+    OUTPUTS_DIR,
+    in_docker,
+)
 from modelconverter.utils.layout import guess_new_layout, make_default_layout
 from modelconverter.utils.metadata import Metadata, get_metadata
 from modelconverter.utils.types import (
@@ -39,6 +45,37 @@ def get_archive_input(cfg: NNArchiveConfig, name: str) -> NNArchiveInput:
         if inp.name == name:
             return inp
     raise ValueError(f"Input {name} not found in the archive config")
+
+
+def _join_display_path(root: str, relative: Path) -> str:
+    relative_display = relative.as_posix()
+    if relative_display == ".":
+        return root
+
+    use_backslash = "\\" in root and "/" not in root
+    separator = "\\" if use_backslash else "/"
+    if use_backslash:
+        relative_display = relative_display.replace("/", separator)
+
+    clean_root = root.rstrip("/\\")
+    if not clean_root:
+        return f"{separator}{relative_display}"
+    return f"{clean_root}{separator}{relative_display}"
+
+
+def _archive_display_path(archive: Path) -> str:
+    host_output_dir = os.environ.get(HOST_OUTPUT_DIR_ENV_VAR)
+    if not in_docker() or not host_output_dir:
+        return str(archive)
+
+    try:
+        relative = archive.relative_to(OUTPUTS_DIR)
+    except ValueError:
+        return str(archive)
+
+    if ".." in relative.parts:
+        return str(archive)
+    return _join_display_path(host_output_dir, relative)
 
 
 def process_nn_archive(
@@ -542,7 +579,7 @@ def generate_archive(
         ],
     )
     archive = generator.make_archive()
-    logger.info(f"Model exported to {archive}")
+    logger.info(f"Model exported to {_archive_display_path(archive)}")
     return archive
 
 

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -1,5 +1,4 @@
 import json
-import os
 import tarfile
 from itertools import pairwise
 from pathlib import Path
@@ -24,12 +23,7 @@ from modelconverter.utils.config import (
     InputConfig,
     PlatformConfig,
 )
-from modelconverter.utils.constants import (
-    HOST_OUTPUT_DIR_ENV_VAR,
-    MISC_DIR,
-    OUTPUTS_DIR,
-    in_docker,
-)
+from modelconverter.utils.constants import MISC_DIR
 from modelconverter.utils.layout import guess_new_layout, make_default_layout
 from modelconverter.utils.metadata import Metadata, get_metadata
 from modelconverter.utils.types import (
@@ -45,37 +39,6 @@ def get_archive_input(cfg: NNArchiveConfig, name: str) -> NNArchiveInput:
         if inp.name == name:
             return inp
     raise ValueError(f"Input {name} not found in the archive config")
-
-
-def _join_display_path(root: str, relative: Path) -> str:
-    relative_display = relative.as_posix()
-    if relative_display == ".":
-        return root
-
-    use_backslash = "\\" in root and "/" not in root
-    separator = "\\" if use_backslash else "/"
-    if use_backslash:
-        relative_display = relative_display.replace("/", separator)
-
-    clean_root = root.rstrip("/\\")
-    if not clean_root:
-        return f"{separator}{relative_display}"
-    return f"{clean_root}{separator}{relative_display}"
-
-
-def _archive_display_path(archive: Path) -> str:
-    host_output_dir = os.environ.get(HOST_OUTPUT_DIR_ENV_VAR)
-    if not in_docker() or not host_output_dir:
-        return str(archive)
-
-    try:
-        relative = archive.relative_to(OUTPUTS_DIR)
-    except ValueError:
-        return str(archive)
-
-    if ".." in relative.parts:
-        return str(archive)
-    return _join_display_path(host_output_dir, relative)
 
 
 def process_nn_archive(
@@ -578,9 +541,7 @@ def generate_archive(
             output_path / "buildinfo.json",
         ],
     )
-    archive = generator.make_archive()
-    logger.info(f"Model exported to {_archive_display_path(archive)}")
-    return archive
+    return generator.make_archive()
 
 
 def _get_io_dtype(

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 import pytest
 
+import modelconverter.cli.utils as cli_utils
 from modelconverter.cli.utils import (
+    display_output_path,
     extract_preprocessing,
     get_configs,
     get_output_dir_name,
@@ -16,6 +18,7 @@ from modelconverter.utils.constants import (
     CALIBRATION_DIR,
     CONFIGS_DIR,
     CONVERSION_MARKER,
+    HOST_OUTPUT_DIR_ENV_VAR,
     MODELS_DIR,
     OUTPUTS_DIR,
 )
@@ -37,6 +40,74 @@ def test_output_dir_default_name():
     out = get_output_dir_name(Platform.RVC4, "my_model", None)
     assert out.parent == OUTPUTS_DIR
     assert out.name.startswith("my_model_to_rvc4_")
+
+
+@pytest.mark.parametrize(
+    (
+        "in_docker_context",
+        "host_output_dir",
+        "path",
+        "expected",
+    ),
+    [
+        (
+            True,
+            "/home/user/project/output",
+            Path("/app/output/model/model.rvc4.tar.xz"),
+            "/home/user/project/output/model/model.rvc4.tar.xz",
+        ),
+        (
+            True,
+            None,
+            Path("/app/output/model/model.rvc4.tar.xz"),
+            "/app/output/model/model.rvc4.tar.xz",
+        ),
+        (
+            True,
+            "/home/user/project/output",
+            Path("/outside-output/model.rvc4.tar.xz"),
+            "/outside-output/model.rvc4.tar.xz",
+        ),
+        (
+            False,
+            "/home/user/project/output",
+            Path("/app/output/model/model.rvc4.tar.xz"),
+            "/app/output/model/model.rvc4.tar.xz",
+        ),
+        (
+            True,
+            "/home/user/project/output",
+            Path("/app/output/../other/model.rvc4.tar.xz"),
+            "/app/output/../other/model.rvc4.tar.xz",
+        ),
+        (
+            True,
+            r"C:\Users\me\project\output",
+            Path("/app/output/model/model.rvc4.tar.xz"),
+            r"C:\Users\me\project\output\model\model.rvc4.tar.xz",
+        ),
+    ],
+)
+def test_display_output_path(
+    monkeypatch: pytest.MonkeyPatch,
+    in_docker_context: bool,
+    host_output_dir: str | None,
+    path: Path,
+    expected: str,
+):
+    if in_docker_context:
+        monkeypatch.setenv("IN_DOCKER", "1")
+    else:
+        monkeypatch.delenv("IN_DOCKER", raising=False)
+
+    if host_output_dir is None:
+        monkeypatch.delenv(HOST_OUTPUT_DIR_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, host_output_dir)
+
+    monkeypatch.setattr(cli_utils, "OUTPUTS_DIR", Path("/app/output"))
+
+    assert display_output_path(path) == expected
 
 
 def test_output_dir_explicit_and_previous_conversion_is_wiped():

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -29,10 +29,10 @@ class _FakeExporter(Exporter):
         return {}
 
     def export(self) -> Path:
-        return self._inference_model_path
+        return self.inference_model_path
 
     def run(self) -> Path:
-        return self._inference_model_path
+        return self.inference_model_path
 
 
 class _FakeMultiStageExporter:

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -35,11 +35,30 @@ class _FakeExporter(Exporter):
         return self._inference_model_path
 
 
+class _FakeMultiStageExporter:
+    def __init__(
+        self,
+        platform: Platform,
+        config: Config,
+        output_dir: Path,
+    ) -> None:
+        self.platform = platform
+        self.config = config
+        self.output_dir = output_dir
+
+    def run(self) -> list[Path]:
+        return [
+            self.output_dir / "first.dlc",
+            self.output_dir / "second.dlc",
+        ]
+
+
 @pytest.mark.parametrize(
-    ("output_mode", "expected_name"),
+    ("output_mode", "expected_names", "multistage"),
     [
-        ("native", "model.dlc"),
-        ("nn_archive", "model.rvc4.tar.xz"),
+        ("native", ["model.dlc"], False),
+        ("nn_archive", ["model.rvc4.tar.xz"], False),
+        ("native", ["first.dlc", "second.dlc"], True),
     ],
 )
 def test_convert_logs_final_artifact_for_each_output_mode(
@@ -47,16 +66,30 @@ def test_convert_logs_final_artifact_for_each_output_mode(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     output_mode: Literal["native", "nn_archive"],
-    expected_name: str,
+    expected_names: list[str],
+    multistage: bool,
 ) -> None:
-    cfg = Config.get_config(
-        None,
-        {
-            "input_model": str(dummy_onnx),
-            "shape": [1, 3, 64, 64],
-        },
-    )
-    main_stage = next(iter(cfg.stages))
+    if multistage:
+        cfg = Config.get_config(
+            None,
+            {
+                "name": "pipeline",
+                "stages": {
+                    "first": {"input_model": str(dummy_onnx)},
+                    "second": {"input_model": str(dummy_onnx)},
+                },
+            },
+        )
+        main_stage = "first"
+    else:
+        cfg = Config.get_config(
+            None,
+            {
+                "input_model": str(dummy_onnx),
+                "shape": [1, 3, 64, 64],
+            },
+        )
+        main_stage = next(iter(cfg.stages))
     output_dir = tmp_path / "output"
     messages: list[str] = []
 
@@ -84,6 +117,11 @@ def test_convert_logs_final_artifact_for_each_output_mode(
             config,
             output_dir,
         ),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "MultiStageExporter",
+        _FakeMultiStageExporter,
     )
     monkeypatch.setattr(
         main_module,
@@ -130,5 +168,5 @@ def test_convert_logs_final_artifact_for_each_output_mode(
     ]
 
     assert export_messages == [
-        f"Model exported to /host/output/{expected_name}"
+        f"Model exported to /host/output/{name}" for name in expected_names
     ]

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -1,0 +1,134 @@
+from pathlib import Path
+from typing import Literal
+
+import pytest
+from luxonis_ml.typing import Params
+
+import modelconverter.__main__ as main_module
+from modelconverter.platforms.base_exporter import Exporter
+from modelconverter.utils.config import Config, SingleStageConfig
+from modelconverter.utils.types import Platform
+
+
+class _FakeTelemetry:
+    def capture(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+
+class _FakeExporter(Exporter):
+    def __init__(
+        self,
+        config: SingleStageConfig,
+        output_dir: Path,
+    ) -> None:
+        self.config = config
+        self.output_dir = output_dir
+        self._inference_model_path = output_dir / "model.dlc"
+
+    def exporter_buildinfo(self) -> Params:
+        return {}
+
+    def export(self) -> Path:
+        return self._inference_model_path
+
+    def run(self) -> Path:
+        return self._inference_model_path
+
+
+@pytest.mark.parametrize(
+    ("output_mode", "expected_name"),
+    [
+        ("native", "model.dlc"),
+        ("nn_archive", "model.rvc4.tar.xz"),
+    ],
+)
+def test_convert_logs_final_artifact_for_each_output_mode(
+    dummy_onnx: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    output_mode: Literal["native", "nn_archive"],
+    expected_name: str,
+) -> None:
+    cfg = Config.get_config(
+        None,
+        {
+            "input_model": str(dummy_onnx),
+            "shape": [1, 3, 64, 64],
+        },
+    )
+    main_stage = next(iter(cfg.stages))
+    output_dir = tmp_path / "output"
+    messages: list[str] = []
+
+    monkeypatch.setattr(main_module.signal, "signal", lambda *_args: None)
+    monkeypatch.setattr(main_module, "init_dirs", lambda: None)
+    monkeypatch.setattr(
+        main_module,
+        "get_configs",
+        lambda *_args, **_kwargs: (cfg, None, main_stage),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_output_dir_name",
+        lambda *_args, **_kwargs: output_dir,
+    )
+    monkeypatch.setattr(
+        main_module,
+        "setup_logging",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_exporter",
+        lambda _platform, config, output_dir: _FakeExporter(
+            config,
+            output_dir,
+        ),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_component_telemetry",
+        _FakeTelemetry,
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_conversion_run_id",
+        lambda: "test-run",
+    )
+    monkeypatch.setattr(
+        main_module,
+        "peak_ram_usage_bytes",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        main_module,
+        "is_nn_archive",
+        lambda _path: False,
+    )
+    monkeypatch.setattr(
+        main_module,
+        "display_output_path",
+        lambda path: f"/host/output/{path.name}",
+    )
+    monkeypatch.setattr(
+        main_module,
+        "generate_archive",
+        lambda **kwargs: kwargs["output_path"] / "model.rvc4.tar.xz",
+    )
+    monkeypatch.setattr(main_module.logger, "info", messages.append)
+
+    main_module.convert(
+        Platform.RVC4,
+        path=str(dummy_onnx),
+        to=output_mode,
+    )
+
+    export_messages = [
+        message
+        for message in messages
+        if message.startswith("Model exported to ")
+    ]
+
+    assert export_messages == [
+        f"Model exported to /host/output/{expected_name}"
+    ]

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -19,7 +19,6 @@ from luxonis_ml.nn_archive.config_building_blocks import (
 )
 from luxonis_ml.typing import Params, ParamValue
 
-import modelconverter.utils.nn_archive as nn_archive_utils
 from modelconverter.utils.config import (
     Config,
     InputConfig,
@@ -27,14 +26,9 @@ from modelconverter.utils.config import (
     RVC3Config,
     RVC4Config,
 )
-from modelconverter.utils.constants import (
-    HOST_OUTPUT_DIR_ENV_VAR,
-    MISC_DIR,
-    OUTPUTS_DIR,
-)
+from modelconverter.utils.constants import MISC_DIR, OUTPUTS_DIR
 from modelconverter.utils.metadata import get_metadata
 from modelconverter.utils.nn_archive import (
-    _archive_display_path,
     _default_archive_preprocessing,
     _get_io_dtype,
     archive_from_model,
@@ -848,123 +842,6 @@ def test_find_archive_input_found_and_missing(dummy_onnx: Path):
     assert found_input is not None
     assert found_input.name == "input0"
     assert find_archive_input(archive, "nope") is None
-
-
-@pytest.mark.parametrize(
-    (
-        "in_docker_context",
-        "host_output_dir",
-        "archive",
-        "expected",
-    ),
-    [
-        (
-            True,
-            "/home/user/project/output",
-            Path("/app/output/model/model.rvc4.tar.xz"),
-            "/home/user/project/output/model/model.rvc4.tar.xz",
-        ),
-        (
-            True,
-            None,
-            Path("/app/output/model/model.rvc4.tar.xz"),
-            "/app/output/model/model.rvc4.tar.xz",
-        ),
-        (
-            True,
-            "/home/user/project/output",
-            Path("/outside-output/model.rvc4.tar.xz"),
-            "/outside-output/model.rvc4.tar.xz",
-        ),
-        (
-            False,
-            "/home/user/project/output",
-            Path("/app/output/model/model.rvc4.tar.xz"),
-            "/app/output/model/model.rvc4.tar.xz",
-        ),
-        (
-            True,
-            "/home/user/project/output",
-            Path("/app/output/../other/model.rvc4.tar.xz"),
-            "/app/output/../other/model.rvc4.tar.xz",
-        ),
-        (
-            True,
-            r"C:\Users\me\project\output",
-            Path("/app/output/model/model.rvc4.tar.xz"),
-            r"C:\Users\me\project\output\model\model.rvc4.tar.xz",
-        ),
-    ],
-)
-def test_archive_display_path(
-    monkeypatch: pytest.MonkeyPatch,
-    in_docker_context: bool,
-    host_output_dir: str | None,
-    archive: Path,
-    expected: str,
-):
-    if in_docker_context:
-        monkeypatch.setenv("IN_DOCKER", "1")
-    else:
-        monkeypatch.delenv("IN_DOCKER", raising=False)
-    if host_output_dir is None:
-        monkeypatch.delenv(HOST_OUTPUT_DIR_ENV_VAR, raising=False)
-    else:
-        monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, host_output_dir)
-    monkeypatch.setattr(nn_archive_utils, "OUTPUTS_DIR", Path("/app/output"))
-
-    assert _archive_display_path(archive) == expected
-
-
-class _FakeArchiveGenerator:
-    def __init__(self, **_kwargs: object) -> None:
-        pass
-
-    def make_archive(self) -> Path:
-        return Path("/app/output/model/model.rvc4.tar.xz")
-
-
-def test_generate_archive_logs_host_display_path_but_returns_archive_path(
-    dummy_onnx: Path, monkeypatch: pytest.MonkeyPatch
-):
-    config = _config_from_overrides(dummy_onnx)
-    main_stage = next(iter(config.stages))
-    archive = Path("/app/output/model/model.rvc4.tar.xz")
-    messages: list[str] = []
-
-    class FakeNNArchive:
-        def model_dump(self) -> Params:
-            return {"config_version": "1.0", "model": {}}
-
-    monkeypatch.setenv("IN_DOCKER", "1")
-    monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, "/host/project/output")
-    monkeypatch.setattr(nn_archive_utils, "OUTPUTS_DIR", Path("/app/output"))
-    monkeypatch.setattr(
-        nn_archive_utils,
-        "modelconverter_config_to_nn",
-        lambda *_args: FakeNNArchive(),
-    )
-    monkeypatch.setattr(
-        nn_archive_utils, "ArchiveGenerator", _FakeArchiveGenerator
-    )
-    monkeypatch.setattr(nn_archive_utils.logger, "info", messages.append)
-
-    result = generate_archive(
-        Platform.RVC4,
-        config,
-        main_stage,
-        [Path("/app/output/model/model.dlc")],
-        Path("/app/output/model"),
-        None,
-        {},
-        dummy_onnx,
-        None,
-    )
-
-    assert result == archive
-    assert messages[-1] == (
-        "Model exported to /host/project/output/model/model.rvc4.tar.xz"
-    )
 
 
 def _prepare_output(name: str) -> Path:

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -19,6 +19,7 @@ from luxonis_ml.nn_archive.config_building_blocks import (
 )
 from luxonis_ml.typing import Params, ParamValue
 
+import modelconverter.utils.nn_archive as nn_archive_utils
 from modelconverter.utils.config import (
     Config,
     InputConfig,
@@ -26,9 +27,14 @@ from modelconverter.utils.config import (
     RVC3Config,
     RVC4Config,
 )
-from modelconverter.utils.constants import MISC_DIR, OUTPUTS_DIR
+from modelconverter.utils.constants import (
+    HOST_OUTPUT_DIR_ENV_VAR,
+    MISC_DIR,
+    OUTPUTS_DIR,
+)
 from modelconverter.utils.metadata import get_metadata
 from modelconverter.utils.nn_archive import (
+    _archive_display_path,
     _default_archive_preprocessing,
     _get_io_dtype,
     archive_from_model,
@@ -842,6 +848,129 @@ def test_find_archive_input_found_and_missing(dummy_onnx: Path):
     assert found_input is not None
     assert found_input.name == "input0"
     assert find_archive_input(archive, "nope") is None
+
+
+def test_archive_display_path_remaps_container_output(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("IN_DOCKER", "1")
+    monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, "/home/user/project/output")
+    monkeypatch.setattr(nn_archive_utils, "OUTPUTS_DIR", Path("/app/output"))
+
+    assert (
+        _archive_display_path(Path("/app/output/model/model.rvc4.tar.xz"))
+        == "/home/user/project/output/model/model.rvc4.tar.xz"
+    )
+
+
+def test_archive_display_path_without_host_context_preserves_container_path(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("IN_DOCKER", "1")
+    monkeypatch.delenv(HOST_OUTPUT_DIR_ENV_VAR, raising=False)
+
+    archive = Path("/app/output/model/model.rvc4.tar.xz")
+
+    assert _archive_display_path(archive) == str(archive)
+
+
+def test_archive_display_path_preserves_unrelated_container_path(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("IN_DOCKER", "1")
+    monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, "/home/user/project/output")
+    monkeypatch.setattr(nn_archive_utils, "OUTPUTS_DIR", Path("/app/output"))
+
+    archive = Path("/outside-output/model.rvc4.tar.xz")
+
+    assert _archive_display_path(archive) == str(archive)
+
+
+def test_archive_display_path_outside_docker_preserves_native_path(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("IN_DOCKER", raising=False)
+    monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, "/home/user/project/output")
+
+    archive = Path("/app/output/model/model.rvc4.tar.xz")
+
+    assert _archive_display_path(archive) == str(archive)
+
+
+def test_archive_display_path_preserves_lexical_parent_segment(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("IN_DOCKER", "1")
+    monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, "/home/user/project/output")
+    monkeypatch.setattr(nn_archive_utils, "OUTPUTS_DIR", Path("/app/output"))
+
+    archive = Path("/app/output/../other/model.rvc4.tar.xz")
+
+    assert _archive_display_path(archive) == str(archive)
+
+
+def test_archive_display_path_keeps_windows_host_style(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("IN_DOCKER", "1")
+    monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, r"C:\Users\me\project\output")
+    monkeypatch.setattr(nn_archive_utils, "OUTPUTS_DIR", Path("/app/output"))
+
+    assert (
+        _archive_display_path(Path("/app/output/model/model.rvc4.tar.xz"))
+        == r"C:\Users\me\project\output\model\model.rvc4.tar.xz"
+    )
+
+
+class _FakeArchiveGenerator:
+    def __init__(self, **_kwargs: object) -> None:
+        pass
+
+    def make_archive(self) -> Path:
+        return Path("/app/output/model/model.rvc4.tar.xz")
+
+
+def test_generate_archive_logs_host_display_path_but_returns_archive_path(
+    dummy_onnx: Path, monkeypatch: pytest.MonkeyPatch
+):
+    config = _config_from_overrides(dummy_onnx)
+    main_stage = next(iter(config.stages))
+    archive = Path("/app/output/model/model.rvc4.tar.xz")
+    messages: list[str] = []
+
+    class FakeNNArchive:
+        def model_dump(self) -> Params:
+            return {"config_version": "1.0", "model": {}}
+
+    monkeypatch.setenv("IN_DOCKER", "1")
+    monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, "/host/project/output")
+    monkeypatch.setattr(nn_archive_utils, "OUTPUTS_DIR", Path("/app/output"))
+    monkeypatch.setattr(
+        nn_archive_utils,
+        "modelconverter_config_to_nn",
+        lambda *_args: FakeNNArchive(),
+    )
+    monkeypatch.setattr(
+        nn_archive_utils, "ArchiveGenerator", _FakeArchiveGenerator
+    )
+    monkeypatch.setattr(nn_archive_utils.logger, "info", messages.append)
+
+    result = generate_archive(
+        Platform.RVC4,
+        config,
+        main_stage,
+        [Path("/app/output/model/model.dlc")],
+        Path("/app/output/model"),
+        None,
+        {},
+        dummy_onnx,
+        None,
+    )
+
+    assert result == archive
+    assert messages[-1] == (
+        "Model exported to /host/project/output/model/model.rvc4.tar.xz"
+    )
 
 
 def _prepare_output(name: str) -> Path:

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -850,76 +850,70 @@ def test_find_archive_input_found_and_missing(dummy_onnx: Path):
     assert find_archive_input(archive, "nope") is None
 
 
-def test_archive_display_path_remaps_container_output(
+@pytest.mark.parametrize(
+    (
+        "in_docker_context",
+        "host_output_dir",
+        "archive",
+        "expected",
+    ),
+    [
+        (
+            True,
+            "/home/user/project/output",
+            Path("/app/output/model/model.rvc4.tar.xz"),
+            "/home/user/project/output/model/model.rvc4.tar.xz",
+        ),
+        (
+            True,
+            None,
+            Path("/app/output/model/model.rvc4.tar.xz"),
+            "/app/output/model/model.rvc4.tar.xz",
+        ),
+        (
+            True,
+            "/home/user/project/output",
+            Path("/outside-output/model.rvc4.tar.xz"),
+            "/outside-output/model.rvc4.tar.xz",
+        ),
+        (
+            False,
+            "/home/user/project/output",
+            Path("/app/output/model/model.rvc4.tar.xz"),
+            "/app/output/model/model.rvc4.tar.xz",
+        ),
+        (
+            True,
+            "/home/user/project/output",
+            Path("/app/output/../other/model.rvc4.tar.xz"),
+            "/app/output/../other/model.rvc4.tar.xz",
+        ),
+        (
+            True,
+            r"C:\Users\me\project\output",
+            Path("/app/output/model/model.rvc4.tar.xz"),
+            r"C:\Users\me\project\output\model\model.rvc4.tar.xz",
+        ),
+    ],
+)
+def test_archive_display_path(
     monkeypatch: pytest.MonkeyPatch,
+    in_docker_context: bool,
+    host_output_dir: str | None,
+    archive: Path,
+    expected: str,
 ):
-    monkeypatch.setenv("IN_DOCKER", "1")
-    monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, "/home/user/project/output")
+    if in_docker_context:
+        monkeypatch.setenv("IN_DOCKER", "1")
+    else:
+        monkeypatch.delenv("IN_DOCKER", raising=False)
+    if host_output_dir is None:
+        monkeypatch.delenv(HOST_OUTPUT_DIR_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, host_output_dir)
     monkeypatch.setattr(nn_archive_utils, "OUTPUTS_DIR", Path("/app/output"))
 
-    assert (
-        _archive_display_path(Path("/app/output/model/model.rvc4.tar.xz"))
-        == "/home/user/project/output/model/model.rvc4.tar.xz"
-    )
-
-
-def test_archive_display_path_without_host_context_preserves_container_path(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.setenv("IN_DOCKER", "1")
-    monkeypatch.delenv(HOST_OUTPUT_DIR_ENV_VAR, raising=False)
-
-    archive = Path("/app/output/model/model.rvc4.tar.xz")
-
-    assert _archive_display_path(archive) == str(archive)
-
-
-def test_archive_display_path_preserves_unrelated_container_path(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.setenv("IN_DOCKER", "1")
-    monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, "/home/user/project/output")
-    monkeypatch.setattr(nn_archive_utils, "OUTPUTS_DIR", Path("/app/output"))
-
-    archive = Path("/outside-output/model.rvc4.tar.xz")
-
-    assert _archive_display_path(archive) == str(archive)
-
-
-def test_archive_display_path_outside_docker_preserves_native_path(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.delenv("IN_DOCKER", raising=False)
-    monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, "/home/user/project/output")
-
-    archive = Path("/app/output/model/model.rvc4.tar.xz")
-
-    assert _archive_display_path(archive) == str(archive)
-
-
-def test_archive_display_path_preserves_lexical_parent_segment(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.setenv("IN_DOCKER", "1")
-    monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, "/home/user/project/output")
-    monkeypatch.setattr(nn_archive_utils, "OUTPUTS_DIR", Path("/app/output"))
-
-    archive = Path("/app/output/../other/model.rvc4.tar.xz")
-
-    assert _archive_display_path(archive) == str(archive)
-
-
-def test_archive_display_path_keeps_windows_host_style(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.setenv("IN_DOCKER", "1")
-    monkeypatch.setenv(HOST_OUTPUT_DIR_ENV_VAR, r"C:\Users\me\project\output")
-    monkeypatch.setattr(nn_archive_utils, "OUTPUTS_DIR", Path("/app/output"))
-
-    assert (
-        _archive_display_path(Path("/app/output/model/model.rvc4.tar.xz"))
-        == r"C:\Users\me\project\output\model\model.rvc4.tar.xz"
-    )
+    assert _archive_display_path(archive) == expected
 
 
 class _FakeArchiveGenerator:

--- a/tests/unit/test_rootless_workflow.py
+++ b/tests/unit/test_rootless_workflow.py
@@ -11,7 +11,10 @@ from luxonis_ml.typing import Params, ParamValue
 
 from modelconverter.__main__ import app
 from modelconverter.utils import constants, docker_utils
-from modelconverter.utils.constants import CONTAINER_SHARED_DIR
+from modelconverter.utils.constants import (
+    CONTAINER_SHARED_DIR,
+    HOST_OUTPUT_DIR_ENV_VAR,
+)
 from tests.helpers.onnx_factory import single_io_onnx
 
 _IMAGE = "luxonis/modelconverter-rvc4:test"
@@ -171,6 +174,18 @@ def test_output_directory_is_created_by_the_host_user(
     _launch(config, monkeypatch)
 
     assert output_dir.is_dir()
+
+
+@pytest.mark.parametrize("image", [_IMAGE, f"{_IMAGE}-dev"])
+def test_host_output_display_context_reaches_the_container(
+    work_dir: Path, monkeypatch: pytest.MonkeyPatch, image: str
+):
+    config = _project(work_dir)
+
+    launch = _launch(config, monkeypatch, image=image)
+
+    environment = _mapping(launch.service["environment"])
+    assert environment[HOST_OUTPUT_DIR_ENV_VAR] == str(work_dir / "output")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- show the host-side output path in the final `Model exported to` log when running through Docker
- pass the host output directory into the container as display-only context
- preserve the actual archive path when host mapping context is unavailable or cannot be trusted

## Validation

- `python -m pytest tests/unit -n auto` - 883 passed, 1 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exported model paths are now displayed using host-visible paths when conversions run in Docker.
  - Docker workflows now provide the host output directory to containers.
  - Export completion logs consistently show the generated artifact path.

- **Bug Fixes**
  - Improved output path handling across Docker and non-Docker environments, including Windows-style paths and invalid relative paths.

- **Tests**
  - Added coverage for host output directory configuration, path display behavior, and export logging across supported output modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->