### PR TITLE
ModelConverter `v0.6.1`

### DIFF
--- a/modelconverter/__init__.py
+++ b/modelconverter/__init__.py
@@ -19,7 +19,7 @@ from typing import Final
 from luxonis_ml.utils import PUT_FILE_REGISTRY
 from pydantic_extra_types.semantic_version import SemanticVersion
 
-__version__: Final[str] = "0.6.0"
+__version__: Final[str] = "0.6.1"
 __semver__: Final[SemanticVersion] = SemanticVersion.parse(__version__)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Pillow
-luxonis-ml[data,nn_archive,s3,gcs,telemetry]~=0.9.0
+luxonis-ml[data,nn_archive,s3,gcs,telemetry]~=0.10.0
 cyclopts~=4.16
 onnx==1.21.0
 onnxruntime


### PR DESCRIPTION
## Purpose
Release ModelConverter `v0.6.1`. The `Release PR` workflow opened this
pull request, and the merge of it starts the release.

## Specification
The version in `modelconverter/__init__.py` becomes `0.6.1`.

Changes after `v0.6.0-beta`:

- Add strict validation for RVC4 quantization overrides (#288)
- Automate the release with the shared workflows (#298)
- Fix the image pull against the containerd image store (#296)
- Fix exported model path in Docker logs (#293)
- Migrate the test docs to Google docstyle (#289)
- Migrate the package docs to Google docstyle, document the public API, and gate CI on both (#274)
- Add Hailo 2025.07 and remove 2025.01 (#292)
- docs: document LDF calibration data support (#291)
- Add the pyright type gate and the unit coverage that goes with it (#282)
- Pre-docs cleanup: unify terminology and tighten the lint gate (#276)
- Increase top limit for coco auto test (#287)
- Setup Python virtual environment in CI workflow (#286)
- Updated eval  requirements (#281)
- Replace `hub_requests` with `hubai-sdk` (#279)
- Update GitHub Action Versions (#285)
- Add INT16_STANDARD quantization mode for RVC4 (#275)
- Update GitHub Action Versions (#280)
- Fix Hailo environment (#284)
- Install luxonis-ml before the NumPy pin returns (#278)
- Constrain NumPy when CI installs luxonis-ml into a platform image (#277)

## Dependencies & Potential Impact
This pull request changes the version only. The new version then goes to
PyPI under the same package name.

## Deployment Plan
1. Approve and merge this pull request.
2. The `Release Tag` workflow creates the tag, the release, and the notes.
3. The release event starts the publish workflows.

## Testing & Validation
CI runs on this pull request.

## AI Usage
The `Release PR` workflow generated this pull request. No AI tool wrote it.

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
