### PR TITLE
Fix the image pull against the containerd image store

### DIFF
--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -555,13 +555,21 @@ def pull_image(client: docker.DockerClient, image: str) -> str:
         bars = {}
         for log in client.api.pull(repository, tag=tag, stream=True):
             log = json.loads(log)
-            if "error" in log:
-                raise RuntimeError(log["error"])
+            # The daemon reports a failed pull in `errorDetail`. It used
+            # to repeat the text in a top-level `error`, but that field is
+            # deprecated and its API types no longer carry it.
+            if "errorDetail" in log or "error" in log:
+                detail = log.get("errorDetail", {})
+                raise RuntimeError(detail.get("message") or log.get("error"))
             status = log.get("status")
             if status not in {"Downloading", "Extracting"}:
                 continue
             id = log["id"]
             detail = log["progressDetail"]
+            # The containerd image store -- the default since Docker 29 --
+            # times the extraction instead of counting its bytes, and sends
+            # `{"current": 3, "units": "s"}`. Such a message has no total, and
+            # its seconds must not be written into a bar that counts bytes.
             total = detail.get("total")
             completed = detail["current"] if total is not None else None
             if id not in bars:

--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -15,7 +15,6 @@ import subprocess
 import sys
 import tempfile
 import zipfile
-from contextlib import suppress
 from functools import cache
 from http.client import HTTPMessage
 from pathlib import Path
@@ -542,6 +541,9 @@ def pull_image(client: docker.DockerClient, image: str) -> str:
     Returns:
         The name of the pulled image.
 
