### PR TITLE
Make IO encoding normalization optional

### DIFF
--- a/configs/defaults.yaml
+++ b/configs/defaults.yaml
@@ -252,6 +252,11 @@ stages:
       # Currently supported only for ONNX input models.
       strict_quantization_overrides: False
 
+      # Normalize exposed input/output activation encodings to default int8
+      # values for DepthAI compatibility. Disable to preserve configured IO
+      # encodings.
+      normalize_io_encodings: True
+
       # List of platforms to pre-compute the DLC graph for.
       htp_socs: ["sm8550"]
 

--- a/modelconverter/platforms/rvc4/exporter.py
+++ b/modelconverter/platforms/rvc4/exporter.py
@@ -78,6 +78,7 @@ class RVC4Exporter(Exporter):
         self._strict_quantization_overrides = (
             rvc4_cfg.strict_quantization_overrides
         )
+        self._normalize_io_encodings = rvc4_cfg.normalize_io_encodings
         self._optimization_level = rvc4_cfg.optimization_level
         self._quantization_mode = rvc4_cfg.quantization_mode
         if self._quantization_mode != QuantizationMode.CUSTOM:
@@ -350,14 +351,15 @@ class RVC4Exporter(Exporter):
     def _generate_io_encodings(self, encodings: Encodings) -> Path:
         """Write the quantization overrides to a JSON file.
 
-        The encodings of the model's own inputs and outputs are replaced
-        by the default 8-bit integer encoding, as DAI does not support
-        custom TF8 encodings on exposed tensors. The encodings of the
-        internal tensors are written out unchanged.
+        When IO normalization is enabled, the encodings of the model's
+        own inputs and outputs are replaced by the default 8-bit integer
+        encoding for DAI compatibility. Otherwise, their configured
+        encodings are preserved. Internal tensor encodings are preserved
+        in either case.
 
         Args:
             encodings: Encodings as resolved from the configuration,
-                before the exposed tensors are normalized.
+                before any optional exposed-tensor normalization.
 
         Returns:
             Path to the written ``encodings.json``.
@@ -366,11 +368,12 @@ class RVC4Exporter(Exporter):
         encodings_dict = encodings.model_dump(mode="json", exclude_none=True)
         # DAI does not support custom TF8 encodings on exposed tensors.
         # Keep AIMET's internal tensor encodings, but normalize exposed
-        # inputs and outputs to default int8 IO.
-        for name in list(self._inputs.keys()) + list(self._outputs.keys()):
-            encodings_dict["activation_encodings"][name] = [
-                {"bitwidth": 8, "dtype": "int"}
-            ]
+        # inputs and outputs to default int8 IO when requested.
+        if self._normalize_io_encodings:
+            for name in list(self._inputs.keys()) + list(self._outputs.keys()):
+                encodings_dict["activation_encodings"][name] = [
+                    {"bitwidth": 8, "dtype": "int"}
+                ]
         encodings_path = self.intermediate_outputs_dir / "encodings.json"
         with open(encodings_path, "w") as encodings_file:
             json.dump(encodings_dict, encodings_file, indent=4)

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -568,6 +568,8 @@ class RVC4Config(PlatformConfig):
         strict_quantization_overrides: Whether to validate configured
             quantization override names against their activation/parameter
             groups in the effective ONNX model.
+        normalize_io_encodings: Whether to replace exposed input/output
+            activation encodings with the default 8-bit integer encoding.
         optimization_level: Optimization level of the DLC graph
             preparation. Higher levels take longer but yield a faster
             graph.
@@ -585,6 +587,7 @@ class RVC4Config(PlatformConfig):
     use_per_channel_quantization: bool = True
     use_per_row_quantization: bool = False
     strict_quantization_overrides: bool = False
+    normalize_io_encodings: bool = True
     optimization_level: Literal[1, 2, 3] = 2
     quantization_mode: QuantizationMode = QuantizationMode.INT8_STD
     htp_socs: list[

--- a/tests/conversion/test_rvc4_encodings.py
+++ b/tests/conversion/test_rvc4_encodings.py
@@ -16,10 +16,12 @@ so this e2e converts the toy conv net with:
     (off by default, so otherwise never exercised);
   * a non-default ``htp_socs`` -> ``snpe-dlc-graph-prepare --htp_socs``.
 
-``_generate_io_encodings`` normalizes the *exposed* input/output activation
-encodings to default int8 IO whatever we pass, so the custom values mainly
-exercise the internal-tensor / param path. The point is the exporter code, not
-numeric fidelity, so asserting a quantized ``.dlc`` is produced is enough.
+By default, ``_generate_io_encodings`` normalizes the *exposed*
+input/output activation encodings to default int8 IO, so the custom values
+mainly exercise the internal-tensor / param path. Setting
+``rvc4.normalize_io_encodings`` to false opts out of that rewrite. The point is
+the exporter code, not numeric fidelity, so asserting a quantized ``.dlc`` is
+produced is enough. Unit tests cover the normalization switch directly.
 
 Run inside the RVC4 Docker image::
 
@@ -95,15 +97,27 @@ def encodings_config(
 
 
 @pytest.mark.rvc4
-def test_rvc4_encodings(encodings_config: tuple[Path, Path]):
+@pytest.mark.parametrize(
+    "normalize_io_encodings",
+    [True, False],
+    ids=["normalize-io", "preserve-io"],
+)
+def test_rvc4_encodings(
+    encodings_config: tuple[Path, Path],
+    normalize_io_encodings: bool,
+):
     config_path, encodings_path = encodings_config
-    output_name = "_rvc4-encodings"
+    output_name = (
+        f"_rvc4-encodings-normalize-{str(normalize_io_encodings).lower()}"
+    )
     # `ast.literal_eval` parses the list/bool opts; the path string for
     # `rvc4.encodings` falls through as-is.
     convert(
         Platform.RVC4,
         "rvc4.encodings",
         str(encodings_path),
+        "rvc4.normalize_io_encodings",
+        str(normalize_io_encodings),
         "rvc4.use_per_row_quantization",
         "True",
         "rvc4.use_per_channel_quantization",

--- a/tests/unit/test_rvc4_exporter.py
+++ b/tests/unit/test_rvc4_exporter.py
@@ -1,11 +1,12 @@
 """Tests for the RVC4 exporter."""
 
+import json
 from pathlib import Path
 
 import pytest
 
 from modelconverter.platforms.rvc4.exporter import RVC4Exporter
-from modelconverter.utils.config import Config
+from modelconverter.utils.config import Config, Encodings, RVC4Config
 from tests.helpers.onnx_factory import single_io_onnx
 
 
@@ -14,6 +15,7 @@ def _make_exporter(
     mode: str,
     *,
     use_per_row_quantization: bool = False,
+    normalize_io_encodings: bool = True,
 ) -> RVC4Exporter:
     model = single_io_onnx(work_dir / f"{mode.lower()}.onnx").resolve()
 
@@ -24,6 +26,7 @@ def _make_exporter(
             "shape": [1, 3, 64, 64],
             "rvc4.quantization_mode": mode,
             "rvc4.use_per_row_quantization": use_per_row_quantization,
+            "rvc4.normalize_io_encodings": normalize_io_encodings,
         },
     )
     stage = next(iter(config.stages.values()))
@@ -91,6 +94,51 @@ def _capture_quant_command(
 def _flag_value(command: list[str], flag: str) -> str:
     index = command.index(flag)
     return command[index + 1]
+
+
+def test_normalize_io_encodings_default_true():
+    assert RVC4Config().normalize_io_encodings is True
+
+
+@pytest.mark.parametrize("normalize_io_encodings", [True, False])
+def test_normalize_io_encodings_controls_exposed_tensor_rewrite(
+    work_dir: Path,
+    normalize_io_encodings: bool,
+):
+    exporter = _make_exporter(
+        work_dir,
+        "CUSTOM",
+        normalize_io_encodings=normalize_io_encodings,
+    )
+    assert exporter._normalize_io_encodings is normalize_io_encodings
+
+    custom_encoding = {"bitwidth": 16, "dtype": "int"}
+    encodings = Encodings.model_validate(
+        {
+            "activation_encodings": {
+                "input0": [custom_encoding],
+                "hidden": [custom_encoding],
+                "output0": [custom_encoding],
+            },
+            "param_encodings": {
+                "weight": [custom_encoding],
+            },
+        }
+    )
+
+    encodings_path = exporter._generate_io_encodings(encodings)
+    generated = json.loads(encodings_path.read_text())
+
+    expected_io_encoding = (
+        [{"bitwidth": 8, "dtype": "int"}]
+        if normalize_io_encodings
+        else [custom_encoding]
+    )
+
+    assert generated["activation_encodings"]["input0"] == expected_io_encoding
+    assert generated["activation_encodings"]["output0"] == expected_io_encoding
+    assert generated["activation_encodings"]["hidden"] == [custom_encoding]
+    assert generated["param_encodings"]["weight"] == [custom_encoding]
 
 
 def test_int16_standard_native_quantizer_contract(


### PR DESCRIPTION
## Summary

Adds a new RVC4 configuration option:

```yaml
normalize_io_encodings: True
```

By default, exposed model input/output activation encodings continue to be normalized to the default INT8 encoding for DepthAI compatibility.

Setting `normalize_io_encodings` to `False` skips only that exposed-IO rewrite, preserving the configured encodings while leaving internal activation and parameter encodings unchanged.

The default is `True` to preserve the existing behavior.

## Testing

* Added unit coverage for:

  * default `True` behavior
  * exposed IO normalization when enabled
  * exposed IO preservation when disabled
  * unchanged internal activation encodings
  * unchanged parameter encodings
* Extended the RVC4 encodings conversion test to exercise both `True` and `False`.
* Targeted unit tests: `153 passed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an RVC4 option to control normalization of exposed input and output activation encodings.
  - Normalization is enabled by default, converting exposed encodings to the standard 8-bit integer format for DepthAI compatibility.
  - Users can disable normalization to preserve their configured input and output encodings.
  - Internal tensor encodings remain unchanged regardless of this setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->