+    Raises:
+        RuntimeError: If the daemon reports an error while it pulls.
+
     """
     repository, tag = parse_repository_tag(image)
 
@@ -553,23 +555,23 @@ def pull_image(client: docker.DockerClient, image: str) -> str:
         bars = {}
         for log in client.api.pull(repository, tag=tag, stream=True):
             log = json.loads(log)
-            status = log["status"]
-            if status in {"Downloading", "Extracting"}:
-                id = log["id"]
-                detail = log["progressDetail"]
-                if id not in bars:
-                    bars[id] = progress.add_task(
-                        f"{id} [{status}]:",
-                        completed=detail["current"],
-                        total=detail["total"],
-                    )
-                else:
-                    progress.update(
-                        bars[id],
-                        completed=detail["current"],
-                        total=detail["total"],
-                        description=f"{id} [{status}]:",
-                    )
+            if "error" in log:
+                raise RuntimeError(log["error"])
+            status = log.get("status")
+            if status not in {"Downloading", "Extracting"}:
+                continue
+            id = log["id"]
+            detail = log["progressDetail"]
+            total = detail.get("total")
+            completed = detail["current"] if total is not None else None
+            if id not in bars:
+                bars[id] = progress.add_task(f"{id} [{status}]:", total=total)
+            progress.update(
+                bars[id],
+                completed=completed,
+                total=total,
+                description=f"{id} [{status}]:",
+            )
     return image
 
 
@@ -698,8 +700,10 @@ def _get_or_build_docker_image(
             f"the latest image from 'ghcr.io/{candidate}'..."
         )
 
-        with suppress(Exception):
+        try:
             return pull_image(client, f"ghcr.io/{candidate}")
+        except Exception as e:
+            logger.warning(f"Failed to pull 'ghcr.io/{candidate}': {e}")
 
     logger.error("Failed to pull the image, building it locally...")
     return docker_build(platform, bare_tag, version, image)

--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -555,30 +555,29 @@ def pull_image(client: docker.DockerClient, image: str) -> str:
         bars = {}
         for log in client.api.pull(repository, tag=tag, stream=True):
             log = json.loads(log)
-            # The daemon reports a failed pull in `errorDetail`. It used
-            # to repeat the text in a top-level `error`, but that field is
-            # deprecated and its API types no longer carry it.
-            if "errorDetail" in log or "error" in log:
-                detail = log.get("errorDetail", {})
-                raise RuntimeError(detail.get("message") or log.get("error"))
+            # A failed pull arrives in `errorDetail`. An older daemon also
+            # repeats the text in `error`, a field the current API drops.
+            error_detail = log.get("errorDetail", {})
+            error = error_detail.get("message") or log.get("error")
+            if error:
+                raise RuntimeError(error)
             status = log.get("status")
             if status not in {"Downloading", "Extracting"}:
                 continue
             id = log["id"]
             detail = log["progressDetail"]
-            # The containerd image store -- the default since Docker 29 --
-            # times the extraction instead of counting its bytes, and sends
-            # `{"current": 3, "units": "s"}`. Such a message has no total, and
-            # its seconds must not be written into a bar that counts bytes.
+            description = f"{id} [{status}]:"
+            # The containerd image store times an extraction rather than
+            # counting its bytes: no `total`, and `current` in seconds.
+            # `update` skips a None field, so the byte bar stays as it is.
             total = detail.get("total")
-            completed = detail["current"] if total is not None else None
             if id not in bars:
-                bars[id] = progress.add_task(f"{id} [{status}]:", total=total)
+                bars[id] = progress.add_task(description, total=total)
             progress.update(
                 bars[id],
-                completed=completed,
+                completed=detail["current"] if total is not None else None,
                 total=total,
-                description=f"{id} [{status}]:",
+                description=description,
             )
     return image
 
@@ -703,15 +702,15 @@ def _get_or_build_docker_image(
 ) -> str:
     client = get_docker_client_from_active_context()
     for candidate in candidate_images:
+        remote = f"ghcr.io/{candidate}"
         logger.warning(
-            f"Image '{candidate}' not found locally, pulling "
-            f"the latest image from 'ghcr.io/{candidate}'..."
+            f"Image '{candidate}' not found locally, "
+            f"pulling the latest image from '{remote}'..."
         )
-
         try:
-            return pull_image(client, f"ghcr.io/{candidate}")
+            return pull_image(client, remote)
         except Exception as e:
-            logger.warning(f"Failed to pull 'ghcr.io/{candidate}': {e}")
+            logger.warning(f"Failed to pull '{remote}': {e}")
 
     logger.error("Failed to pull the image, building it locally...")
     return docker_build(platform, bare_tag, version, image)

--- a/modelconverter/utils/docker_utils.py
+++ b/modelconverter/utils/docker_utils.py
@@ -555,8 +555,6 @@ def pull_image(client: docker.DockerClient, image: str) -> str:
         bars = {}
         for log in client.api.pull(repository, tag=tag, stream=True):
             log = json.loads(log)
-            # A failed pull arrives in `errorDetail`. An older daemon also
-            # repeats the text in `error`, a field the current API drops.
             error_detail = log.get("errorDetail", {})
             error = error_detail.get("message") or log.get("error")
             if error:
@@ -567,9 +565,6 @@ def pull_image(client: docker.DockerClient, image: str) -> str:
             id = log["id"]
             detail = log["progressDetail"]
             description = f"{id} [{status}]:"
-            # The containerd image store times an extraction rather than
-            # counting its bytes: no `total`, and `current` in seconds.
-            # `update` skips a None field, so the byte bar stays as it is.
             total = detail.get("total")
             if id not in bars:
                 bars[id] = progress.add_task(description, total=total)


### PR DESCRIPTION
## Purpose

Docker 29 makes the containerd image store its default. On such a host
`modelconverter` never pulls a platform image. The pull stops part way, and
the tool builds the image locally instead.

The two image stores describe an extraction differently. The classic store
counts its bytes. The containerd store times it, and sends
`{"current": 3, "units": "s"}`, a message with no `total`. `pull_image` read
`detail["total"]` on every message, so the first `Extracting` message raised
`KeyError: 'total'`. `_get_or_build_docker_image` suppressed that crash, so
the only sign was "Failed to pull the image, building it locally...".

## Specification

`modelconverter/utils/docker_utils.py` only:

- A message with no `total` relabels the bar and leaves its byte count alone.
  The elapsed seconds must not overwrite a count of bytes.
- A failed pull raises `RuntimeError`. The daemon reports it in `errorDetail`.
  The top-level `error` is deprecated, and the current API types drop it.
- The fallback logs why each candidate image failed, then builds as before.

## Dependencies & Potential Impact

No runtime dependency additions. The change is limited to the host-side pull.
The classic image store keeps its byte-counted bars.

## Testing & Validation

- Reproduced on Docker 29.7.2, rootless, containerd snapshotter.
  Every pull raised `KeyError: 'total'`.
- Real pulls of the `rvc2`, `rvc3`, `rvc4` and `hailo` images now run to the
  end and return the image name.
- Canned streams replayed through the pre-fix code confirm both failures: a
  timed extraction raises `KeyError: 'total'`, and an `errorDetail` the code
  could not read reports a failed pull as a success.

## AI Usage

Assisted-by: Claude Code:claude-opus-5[1m] ruff pyright

Submitted code was reviewed by a human: NO

The author is taking the responsibility for the contribution: YES

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScoPTxwFfatDMdrcN2PFwR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image pull error handling and logging.
  * Image pulls with incomplete progress information are now handled more reliably.
  * Improved compatibility with different Docker error response formats.
  * Failed image pulls now fall back to local image building with clearer error visibility.
* **Documentation**
  * Documented the runtime error behavior for image pulls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
