### PR TITLE
Fix embedded preprocessing and NN Archive fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ The `encoding` flag in the YAML configuration file specifies the format that the
 > [!NOTE]
 > Certain options can be set **globally**, applying to all inputs of the model, or **per input**. If specified per input, these settings will override the global configuration for that input alone. The options that support this flexibility include `scale_values`, `mean_values`, `encoding`, `data_type`, `shape`, and `layout`.
 
+> [!NOTE]
+> A single `mean_values` or `scale_values` value is broadcast to every channel. A list must contain one value per channel, and scale values must be non-zero. ONNX preprocessing embedding currently supports `NCHW` and `NHWC` inputs.
+
 ### NN Archive Configuration File
 
 In the NN Archive configuration, there are two flags related to color encoding control:
@@ -122,14 +125,15 @@ In the NN Archive configuration, there are two flags related to color encoding c
 
   This flag is deprecated and will be replaced by the `dai_type` flag in future versions.
 
-- **`interleaved_to_planar`**:
-  A boolean flag indicating whether the input data should be converted from interleaved (`NHWC`) to planar (`NCHW`) format.
+- **`interleaved_to_planar` (Deprecated)**:
+  A legacy NN Archive flag indicating whether input data should be converted from interleaved (`NHWC`) to planar (`NCHW`) format.
 
-  - `True`: The converter will insert extra ONNX nodes to change the layout from interleaved to planar.
-  - `False`: No layout conversion is performed.
+  - `True`: ModelConverter treats the archive input as `NHWC` and passes that layout to the platform conversion tools.
+  - `False`: ModelConverter treats the archive input as `NCHW`.
 
-  If this flag is set to `null` or not provided, the converter will automatically determine and apply the necessary layout conversions. \
-  This flag is deprecated and will be replaced by the `dai_type` flag in future versions.
+  This can affect the input layout of the converted model. The exact conversion is platform-specific and does not necessarily involve inserting ONNX transpose nodes.
+
+This flag is deprecated and will be replaced by the `dai_type` flag in future versions.
 
 > [!NOTE]
 > If neither `dai_type` nor `reverse_channels` are provided, the input to the model is considered to be *"RGB"*.
@@ -486,10 +490,13 @@ Below is a table of common command-line options available when using the `modelc
 | `--main-stage`                                     |       | TEXT   | Name of the stage with the main model                                                                                                                      |
 | `--tool-version`                                   |       | TEXT   | Version of the underlying conversion tools to use. Available options differ based on the platform (RVC2, RVC3, RVC4, HAILO)                                |
 | `--image/docker-image`                             |       | TEXT   | Full Docker image name to use. If a tag is included, it is used as-is and overrides `--tool-version`, otherwise, the tag is derived from `--tool-version`. |
-| `--archive-preprocess` / `--no-archive-preprocess` |       | FLAG   | Add pre-processing to the NN archive instead of the model                                                                                                  |
+| `--archive-preprocess` / `--no-archive-preprocess` |       | FLAG   | Force preprocessing into NN Archive metadata instead of embedding it in the model; requires `--to nn_archive`                                              |
 
 > [!NOTE]
 > This table is not exhaustive. For more detailed information about available options, run `modelconverter convert --help` in your command line interface. You can also check all the `[ config overrides ]` available at [defaults.yaml](configs/defaults.yaml).
+
+> [!NOTE]
+> By default, ModelConverter first tries to embed preprocessing in the model. For NN Archive output, valid preprocessing that cannot be embedded is moved to archive metadata and conversion is retried with a warning. Native output fails instead because it has nowhere to preserve that preprocessing.
 
 **RVC4 Quantization Mode**
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ In the NN Archive configuration, there are two flags related to color encoding c
 
   This can affect the input layout of the converted model. The exact conversion is platform-specific and does not necessarily involve inserting ONNX transpose nodes.
 
-This flag is deprecated and will be replaced by the `dai_type` flag in future versions.
+  This flag is deprecated and will be replaced by the `dai_type` flag in future versions.
 
 > [!NOTE]
 > If neither `dai_type` nor `reverse_channels` are provided, the input to the model is considered to be *"RGB"*.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The `encoding` flag in the YAML configuration file specifies the format that the
 > Certain options can be set **globally**, applying to all inputs of the model, or **per input**. If specified per input, these settings will override the global configuration for that input alone. The options that support this flexibility include `scale_values`, `mean_values`, `encoding`, `data_type`, `shape`, and `layout`.
 
 > [!NOTE]
-> A single `mean_values` or `scale_values` value is broadcast to every channel. A list must contain one value per channel, and scale values must be non-zero. ONNX preprocessing embedding currently supports `NCHW` and `NHWC` inputs.
+> A single `mean_values` or `scale_values` value is broadcast to every channel. A list must contain either one value to broadcast or one value per channel, and scale values must be non-zero. ONNX preprocessing embedding currently supports `NCHW` and `NHWC` inputs.
 
 > [!IMPORTANT]
 > Use RGB, BGR, or GRAY encoding only when the input channels represent an image. Packed tensors, feature maps, and other non-image inputs—including tensors with nonstandard channel counts—must use `encoding: NONE`, which makes them raw tensor inputs rather than DepthAI image inputs.
@@ -493,13 +493,13 @@ Below is a table of common command-line options available when using the `modelc
 | `--main-stage`                                     |       | TEXT   | Name of the stage with the main model                                                                                                                      |
 | `--tool-version`                                   |       | TEXT   | Version of the underlying conversion tools to use. Available options differ based on the platform (RVC2, RVC3, RVC4, HAILO)                                |
 | `--image/docker-image`                             |       | TEXT   | Full Docker image name to use. If a tag is included, it is used as-is and overrides `--tool-version`, otherwise, the tag is derived from `--tool-version`. |
-| `--archive-preprocess` / `--no-archive-preprocess` |       | FLAG   | Force preprocessing into NN Archive metadata instead of embedding it in the model; requires `--to nn_archive`                                              |
+| `--archive-preprocess` / `--no-archive-preprocess` |       | FLAG   | For single-stage conversion, force preprocessing into NN Archive metadata instead of embedding it in the model; requires `--to nn_archive`                 |
 
 > [!NOTE]
 > This table is not exhaustive. For more detailed information about available options, run `modelconverter convert --help` in your command line interface. You can also check all the `[ config overrides ]` available at [defaults.yaml](configs/defaults.yaml).
 
 > [!NOTE]
-> By default, ModelConverter first tries to embed preprocessing in the model. For NN Archive output, valid preprocessing that cannot be embedded is moved to archive metadata and conversion is retried with a warning. Native output fails instead because it has nowhere to preserve that preprocessing.
+> By default, ModelConverter first tries to embed preprocessing in the model. For single-stage NN Archive output, valid preprocessing that cannot be embedded is moved to archive metadata and conversion is retried with a warning. This fallback is not supported for multi-stage conversions. Native output fails instead because it has nowhere to preserve that preprocessing.
 
 **RVC4 Quantization Mode**
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ The `encoding` flag in the YAML configuration file specifies the format that the
 > [!NOTE]
 > A single `mean_values` or `scale_values` value is broadcast to every channel. A list must contain one value per channel, and scale values must be non-zero. ONNX preprocessing embedding currently supports `NCHW` and `NHWC` inputs.
 
+> [!IMPORTANT]
+> Use RGB, BGR, or GRAY encoding only when the input channels represent an image. Packed tensors, feature maps, and other non-image inputs—including tensors with nonstandard channel counts—must use `encoding: NONE`, which makes them raw tensor inputs rather than DepthAI image inputs.
+
 ### NN Archive Configuration File
 
 In the NN Archive configuration, there are two flags related to color encoding control:

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -47,6 +47,7 @@ from modelconverter.platforms import (
     get_visualizer,
 )
 from modelconverter.platforms.base_benchmark import Configuration
+from modelconverter.platforms.base_exporter import Exporter
 from modelconverter.platforms.multistage_exporter import MultiStageExporter
 from modelconverter.utils import (
     ModelconverterException,
@@ -59,7 +60,7 @@ from modelconverter.utils import (
     resolve_path,
     upload_to_remote,
 )
-from modelconverter.utils.config import SingleStageConfig
+from modelconverter.utils.config import Config, SingleStageConfig
 from modelconverter.utils.constants import (
     CONVERSION_MARKER,
     MODELS_DIR,
@@ -101,7 +102,7 @@ from modelconverter.utils.telemetry import (
     resolve_tool_version,
     runtime_failure_reason_from_exception,
 )
-from modelconverter.utils.types import Platform
+from modelconverter.utils.types import InputFileType, Platform
 
 app = App(
     name="Modelconverter",
@@ -119,6 +120,55 @@ docker_parameters = Group.create_ordered(
 )
 docker_commands = Group.create_ordered("Docker Commands")
 device_commands = Group.create_ordered("Device Commands")
+
+
+def _archive_preprocessing_fallback(
+    platform: Platform, cfg: Config
+) -> tuple[list[str], str] | None:
+    """Describe preprocessing that can only be preserved in an archive.
+
+    Exporters do not know whether their output will be packaged in an NN
+    Archive, so they retain their hard failures for preprocessing they cannot
+    embed. The CLI uses this helper before constructing an exporter to recover
+    when an archive can carry that preprocessing instead.
+    """
+    if len(cfg.stages) != 1:
+        return None
+
+    stage = next(iter(cfg.stages.values()))
+    input_names = [
+        inp.name for inp in stage.inputs if inp.requires_input_preprocessing()
+    ]
+    if not input_names:
+        return None
+
+    if (
+        platform == Platform.RVC4
+        and stage.input_file_type != InputFileType.ONNX
+    ):
+        return (
+            input_names,
+            (
+                "RVC4 can only bake preprocessing into ONNX source models "
+                f"(the source is {stage.input_file_type.value})"
+            ),
+        )
+
+    if platform in {Platform.RVC2, Platform.RVC3} and (
+        stage.input_file_type == InputFileType.IR
+    ):
+        return (
+            input_names,
+            "RVC2/RVC3 cannot add preprocessing to an existing OpenVINO IR",
+        )
+
+    if platform == Platform.HAILO and stage.hailo.disable_calibration:
+        return (
+            input_names,
+            "Hailo cannot bake preprocessing when calibration is disabled",
+        )
+
+    return None
 
 
 @contextmanager
@@ -194,6 +244,12 @@ def convert(
     caught_exc: BaseException | None = None
 
     try:
+        if archive_preprocess and to != "nn_archive":
+            raise ModelconverterException(
+                "`--archive-preprocess` requires `--to nn_archive`; native "
+                "output cannot store externalized preprocessing."
+            )
+
         main_stage_provided = main_stage is not None
         if path is not None:
             suffix = Path(path).suffix
@@ -233,9 +289,23 @@ def convert(
             raise ValueError(
                 "Main stage name must be provided for multistage models."
             )
+
         preprocessing = {}
+        fallback_log: str | None = None
         if archive_preprocess:
             cfg, preprocessing = extract_preprocessing(cfg)
+        elif to == "nn_archive":
+            fallback = _archive_preprocessing_fallback(platform, cfg)
+            if fallback is not None:
+                input_names, reason = fallback
+                cfg, preprocessing = extract_preprocessing(cfg)
+                names = ", ".join(repr(name) for name in input_names)
+                fallback_log = (
+                    f"Automatic NN Archive preprocessing fallback: {reason}. "
+                    f"Moving preprocessing for input(s) {names} into the NN "
+                    "Archive; the converted model will not contain these "
+                    "preprocessing operations."
+                )
 
         output_path = get_output_dir_name(platform, cfg.name, output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
@@ -244,6 +314,15 @@ def convert(
             file=str(output_path / "modelconverter.log"),
             use_rich=cfg.rich_logging,
         )
+        if archive_preprocess:
+            logger.info(
+                "`--archive-preprocess` was specified; storing input "
+                "preprocessing in the NN Archive instead of baking it into "
+                "the converted model."
+            )
+        elif fallback_log is not None:
+            logger.warning(fallback_log)
+
         if is_multistage:
             exporter = MultiStageExporter(
                 platform=platform, config=cfg, output_dir=output_path
@@ -254,7 +333,6 @@ def convert(
                 config=next(iter(cfg.stages.values())),
                 output_dir=output_path,
             )
-
         conversion_summary = build_flow_properties(
             conversion_run_id,
             TelemetryFlowStep.CONFIGURATION_RESOLVED,
@@ -282,8 +360,6 @@ def convert(
         if not isinstance(out_models, list):
             out_models = [out_models]
         if to == "nn_archive":
-            from modelconverter.platforms.base_exporter import Exporter
-
             archive_name = None
             if original_path is not None and is_nn_archive(original_path):
                 archive_filename = Path(original_path).name

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -246,10 +246,11 @@ def convert(
 
         for stage in cfg.stages.values():
             for inp in stage.inputs:
-                if not inp.requires_input_preprocessing():
-                    continue
                 try:
-                    inp.validate_preprocessing()
+                    if inp.requires_input_preprocessing():
+                        inp.validate_preprocessing()
+                    else:
+                        inp.validate_input_contract()
                 except ValueError as error:
                     raise ModelconverterException(str(error)) from error
 

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -308,7 +308,7 @@ def convert(
 
             cfg, preprocessing = extract_preprocessing(cfg)
             preprocessing_externalized = True
-            names = ", ".join(repr(name) for name in input_names)
+            names = ", ".join(input_names)
             logger.warning(
                 f"Could not embed preprocessing for input(s) {names}: "
                 f"{error}. Falling back to NN Archive preprocessing; the "

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -191,6 +191,7 @@ def convert(
     overrides: list[str] = list(opts)
     conversion_start: float | None = None
     conversion_summary: dict[str, ParamValue] | None = None
+    configuration_captured = False
     output_artifact_count: int | None = None
     uploaded_output = False
     uploaded_intermediate_outputs = False
@@ -327,32 +328,31 @@ def convert(
                 output_dir=output_path,
             )
 
+        def resolved_conversion_summary() -> dict[str, ParamValue]:
+            """Build telemetry from the effective preprocessing placement."""
+            return build_flow_properties(
+                conversion_run_id,
+                TelemetryFlowStep.CONFIGURATION_RESOLVED,
+                build_conversion_summary(
+                    cfg,
+                    platform=platform,
+                    config_source=detect_config_source(
+                        original_path, overrides, archive_cfg
+                    ),
+                    archive_output_mode=ArchiveOutputMode(to),
+                    archive_preprocess=preprocessing_externalized,
+                    main_stage_provided=main_stage_provided,
+                ),
+            )
+
         try:
             exporter = make_exporter()
         except PreprocessingEmbeddingError as error:
             if not externalize_after_embedding_failure(error):
                 raise
+            conversion_summary = resolved_conversion_summary()
             exporter = make_exporter()
-        conversion_summary = build_flow_properties(
-            conversion_run_id,
-            TelemetryFlowStep.CONFIGURATION_RESOLVED,
-            build_conversion_summary(
-                cfg,
-                platform=platform,
-                config_source=detect_config_source(
-                    original_path, overrides, archive_cfg
-                ),
-                archive_output_mode=ArchiveOutputMode(to),
-                archive_preprocess=archive_preprocess,
-                main_stage_provided=main_stage_provided,
-            ),
-        )
-        runtime_telemetry.capture(
-            CONFIGURED_EVENT,
-            conversion_summary,
-            include_system_metadata=True,
-            distinct_id=conversion_run_id,
-        )
+        conversion_summary = resolved_conversion_summary()
 
         conversion_start = time.monotonic()
         phase = ConversionPhase.CONVERSION
@@ -361,8 +361,17 @@ def convert(
         except PreprocessingEmbeddingError as error:
             if not externalize_after_embedding_failure(error):
                 raise
+            conversion_summary = resolved_conversion_summary()
             exporter = make_exporter()
             out_models = exporter.run()
+
+        runtime_telemetry.capture(
+            CONFIGURED_EVENT,
+            conversion_summary,
+            include_system_metadata=True,
+            distinct_id=conversion_run_id,
+        )
+        configuration_captured = True
         if not isinstance(out_models, list):
             out_models = [out_models]
         if to == "nn_archive":
@@ -457,6 +466,13 @@ def convert(
         logger.exception("Encountered an unexpected error!")
         raise SystemExit(2) from exc
     finally:
+        if conversion_summary is not None and not configuration_captured:
+            runtime_telemetry.capture(
+                CONFIGURED_EVENT,
+                conversion_summary,
+                include_system_metadata=True,
+                distinct_id=conversion_run_id,
+            )
         peak_ram_bytes = peak_ram_usage_bytes()
         logger.info(f"Peak RAM usage: {peak_ram_bytes / (1024 * 1024):.2f} MB")
         logger.info(

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -51,6 +51,7 @@ from modelconverter.platforms.base_exporter import Exporter
 from modelconverter.platforms.multistage_exporter import MultiStageExporter
 from modelconverter.utils import (
     ModelconverterException,
+    PreprocessingEmbeddingError,
     archive_from_model,
     docker_build,
     docker_exec,
@@ -60,7 +61,7 @@ from modelconverter.utils import (
     resolve_path,
     upload_to_remote,
 )
-from modelconverter.utils.config import Config, SingleStageConfig
+from modelconverter.utils.config import SingleStageConfig
 from modelconverter.utils.constants import (
     CONVERSION_MARKER,
     MODELS_DIR,
@@ -102,7 +103,7 @@ from modelconverter.utils.telemetry import (
     resolve_tool_version,
     runtime_failure_reason_from_exception,
 )
-from modelconverter.utils.types import InputFileType, Platform
+from modelconverter.utils.types import Platform
 
 app = App(
     name="Modelconverter",
@@ -120,55 +121,6 @@ docker_parameters = Group.create_ordered(
 )
 docker_commands = Group.create_ordered("Docker Commands")
 device_commands = Group.create_ordered("Device Commands")
-
-
-def _archive_preprocessing_fallback(
-    platform: Platform, cfg: Config
-) -> tuple[list[str], str] | None:
-    """Describe preprocessing that can only be preserved in an archive.
-
-    Exporters do not know whether their output will be packaged in an NN
-    Archive, so they retain their hard failures for preprocessing they cannot
-    embed. The CLI uses this helper before constructing an exporter to recover
-    when an archive can carry that preprocessing instead.
-    """
-    if len(cfg.stages) != 1:
-        return None
-
-    stage = next(iter(cfg.stages.values()))
-    input_names = [
-        inp.name for inp in stage.inputs if inp.requires_input_preprocessing()
-    ]
-    if not input_names:
-        return None
-
-    if (
-        platform == Platform.RVC4
-        and stage.input_file_type != InputFileType.ONNX
-    ):
-        return (
-            input_names,
-            (
-                "RVC4 can only bake preprocessing into ONNX source models "
-                f"(the source is {stage.input_file_type.value})"
-            ),
-        )
-
-    if platform in {Platform.RVC2, Platform.RVC3} and (
-        stage.input_file_type == InputFileType.IR
-    ):
-        return (
-            input_names,
-            "RVC2/RVC3 cannot add preprocessing to an existing OpenVINO IR",
-        )
-
-    if platform == Platform.HAILO and stage.hailo.disable_calibration:
-        return (
-            input_names,
-            "Hailo cannot bake preprocessing when calibration is disabled",
-        )
-
-    return None
 
 
 @contextmanager
@@ -215,9 +167,11 @@ def convert(
             Only needed for multistage configs and when converting to
             NN Archive. When converting from NN Archive, the stage names
             are named the same as the model files without the suffix.
-        archive_preprocess: Add the pre-processing to the NN archive
-            instead of the model. In case of conversion from archive to
-            archive, it moves the preprocessing to the new archive.
+        archive_preprocess: Force preprocessing into NN Archive metadata
+            instead of embedding it in the model. Only valid with
+            ``to="nn_archive"``. Without this option, preprocessing is first
+            embedded when possible and otherwise falls back to archive
+            metadata for NN Archive output.
 
     """
 
@@ -290,22 +244,19 @@ def convert(
                 "Main stage name must be provided for multistage models."
             )
 
+        for stage in cfg.stages.values():
+            for inp in stage.inputs:
+                if not inp.requires_input_preprocessing():
+                    continue
+                try:
+                    inp.validate_preprocessing()
+                except ValueError as error:
+                    raise ModelconverterException(str(error)) from error
+
         preprocessing = {}
-        fallback_log: str | None = None
+        preprocessing_externalized = archive_preprocess
         if archive_preprocess:
             cfg, preprocessing = extract_preprocessing(cfg)
-        elif to == "nn_archive":
-            fallback = _archive_preprocessing_fallback(platform, cfg)
-            if fallback is not None:
-                input_names, reason = fallback
-                cfg, preprocessing = extract_preprocessing(cfg)
-                names = ", ".join(repr(name) for name in input_names)
-                fallback_log = (
-                    f"Automatic NN Archive preprocessing fallback: {reason}. "
-                    f"Moving preprocessing for input(s) {names} into the NN "
-                    "Archive; the converted model will not contain these "
-                    "preprocessing operations."
-                )
 
         output_path = get_output_dir_name(platform, cfg.name, output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
@@ -320,19 +271,56 @@ def convert(
                 "preprocessing in the NN Archive instead of baking it into "
                 "the converted model."
             )
-        elif fallback_log is not None:
-            logger.warning(fallback_log)
 
-        if is_multistage:
-            exporter = MultiStageExporter(
-                platform=platform, config=cfg, output_dir=output_path
+        def externalize_after_embedding_failure(
+            error: PreprocessingEmbeddingError,
+        ) -> bool:
+            """Move preprocessing to the archive when retrying is safe."""
+            nonlocal cfg, preprocessing, preprocessing_externalized
+            if (
+                to != "nn_archive"
+                or preprocessing_externalized
+                or is_multistage
+            ):
+                return False
+
+            stage = next(iter(cfg.stages.values()))
+            input_names = [
+                inp.name
+                for inp in stage.inputs
+                if inp.requires_input_preprocessing()
+            ]
+            if not input_names:
+                return False
+
+            cfg, preprocessing = extract_preprocessing(cfg)
+            preprocessing_externalized = True
+            names = ", ".join(repr(name) for name in input_names)
+            logger.warning(
+                f"Could not embed preprocessing for input(s) {names}: "
+                f"{error}. Falling back to NN Archive preprocessing; the "
+                "converted model will not contain these preprocessing "
+                "operations."
             )
-        else:
-            exporter = get_exporter(
+            return True
+
+        def make_exporter() -> Exporter | MultiStageExporter:
+            if is_multistage:
+                return MultiStageExporter(
+                    platform=platform, config=cfg, output_dir=output_path
+                )
+            return get_exporter(
                 platform,
                 config=next(iter(cfg.stages.values())),
                 output_dir=output_path,
             )
+
+        try:
+            exporter = make_exporter()
+        except PreprocessingEmbeddingError as error:
+            if not externalize_after_embedding_failure(error):
+                raise
+            exporter = make_exporter()
         conversion_summary = build_flow_properties(
             conversion_run_id,
             TelemetryFlowStep.CONFIGURATION_RESOLVED,
@@ -356,7 +344,13 @@ def convert(
 
         conversion_start = time.monotonic()
         phase = ConversionPhase.CONVERSION
-        out_models = exporter.run()
+        try:
+            out_models = exporter.run()
+        except PreprocessingEmbeddingError as error:
+            if not externalize_after_embedding_failure(error):
+                raise
+            exporter = make_exporter()
+            out_models = exporter.run()
         if not isinstance(out_models, list):
             out_models = [out_models]
         if to == "nn_archive":

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -254,8 +254,14 @@ def convert(
                     raise ModelconverterException(str(error)) from error
 
         preprocessing = {}
+        preprocessing_input_types: dict[str, Literal["raw", "image"]] = {}
         preprocessing_externalized = archive_preprocess
         if archive_preprocess:
+            stage = next(iter(cfg.stages.values()))
+            preprocessing_input_types = {
+                inp.name: "raw" if inp.is_raw_input else "image"
+                for inp in stage.inputs
+            }
             cfg, preprocessing = extract_preprocessing(cfg)
 
         output_path = get_output_dir_name(platform, cfg.name, output_dir)
@@ -277,6 +283,7 @@ def convert(
         ) -> bool:
             """Move preprocessing to the archive when retrying is safe."""
             nonlocal cfg, preprocessing, preprocessing_externalized
+            nonlocal preprocessing_input_types
             if (
                 to != "nn_archive"
                 or preprocessing_externalized
@@ -285,6 +292,10 @@ def convert(
                 return False
 
             stage = next(iter(cfg.stages.values()))
+            preprocessing_input_types = {
+                inp.name: "raw" if inp.is_raw_input else "image"
+                for inp in stage.inputs
+            }
             input_names = [
                 inp.name
                 for inp in stage.inputs
@@ -374,6 +385,7 @@ def convert(
                     output_path=output_path,
                     archive_cfg=archive_cfg,
                     preprocessing=preprocessing,
+                    preprocessing_input_types=preprocessing_input_types,
                     inference_model_path=(
                         exporter.inference_model_path
                         if isinstance(exporter, Exporter)

--- a/modelconverter/cli/utils.py
+++ b/modelconverter/cli/utils.py
@@ -25,7 +25,7 @@ from modelconverter.utils import (
     resolve_path,
     sanitize_net_name,
 )
-from modelconverter.utils.config import Config
+from modelconverter.utils.config import Config, broadcast_preprocessing_values
 from modelconverter.utils.constants import (
     CALIBRATION_DIR,
     CONFIGS_DIR,
@@ -239,8 +239,16 @@ def extract_preprocessing(
     preprocessing = {}
     for inp in stage_cfg.inputs:
         inp.validate_input_contract()
-        mean = inp.mean_values
-        scale = inp.scale_values
+        mean = (
+            broadcast_preprocessing_values(inp.mean_values, inp.channel_count)
+            if inp.mean_values is not None
+            else None
+        )
+        scale = (
+            broadcast_preprocessing_values(inp.scale_values, inp.channel_count)
+            if inp.scale_values is not None
+            else None
+        )
         encoding = inp.encoding
         layout = inp.layout
 

--- a/modelconverter/cli/utils.py
+++ b/modelconverter/cli/utils.py
@@ -237,6 +237,7 @@ def extract_preprocessing(
     stage_cfg = next(iter(cfg.stages.values()))
     preprocessing = {}
     for inp in stage_cfg.inputs:
+        inp.validate_input_contract()
         mean = inp.mean_values
         scale = inp.scale_values
         encoding = inp.encoding

--- a/modelconverter/cli/utils.py
+++ b/modelconverter/cli/utils.py
@@ -253,7 +253,9 @@ def extract_preprocessing(
                     dai_type=None,
                 )
         else:
-            dai_type = encoding.to.value
+            # Once preprocessing is externalized, the converted model is fed
+            # directly in the format expected by the source graph.
+            dai_type = encoding.from_.value
             if inp.data_type == DataType.FLOAT16:
                 channel_type = "F16F16F16"
             else:
@@ -264,7 +266,7 @@ def extract_preprocessing(
             preprocessing[inp.name] = PreprocessingBlock(
                 mean=mean or [0, 0, 0],
                 scale=scale or [1, 1, 1],
-                reverse_channels=encoding.to == Encoding.RGB,
+                reverse_channels=encoding.from_ == Encoding.RGB,
                 interleaved_to_planar=layout == "NHWC",
                 dai_type=dai_type,
             )

--- a/modelconverter/cli/utils.py
+++ b/modelconverter/cli/utils.py
@@ -261,10 +261,12 @@ def extract_preprocessing(
 
             preprocessing[inp.name] = PreprocessingBlock(
                 mean=(
-                    mean if mean is not None else [0] * identity_value_count
+                    mean if mean is not None else [0.0] * identity_value_count
                 ),
                 scale=(
-                    scale if scale is not None else [1] * identity_value_count
+                    scale
+                    if scale is not None
+                    else [1.0] * identity_value_count
                 ),
                 reverse_channels=encoding.from_ == Encoding.RGB,
                 interleaved_to_planar=layout == "NHWC",

--- a/modelconverter/cli/utils.py
+++ b/modelconverter/cli/utils.py
@@ -20,6 +20,7 @@ from luxonis_ml.typing import Params
 
 from modelconverter.utils import (
     ModelconverterException,
+    make_dai_type,
     process_nn_archive,
     resolve_path,
     sanitize_net_name,
@@ -36,7 +37,7 @@ from modelconverter.utils.constants import (
     in_docker,
 )
 from modelconverter.utils.filesystem_utils import set_input_base
-from modelconverter.utils.types import DataType, Encoding, Platform
+from modelconverter.utils.types import Encoding, Platform
 
 
 def resolve_output_dir(output_dir: str) -> Path:
@@ -255,17 +256,16 @@ def extract_preprocessing(
         else:
             # Once preprocessing is externalized, the converted model is fed
             # directly in the format expected by the source graph.
-            dai_type = encoding.from_.value
-            if inp.data_type == DataType.FLOAT16:
-                channel_type = "F16F16F16"
-            else:
-                channel_type = "888"
-            dai_type += channel_type
-            dai_type += "i" if layout == "NHWC" else "p"
+            dai_type = make_dai_type(encoding.from_, inp.data_type, layout)
+            identity_value_count = 1 if encoding.from_ == Encoding.GRAY else 3
 
             preprocessing[inp.name] = PreprocessingBlock(
-                mean=mean or [0, 0, 0],
-                scale=scale or [1, 1, 1],
+                mean=(
+                    mean if mean is not None else [0] * identity_value_count
+                ),
+                scale=(
+                    scale if scale is not None else [1] * identity_value_count
+                ),
                 reverse_channels=encoding.from_ == Encoding.RGB,
                 interleaved_to_planar=layout == "NHWC",
                 dai_type=dai_type,

--- a/modelconverter/platforms/base_exporter.py
+++ b/modelconverter/platforms/base_exporter.py
@@ -22,6 +22,7 @@ from loguru import logger
 from luxonis_ml.typing import Params, PathType
 
 from modelconverter.utils import (
+    ModelconverterException,
     exit_with,
     read_calib_dir,
     sanitize_net_name,
@@ -252,6 +253,19 @@ class Exporter(ABC):
             json.dump(buildinfo, f, indent=4)
 
         return new_output_path
+
+    def _validate_requested_preprocessing(self) -> list[str]:
+        """Validate requested preprocessing and return affected input names."""
+        requested_inputs: list[str] = []
+        for inp in self._inputs.values():
+            if not inp.requires_input_preprocessing():
+                continue
+            requested_inputs.append(inp.name)
+            try:
+                inp.validate_preprocessing()
+            except ValueError as error:
+                raise ModelconverterException(str(error)) from error
+        return requested_inputs
 
     def _simplify_onnx(self) -> Path:  # pragma: no cover
         """Simplify the staged ONNX model.

--- a/modelconverter/platforms/base_exporter.py
+++ b/modelconverter/platforms/base_exporter.py
@@ -143,10 +143,6 @@ class Exporter(ABC):
                     / sanitize_net_name(self.config.input_bin.stem)
                 ).with_suffix(".bin"),
             )
-            self.config.input_bin = (
-                self.config.input_bin.parent
-                / sanitize_net_name(self.config.input_bin.stem)
-            ).with_suffix(".bin")
         self._input_model = (
             self.intermediate_outputs_dir / sanitized_model_name
         )

--- a/modelconverter/platforms/hailo/exporter.py
+++ b/modelconverter/platforms/hailo/exporter.py
@@ -26,6 +26,7 @@ from modelconverter.utils import (
 from modelconverter.utils.config import (
     ImageCalibrationConfig,
     SingleStageConfig,
+    broadcast_preprocessing_values,
 )
 from modelconverter.utils.types import Platform
 
@@ -296,10 +297,12 @@ class HailoExporter(Exporter):
             values_len = inp.shape[inp.layout.index("C")]
             scale_values = inp.scale_values or [1.0] * values_len
             mean_values = inp.mean_values or [0.0] * values_len
-            if len(scale_values) == 1:
-                scale_values = scale_values * values_len
-            if len(mean_values) == 1:
-                mean_values = mean_values * values_len
+            scale_values = broadcast_preprocessing_values(
+                scale_values, values_len
+            )
+            mean_values = broadcast_preprocessing_values(
+                mean_values, values_len
+            )
             alls.append(
                 f"normalization_{safe_name} = normalization("
                 f"{mean_values},{scale_values},{hn_name})"

--- a/modelconverter/platforms/hailo/exporter.py
+++ b/modelconverter/platforms/hailo/exporter.py
@@ -72,7 +72,7 @@ class HailoExporter(Exporter):
             except ValueError as e:
                 raise ModelconverterException(str(e)) from e
         if self._disable_calibration and requested_inputs:
-            names = ", ".join(repr(name) for name in requested_inputs)
+            names = ", ".join(requested_inputs)
             raise PreprocessingEmbeddingError(
                 "Hailo cannot embed requested preprocessing when calibration "
                 f"is disabled; input(s) {names} still require preprocessing. "

--- a/modelconverter/platforms/hailo/exporter.py
+++ b/modelconverter/platforms/hailo/exporter.py
@@ -19,7 +19,6 @@ from luxonis_ml.typing import Params
 
 from modelconverter.platforms.base_exporter import Exporter
 from modelconverter.utils import (
-    ModelconverterException,
     PreprocessingEmbeddingError,
     exit_with,
     read_image,
@@ -62,15 +61,7 @@ class HailoExporter(Exporter):
         self._disable_compilation = config.hailo.disable_compilation
         self._alls: list[str] = []
         self._hw_arch = config.hailo.hw_arch
-        requested_inputs = []
-        for inp in self._inputs.values():
-            if not inp.requires_input_preprocessing():
-                continue
-            requested_inputs.append(inp.name)
-            try:
-                inp.validate_preprocessing()
-            except ValueError as e:
-                raise ModelconverterException(str(e)) from e
+        requested_inputs = self._validate_requested_preprocessing()
         if self._disable_calibration and requested_inputs:
             names = ", ".join(requested_inputs)
             raise PreprocessingEmbeddingError(

--- a/modelconverter/platforms/hailo/exporter.py
+++ b/modelconverter/platforms/hailo/exporter.py
@@ -287,6 +287,9 @@ class HailoExporter(Exporter):
             f"batch_size={self._batch_size})"
         )
         for name, inp in self._inputs.items():
+            if not inp.requires_input_preprocessing():
+                continue
+
             safe_name = name.replace(".", "")
 
             hn_name, _ = self._get_hn_layer_info(runner, name)

--- a/modelconverter/platforms/hailo/exporter.py
+++ b/modelconverter/platforms/hailo/exporter.py
@@ -18,7 +18,7 @@ from loguru import logger
 from luxonis_ml.typing import Params
 
 from modelconverter.platforms.base_exporter import Exporter
-from modelconverter.utils import exit_with, read_image
+from modelconverter.utils import ModelconverterException, exit_with, read_image
 from modelconverter.utils.config import (
     ImageCalibrationConfig,
     SingleStageConfig,
@@ -57,6 +57,23 @@ class HailoExporter(Exporter):
         self._disable_compilation = config.hailo.disable_compilation
         self._alls: list[str] = []
         self._hw_arch = config.hailo.hw_arch
+        requested_inputs = []
+        for inp in self._inputs.values():
+            if not inp.requires_input_preprocessing():
+                continue
+            requested_inputs.append(inp.name)
+            try:
+                inp.validate_preprocessing()
+            except ValueError as e:
+                raise ModelconverterException(str(e)) from e
+        if self._disable_calibration and requested_inputs:
+            names = ", ".join(repr(name) for name in requested_inputs)
+            raise ModelconverterException(
+                "Hailo cannot embed requested preprocessing when calibration "
+                f"is disabled; input(s) {names} still require preprocessing. "
+                "Enable calibration or use `--archive-preprocess --to "
+                "nn_archive`."
+            )
         if not tf.config.list_physical_devices("GPU"):
             logger.error(
                 "No GPU found. Setting optimization and compression level to 0."
@@ -276,14 +293,14 @@ class HailoExporter(Exporter):
             if not all(x is not None for x in inp.shape):
                 exit_with(ValueError(f"Input `{name}` has dynamic shape."))
 
-            if self._is_tflite:
-                values_len = inp.shape[-1]
-            else:
-                values_len = inp.shape[1]
-
-            assert values_len is not None
+            assert inp.layout is not None
+            values_len = inp.shape[inp.layout.index("C")]
             scale_values = inp.scale_values or [1.0] * values_len
             mean_values = inp.mean_values or [0.0] * values_len
+            if len(scale_values) == 1:
+                scale_values = scale_values * values_len
+            if len(mean_values) == 1:
+                mean_values = mean_values * values_len
             alls.append(
                 f"normalization_{safe_name} = normalization("
                 f"{mean_values},{scale_values},{hn_name})"

--- a/modelconverter/platforms/hailo/exporter.py
+++ b/modelconverter/platforms/hailo/exporter.py
@@ -18,7 +18,12 @@ from loguru import logger
 from luxonis_ml.typing import Params
 
 from modelconverter.platforms.base_exporter import Exporter
-from modelconverter.utils import ModelconverterException, exit_with, read_image
+from modelconverter.utils import (
+    ModelconverterException,
+    PreprocessingEmbeddingError,
+    exit_with,
+    read_image,
+)
 from modelconverter.utils.config import (
     ImageCalibrationConfig,
     SingleStageConfig,
@@ -68,7 +73,7 @@ class HailoExporter(Exporter):
                 raise ModelconverterException(str(e)) from e
         if self._disable_calibration and requested_inputs:
             names = ", ".join(repr(name) for name in requested_inputs)
-            raise ModelconverterException(
+            raise PreprocessingEmbeddingError(
                 "Hailo cannot embed requested preprocessing when calibration "
                 f"is disabled; input(s) {names} still require preprocessing. "
                 "Enable calibration or use `--archive-preprocess --to "

--- a/modelconverter/platforms/rvc2/exporter.py
+++ b/modelconverter/platforms/rvc2/exporter.py
@@ -265,7 +265,7 @@ class RVC2Exporter(Exporter):
             except ValueError as e:
                 raise ModelconverterException(str(e)) from e
         if requested_inputs:
-            names = ", ".join(repr(name) for name in requested_inputs)
+            names = ", ".join(requested_inputs)
             raise PreprocessingEmbeddingError(
                 "RVC2/RVC3 cannot embed requested preprocessing into an "
                 f"existing OpenVINO IR; input(s) {names} still require "

--- a/modelconverter/platforms/rvc2/exporter.py
+++ b/modelconverter/platforms/rvc2/exporter.py
@@ -25,6 +25,7 @@ from luxonis_ml.typing import Params
 
 from modelconverter.platforms.base_exporter import Exporter
 from modelconverter.utils import (
+    ModelconverterException,
     ONNXModifier,
     SubprocessHandle,
     get_container_memory_available,
@@ -133,6 +134,13 @@ class RVC2Exporter(Exporter):
                     inp_str += f"->{value}"
             args.extend(["--input", inp_str])
 
+        for inp in self._inputs.values():
+            if inp.requires_input_preprocessing():
+                try:
+                    inp.validate_preprocessing()
+                except ValueError as e:
+                    raise ModelconverterException(str(e)) from e
+
         if not self._check_reverse_channels():
             logger.warning(
                 "The model optimizer does not support reversing "
@@ -187,20 +195,36 @@ class RVC2Exporter(Exporter):
         mean_values_str = ""
         scale_values_str = ""
         for name, inp in self._inputs.items():
+            channels = (
+                inp.validate_preprocessing()
+                if inp.requires_input_preprocessing()
+                else None
+            )
+
             # Append mean values in a similar style
-            if inp.is_color_input and inp.mean_values is not None:
+            if inp.mean_values is not None and any(
+                value != 0 for value in inp.mean_values
+            ):
                 if mean_values_str:
                     mean_values_str += ","
+                mean_values = _broadcast_preprocessing_values(
+                    inp.mean_values, channels
+                )
                 mean_values_str += (
-                    f"{name}[{','.join(str(v) for v in inp.mean_values)}]"
+                    f"{name}[{','.join(str(v) for v in mean_values)}]"
                 )
 
             # Append scale values in a similar style
-            if inp.is_color_input and inp.scale_values is not None:
+            if inp.scale_values is not None and any(
+                value != 1 for value in inp.scale_values
+            ):
                 if scale_values_str:
                     scale_values_str += ","
+                scale_values = _broadcast_preprocessing_values(
+                    inp.scale_values, channels
+                )
                 scale_values_str += (
-                    f"{name}[{','.join(str(v) for v in inp.scale_values)}]"
+                    f"{name}[{','.join(str(v) for v in scale_values)}]"
                 )
         # Extend args with mean and scale values if they were collected
         if mean_values_str:
@@ -226,6 +250,22 @@ class RVC2Exporter(Exporter):
     def _check_reverse_channels(self) -> bool:
         reverses = [inp.encoding_mismatch for inp in self._inputs.values()]
         return all(reverses) or not any(reverses)
+
+    def _validate_ir_preprocessing_contract(self) -> None:
+        """Reject preprocessing that cannot be added to an existing IR."""
+        requested_inputs = [
+            name
+            for name, inp in self._inputs.items()
+            if inp.requires_input_preprocessing()
+        ]
+        if requested_inputs:
+            names = ", ".join(repr(name) for name in requested_inputs)
+            raise ModelconverterException(
+                "RVC2/RVC3 cannot embed requested preprocessing into an "
+                f"existing OpenVINO IR; input(s) {names} still require "
+                "preprocessing. Use an ONNX/TFLite source or "
+                "`--archive-preprocess --to nn_archive`."
+            )
 
     @staticmethod
     def _write_config(shaves: int, slices: int) -> str:
@@ -296,6 +336,7 @@ class RVC2Exporter(Exporter):
         if self._input_file_type == InputFileType.ONNX:
             xml_path = self._export_openvino_ir()
         elif self._input_file_type == InputFileType.IR:
+            self._validate_ir_preprocessing_contract()
             xml_path = self._input_model
         else:
             raise NotImplementedError
@@ -563,3 +604,12 @@ def _lst_join(args: Iterable[int | float], sep: str = ",") -> str:
 
 def _get_available_memory() -> int:
     return int(get_container_memory_available() * 0.7)
+
+
+def _broadcast_preprocessing_values(
+    values: list[float], channels: int | None
+) -> list[float]:
+    """Expand a scalar preprocessing value for OpenVINO compatibility."""
+    if len(values) == 1 and channels is not None:
+        return values * channels
+    return values

--- a/modelconverter/platforms/rvc2/exporter.py
+++ b/modelconverter/platforms/rvc2/exporter.py
@@ -31,7 +31,10 @@ from modelconverter.utils import (
     get_container_memory_available,
     onnx_attach_normalization_to_inputs,
 )
-from modelconverter.utils.config import SingleStageConfig
+from modelconverter.utils.config import (
+    SingleStageConfig,
+    broadcast_preprocessing_values,
+)
 from modelconverter.utils.subprocess import SubprocessResult
 from modelconverter.utils.types import (
     DataType,
@@ -203,7 +206,7 @@ class RVC2Exporter(Exporter):
             ):
                 if mean_values_str:
                     mean_values_str += ","
-                mean_values = _broadcast_preprocessing_values(
+                mean_values = broadcast_preprocessing_values(
                     inp.mean_values, channels
                 )
                 mean_values_str += (
@@ -216,7 +219,7 @@ class RVC2Exporter(Exporter):
             ):
                 if scale_values_str:
                     scale_values_str += ","
-                scale_values = _broadcast_preprocessing_values(
+                scale_values = broadcast_preprocessing_values(
                     inp.scale_values, channels
                 )
                 scale_values_str += (
@@ -596,12 +599,3 @@ def _lst_join(args: Iterable[int | float], sep: str = ",") -> str:
 
 def _get_available_memory() -> int:
     return int(get_container_memory_available() * 0.7)
-
-
-def _broadcast_preprocessing_values(
-    values: list[float], channels: int | None
-) -> list[float]:
-    """Expand a scalar preprocessing value for OpenVINO compatibility."""
-    if len(values) == 1 and channels is not None:
-        return values * channels
-    return values

--- a/modelconverter/platforms/rvc2/exporter.py
+++ b/modelconverter/platforms/rvc2/exporter.py
@@ -25,7 +25,6 @@ from luxonis_ml.typing import Params
 
 from modelconverter.platforms.base_exporter import Exporter
 from modelconverter.utils import (
-    ModelconverterException,
     ONNXModifier,
     PreprocessingEmbeddingError,
     SubprocessHandle,
@@ -135,12 +134,7 @@ class RVC2Exporter(Exporter):
                     inp_str += f"->{value}"
             args.extend(["--input", inp_str])
 
-        for inp in self._inputs.values():
-            if inp.requires_input_preprocessing():
-                try:
-                    inp.validate_preprocessing()
-                except ValueError as e:
-                    raise ModelconverterException(str(e)) from e
+        self._validate_requested_preprocessing()
 
         if not self._check_reverse_channels():
             logger.warning(
@@ -255,15 +249,7 @@ class RVC2Exporter(Exporter):
 
     def _validate_ir_preprocessing_contract(self) -> None:
         """Reject preprocessing that cannot be added to an existing IR."""
-        requested_inputs = []
-        for inp in self._inputs.values():
-            if not inp.requires_input_preprocessing():
-                continue
-            requested_inputs.append(inp.name)
-            try:
-                inp.validate_preprocessing()
-            except ValueError as e:
-                raise ModelconverterException(str(e)) from e
+        requested_inputs = self._validate_requested_preprocessing()
         if requested_inputs:
             names = ", ".join(requested_inputs)
             raise PreprocessingEmbeddingError(

--- a/modelconverter/platforms/rvc2/exporter.py
+++ b/modelconverter/platforms/rvc2/exporter.py
@@ -27,6 +27,7 @@ from modelconverter.platforms.base_exporter import Exporter
 from modelconverter.utils import (
     ModelconverterException,
     ONNXModifier,
+    PreprocessingEmbeddingError,
     SubprocessHandle,
     get_container_memory_available,
     onnx_attach_normalization_to_inputs,
@@ -253,14 +254,18 @@ class RVC2Exporter(Exporter):
 
     def _validate_ir_preprocessing_contract(self) -> None:
         """Reject preprocessing that cannot be added to an existing IR."""
-        requested_inputs = [
-            name
-            for name, inp in self._inputs.items()
-            if inp.requires_input_preprocessing()
-        ]
+        requested_inputs = []
+        for inp in self._inputs.values():
+            if not inp.requires_input_preprocessing():
+                continue
+            requested_inputs.append(inp.name)
+            try:
+                inp.validate_preprocessing()
+            except ValueError as e:
+                raise ModelconverterException(str(e)) from e
         if requested_inputs:
             names = ", ".join(repr(name) for name in requested_inputs)
-            raise ModelconverterException(
+            raise PreprocessingEmbeddingError(
                 "RVC2/RVC3 cannot embed requested preprocessing into an "
                 f"existing OpenVINO IR; input(s) {names} still require "
                 "preprocessing. Use an ONNX/TFLite source or "

--- a/modelconverter/platforms/rvc2/exporter.py
+++ b/modelconverter/platforms/rvc2/exporter.py
@@ -161,8 +161,7 @@ class RVC2Exporter(Exporter):
                     inp.scale_values = inp.scale_values[::-1]
                 # Only colour inputs get their channels reversed in the ONNX;
                 # after that, the exposed input still expects the configured
-                # runtime encoding (`to`). Preserve it for archive metadata and
-                # calibration instead of assuming the runtime side is BGR.
+                # runtime encoding (`to`).
                 if inp.is_color_input and inp.encoding_mismatch:
                     runtime_encoding = inp.encoding.to
                     inp.encoding.from_ = runtime_encoding

--- a/modelconverter/platforms/rvc2/exporter.py
+++ b/modelconverter/platforms/rvc2/exporter.py
@@ -160,11 +160,13 @@ class RVC2Exporter(Exporter):
                 if inp.scale_values is not None and inp.encoding_mismatch:
                     inp.scale_values = inp.scale_values[::-1]
                 # Only colour inputs get their channels reversed in the ONNX;
-                # marking non-colour inputs (e.g. grayscale) as BGR is wrong and
-                # later makes their inferer read a 1-channel input as 3-channel.
+                # after that, the exposed input still expects the configured
+                # runtime encoding (`to`). Preserve it for archive metadata and
+                # calibration instead of assuming the runtime side is BGR.
                 if inp.is_color_input and inp.encoding_mismatch:
-                    inp.encoding.from_ = Encoding.BGR
-                    inp.encoding.to = Encoding.BGR
+                    runtime_encoding = inp.encoding.to
+                    inp.encoding.from_ = runtime_encoding
+                    inp.encoding.to = runtime_encoding
 
         if not self._onnx_optimizations.all_disabled():
             onnx_modifier = ONNXModifier(

--- a/modelconverter/platforms/rvc3/exporter.py
+++ b/modelconverter/platforms/rvc3/exporter.py
@@ -83,6 +83,7 @@ class RVC3Exporter(RVC2Exporter):
         if self._input_file_type == InputFileType.ONNX:
             xml_path = self._export_openvino_ir()
         elif self._input_file_type == InputFileType.IR:
+            self._validate_ir_preprocessing_contract()
             xml_path = self._input_model
         else:
             raise NotImplementedError

--- a/modelconverter/platforms/rvc4/exporter.py
+++ b/modelconverter/platforms/rvc4/exporter.py
@@ -20,6 +20,7 @@ from luxonis_ml.typing import Params
 
 from modelconverter.platforms.base_exporter import Exporter
 from modelconverter.utils import (
+    ONNXException,
     ONNXModifier,
     exit_with,
     onnx_attach_normalization_to_inputs,
@@ -125,9 +126,20 @@ class RVC4Exporter(Exporter):
                     if onnx_modifier.output_path.exists():  # pragma: no cover
                         onnx_modifier.output_path.unlink()
         else:
-            logger.warning(
-                "Input file type is not ONNX. Skipping pre-processing."
-            )
+            requested_inputs = [
+                name
+                for name, inp in self._inputs.items()
+                if inp.requires_input_preprocessing()
+            ]
+            if requested_inputs:
+                names = ", ".join(repr(name) for name in requested_inputs)
+                raise ONNXException(
+                    "RVC4 can only embed requested preprocessing into ONNX "
+                    f"models; input(s) {names} still require preprocessing. "
+                    "Use an ONNX source or `--archive-preprocess --to "
+                    "nn_archive`."
+                )
+            logger.info("No RVC4 input preprocessing requested.")
         self._raw_img_dir = self.intermediate_outputs_dir / "raw_files"
         self._input_list_path = self.intermediate_outputs_dir / "img_list.txt"
 

--- a/modelconverter/platforms/rvc4/exporter.py
+++ b/modelconverter/platforms/rvc4/exporter.py
@@ -20,7 +20,6 @@ from luxonis_ml.typing import Params
 
 from modelconverter.platforms.base_exporter import Exporter
 from modelconverter.utils import (
-    ModelconverterException,
     ONNXModifier,
     PreprocessingEmbeddingError,
     exit_with,
@@ -97,15 +96,7 @@ class RVC4Exporter(Exporter):
         else:
             self._htp_socs = rvc4_cfg.htp_socs
 
-        requested_inputs = []
-        for inp in self._inputs.values():
-            if not inp.requires_input_preprocessing():
-                continue
-            requested_inputs.append(inp.name)
-            try:
-                inp.validate_preprocessing()
-            except ValueError as e:
-                raise ModelconverterException(str(e)) from e
+        requested_inputs = self._validate_requested_preprocessing()
 
         if self.config.input_file_type == InputFileType.ONNX:
             self._input_model = onnx_attach_normalization_to_inputs(

--- a/modelconverter/platforms/rvc4/exporter.py
+++ b/modelconverter/platforms/rvc4/exporter.py
@@ -140,16 +140,14 @@ class RVC4Exporter(Exporter):
                 finally:
                     if onnx_modifier.output_path.exists():  # pragma: no cover
                         onnx_modifier.output_path.unlink()
-        else:
-            if requested_inputs:
-                names = ", ".join(repr(name) for name in requested_inputs)
-                raise PreprocessingEmbeddingError(
-                    "RVC4 can only embed requested preprocessing into ONNX "
-                    f"models; input(s) {names} still require preprocessing. "
-                    "Use an ONNX source or `--archive-preprocess --to "
-                    "nn_archive`."
-                )
-            logger.info("No RVC4 input preprocessing requested.")
+        elif requested_inputs:
+            names = ", ".join(repr(name) for name in requested_inputs)
+            raise PreprocessingEmbeddingError(
+                "RVC4 can only embed requested preprocessing into ONNX "
+                f"models; input(s) {names} still require preprocessing. "
+                "Use an ONNX source or `--archive-preprocess --to "
+                "nn_archive`."
+            )
         self._raw_img_dir = self.intermediate_outputs_dir / "raw_files"
         self._input_list_path = self.intermediate_outputs_dir / "img_list.txt"
 

--- a/modelconverter/platforms/rvc4/exporter.py
+++ b/modelconverter/platforms/rvc4/exporter.py
@@ -142,7 +142,7 @@ class RVC4Exporter(Exporter):
                     if onnx_modifier.output_path.exists():  # pragma: no cover
                         onnx_modifier.output_path.unlink()
         elif requested_inputs:
-            names = ", ".join(repr(name) for name in requested_inputs)
+            names = ", ".join(requested_inputs)
             raise PreprocessingEmbeddingError(
                 "RVC4 can only embed requested preprocessing into ONNX "
                 f"models; input(s) {names} still require preprocessing. "

--- a/modelconverter/platforms/rvc4/exporter.py
+++ b/modelconverter/platforms/rvc4/exporter.py
@@ -20,8 +20,9 @@ from luxonis_ml.typing import Params
 
 from modelconverter.platforms.base_exporter import Exporter
 from modelconverter.utils import (
-    ONNXException,
+    ModelconverterException,
     ONNXModifier,
+    PreprocessingEmbeddingError,
     exit_with,
     onnx_attach_normalization_to_inputs,
     read_image,
@@ -91,6 +92,16 @@ class RVC4Exporter(Exporter):
         else:
             self._htp_socs = rvc4_cfg.htp_socs
 
+        requested_inputs = []
+        for inp in self._inputs.values():
+            if not inp.requires_input_preprocessing():
+                continue
+            requested_inputs.append(inp.name)
+            try:
+                inp.validate_preprocessing()
+            except ValueError as e:
+                raise ModelconverterException(str(e)) from e
+
         if self.config.input_file_type == InputFileType.ONNX:
             self._input_model = onnx_attach_normalization_to_inputs(
                 self._input_model,
@@ -126,14 +137,9 @@ class RVC4Exporter(Exporter):
                     if onnx_modifier.output_path.exists():  # pragma: no cover
                         onnx_modifier.output_path.unlink()
         else:
-            requested_inputs = [
-                name
-                for name, inp in self._inputs.items()
-                if inp.requires_input_preprocessing()
-            ]
             if requested_inputs:
                 names = ", ".join(repr(name) for name in requested_inputs)
-                raise ONNXException(
+                raise PreprocessingEmbeddingError(
                     "RVC4 can only embed requested preprocessing into ONNX "
                     f"models; input(s) {names} still require preprocessing. "
                     "Use an ONNX source or `--archive-preprocess --to "

--- a/modelconverter/platforms/rvc4/inferer.py
+++ b/modelconverter/platforms/rvc4/inferer.py
@@ -35,8 +35,9 @@ class RVC4Inferer(Inferer):
         referenced from the SNPE input list, ``snpe-net-run`` is then
         invoked on the DLC model, and the raw files it produces are
         read back and reshaped to the configured output shapes.
-        Four-dimensional outputs are assumed to be channels-last and
-        are transposed to ``NCHW``.
+        SNPE's four-dimensional output data is channels-last. Its
+        dimensions are recovered from the configured output layout and
+        exposed as ``NCHW``.
 
         Args:
             inputs: Path to the image for every model input, keyed by
@@ -86,16 +87,31 @@ class RVC4Inferer(Inferer):
         )
         out_paths = outputs_path.rglob("*.raw")
         outputs = {}
+        output_layouts = (
+            {out.name: out.layout for out in self.config.outputs}
+            if self.config is not None
+            else {}
+        )
         for p in out_paths:
             arr = np.fromfile(
                 p, dtype=self.out_dtypes[p.stem].as_numpy_dtype()
             )
             out_shape = self.out_shapes[p.stem]
-
-            # TODO: detect layout
-            if len(out_shape) == 4:
-                N, C, H, W = out_shape
-                outputs[p.stem] = arr.reshape(N, H, W, C).transpose(0, 3, 1, 2)
-            else:
-                outputs[p.stem] = arr.reshape(out_shape)
+            outputs[p.stem] = _reshape_output(
+                arr, out_shape, output_layouts.get(p.stem)
+            )
         return outputs
+
+
+def _reshape_output(
+    arr: np.ndarray, shape: list[int], layout: str | None
+) -> np.ndarray:
+    """Reshape an SNPE output, exposing four-dimensional tensors as NCHW."""
+    if len(shape) != 4:
+        return arr.reshape(shape)
+
+    if layout == "NHWC":
+        n, h, w, c = shape
+    else:
+        n, c, h, w = shape
+    return arr.reshape(n, h, w, c).transpose(0, 3, 1, 2)

--- a/modelconverter/platforms/rvc4/inferer.py
+++ b/modelconverter/platforms/rvc4/inferer.py
@@ -19,14 +19,23 @@ from modelconverter.utils.types import DataType
 class RVC4Inferer(Inferer):
     """Inferer for RVC4 DLC models based on ``snpe-net-run``."""
 
-    def setup(self) -> None:
-        """Set the raw image directory and the input list header.
+    _output_layouts: dict[str, str | None]
 
-        The header names the outputs SNPE is asked to write out.
+    def setup(self) -> None:
+        """Set paths and cache metadata used by every inference.
+
+        The header names the outputs SNPE is asked to write out. Output layouts
+        are captured once alongside the shapes and data types populated by
+        ``Inferer.from_config``.
 
         """
         self._raw_images_path = Path("raw_images")
         self._header = f"%{' '.join(name for name in self.out_shapes)}"
+        self._output_layouts = (
+            {out.name: out.layout for out in self.config.outputs}
+            if self.config is not None
+            else {}
+        )
 
     def infer(self, inputs: dict[str, Path]) -> dict[str, np.ndarray]:
         """Run the model on a single set of input images.
@@ -87,18 +96,13 @@ class RVC4Inferer(Inferer):
         )
         out_paths = outputs_path.rglob("*.raw")
         outputs = {}
-        output_layouts = (
-            {out.name: out.layout for out in self.config.outputs}
-            if self.config is not None
-            else {}
-        )
         for p in out_paths:
             arr = np.fromfile(
                 p, dtype=self.out_dtypes[p.stem].as_numpy_dtype()
             )
             out_shape = self.out_shapes[p.stem]
             outputs[p.stem] = _reshape_output(
-                arr, out_shape, output_layouts.get(p.stem)
+                arr, out_shape, self._output_layouts.get(p.stem)
             )
         return outputs
 

--- a/modelconverter/utils/__init__.py
+++ b/modelconverter/utils/__init__.py
@@ -30,6 +30,7 @@ from .environ import environ
 from .exceptions import (
     ModelconverterException,
     ONNXException,
+    PreprocessingEmbeddingError,
     S3Exception,
     exit_with,
 )
@@ -68,6 +69,7 @@ __all__ = [
     "ModelconverterException",
     "ONNXException",
     "ONNXModifier",
+    "PreprocessingEmbeddingError",
     "S3Exception",
     "SSHHandler",
     "SubprocessHandle",

--- a/modelconverter/utils/__init__.py
+++ b/modelconverter/utils/__init__.py
@@ -29,6 +29,7 @@ from .docker_utils import (
 from .environ import environ
 from .exceptions import (
     ModelconverterException,
+    ONNXException,
     S3Exception,
     exit_with,
 )
@@ -65,6 +66,7 @@ __all__ = [
     "DeviceMonitor",
     "Metadata",
     "ModelconverterException",
+    "ONNXException",
     "ONNXModifier",
     "S3Exception",
     "SSHHandler",

--- a/modelconverter/utils/__init__.py
+++ b/modelconverter/utils/__init__.py
@@ -48,6 +48,7 @@ from .metadata import Metadata, get_metadata
 from .nn_archive import (
     archive_from_model,
     get_archive_input,
+    make_dai_type,
     modelconverter_config_to_nn,
     process_nn_archive,
 )
@@ -94,6 +95,7 @@ __all__ = [
     "guess_new_layout",
     "in_docker",
     "is_hubai_model_variant_available",
+    "make_dai_type",
     "make_default_layout",
     "modelconverter_config_to_nn",
     "onnx_attach_normalization_to_inputs",

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -355,13 +355,28 @@ class InputConfig(OutputConfig):
         if isinstance(value, str) and value in NAMED_VALUES:
             return NAMED_VALUES[value][values_type]
         if isinstance(value, float | int):
-            return [value, value, value]
+            # Keep the documented scalar meaning until the input's channel
+            # count is known.
+            return [value]
         return value
 
-    def requires_onnx_input_modification(
+    @model_validator(mode="after")
+    def _validate_preprocessing_values(self) -> Self:
+        """Reject invalid preprocessing values."""
+        if self.scale_values is not None and any(
+            value == 0 for value in self.scale_values
+        ):
+            raise ValueError(
+                f"Input '{self.name}' has a zero scale value; scale values "
+                "must be non-zero."
+            )
+
+        return self
+
+    def requires_input_preprocessing(
         self, *, reverse_only: bool = False
     ) -> bool:
-        """Check whether the ONNX graph must be modified for this input.
+        """Check whether preprocessing is requested for this input.
 
         Args:
             reverse_only: If ``True``, only the channel reversal is
@@ -385,6 +400,76 @@ class InputConfig(OutputConfig):
             self.scale_values is not None
             and any(v != 1 for v in self.scale_values)
         )
+
+    def requires_onnx_input_modification(
+        self, *, reverse_only: bool = False
+    ) -> bool:
+        """Check whether preprocessing requires an ONNX graph change."""
+        return self.requires_input_preprocessing(reverse_only=reverse_only)
+
+    def validate_preprocessing(self, *, reverse_only: bool = False) -> int:
+        """Validate requested preprocessing and return the channel count.
+
+        Args:
+            reverse_only: Validate only a requested encoding conversion.
+
+        Returns:
+            The resolved number of input channels.
+
+        Raises:
+            ValueError: If the input contract is insufficient or inconsistent.
+
+        """
+        if self.shape is None or self.layout is None or "C" not in self.layout:
+            raise ValueError(
+                f"Cannot apply preprocessing to input '{self.name}' without "
+                "a shape and layout containing a channel dimension."
+            )
+
+        channels = self.shape[self.layout.index("C")]
+        if channels <= 0:
+            raise ValueError(
+                f"Cannot apply preprocessing to input '{self.name}' with an "
+                "unknown channel count."
+            )
+
+        if self.encoding_mismatch:
+            if not self.is_color_input or self.encoding.to not in {
+                Encoding.RGB,
+                Encoding.BGR,
+            }:
+                raise ValueError(
+                    f"Cannot reverse channels for input '{self.name}': "
+                    "channel reversal requires RGB/BGR color encodings."
+                )
+            if channels != 3:
+                raise ValueError(
+                    f"Cannot reverse channels for input '{self.name}' with "
+                    f"{channels} channels; RGB/BGR reversal requires exactly "
+                    "3 channels."
+                )
+
+        if not reverse_only:
+            for values_name, values in (
+                ("mean_values", self.mean_values),
+                ("scale_values", self.scale_values),
+            ):
+                if values is not None and len(values) not in {1, channels}:
+                    raise ValueError(
+                        f"Input '{self.name}' has {channels} channels, but "
+                        f"'{values_name}' contains {len(values)} values; "
+                        "provide one value to broadcast or one value per "
+                        "channel."
+                    )
+            if self.scale_values is not None and any(
+                value == 0 for value in self.scale_values
+            ):
+                raise ValueError(
+                    f"Input '{self.name}' has a zero scale value; scale "
+                    "values must be non-zero."
+                )
+
+        return channels
 
 
 class PlatformConfig(BaseModelExtraForbid):

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -282,6 +282,14 @@ class InputConfig(OutputConfig):
             and self.encoding.to == Encoding.NONE
         )
 
+    @property
+    def channel_count(self) -> int | None:
+        """Return the known positive channel count, if available."""
+        if self.shape is None or self.layout is None or "C" not in self.layout:
+            return None
+        channels = self.shape[self.layout.index("C")]
+        return channels if channels > 0 else None
+
     @model_validator(mode="after")
     def _validate_grayscale_inputs(self) -> Self:
         if self.layout is None:
@@ -1300,6 +1308,15 @@ class Config(LuxonisConfig):
             self.stages = {model_name: stage}
             self.name = model_name
         return self
+
+
+def broadcast_preprocessing_values(
+    values: list[float], channels: int | None
+) -> list[float]:
+    """Expand a scalar preprocessing value to the resolved channel count."""
+    if len(values) == 1 and channels is not None:
+        return values * channels
+    return list(values)
 
 
 def _dtype_name(dtype: DataType | None) -> str | None:

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -452,12 +452,6 @@ class InputConfig(OutputConfig):
             and any(v != 1 for v in self.scale_values)
         )
 
-    def requires_onnx_input_modification(
-        self, *, reverse_only: bool = False
-    ) -> bool:
-        """Check whether preprocessing requires an ONNX graph change."""
-        return self.requires_input_preprocessing(reverse_only=reverse_only)
-
     def validate_preprocessing(self, *, reverse_only: bool = False) -> int:
         """Validate requested preprocessing and return the channel count.
 

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -334,13 +334,14 @@ class InputConfig(OutputConfig):
                 and all(isinstance(dim, int) for dim in shape)
                 and (layout is None or isinstance(layout, str))
             ):
+                int_shape = [dim for dim in shape if isinstance(dim, int)]
                 resolved_layout = (
-                    make_default_layout(shape)
+                    make_default_layout(int_shape)
                     if layout is None
                     else layout.upper()
                 )
                 if "C" in resolved_layout:
-                    channels = shape[resolved_layout.index("C")]
+                    channels = int_shape[resolved_layout.index("C")]
                     if channels > 0 and channels not in {1, 3}:
                         data["encoding"] = {
                             "from": "NONE",

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -340,12 +340,18 @@ class InputConfig(OutputConfig):
                     if layout is None
                     else layout.upper()
                 )
-                if (
-                    len(resolved_layout) == len(int_shape)
-                    and "C" in resolved_layout
-                ):
-                    channels = int_shape[resolved_layout.index("C")]
-                    if channels > 0 and channels not in {1, 3}:
+                if len(resolved_layout) == len(int_shape):
+                    image_layout = resolved_layout in {"NCHW", "NHWC"}
+                    channels = (
+                        int_shape[resolved_layout.index("C")]
+                        if "C" in resolved_layout
+                        else None
+                    )
+                    if not image_layout or (
+                        channels is not None
+                        and channels > 0
+                        and channels not in {1, 3}
+                    ):
                         data["encoding"] = {
                             "from": "NONE",
                             "to": "NONE",

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -41,7 +41,10 @@ from modelconverter.utils.calibration_data import download_calibration_data
 from modelconverter.utils.constants import MISC_DIR, MODELS_DIR
 from modelconverter.utils.encodings import parse_encodings
 from modelconverter.utils.filesystem_utils import resolve_path
-from modelconverter.utils.layout import make_default_layout
+from modelconverter.utils.layout import (
+    is_image_input_shape,
+    make_default_layout,
+)
 from modelconverter.utils.metadata import Metadata, get_metadata
 from modelconverter.utils.onnx_compatibility import (
     has_external_data,
@@ -340,23 +343,15 @@ class InputConfig(OutputConfig):
                     if layout is None
                     else layout.upper()
                 )
-                if len(resolved_layout) == len(int_shape):
-                    image_layout = resolved_layout in {"NCHW", "NHWC"}
-                    channels = (
-                        int_shape[resolved_layout.index("C")]
-                        if "C" in resolved_layout
-                        else None
-                    )
-                    if not image_layout or (
-                        channels is not None
-                        and channels > 0
-                        and channels not in {1, 3}
-                    ):
-                        data["encoding"] = {
-                            "from": "NONE",
-                            "to": "NONE",
-                        }
-                        return data
+                layout_matches_shape = len(resolved_layout) == len(int_shape)
+                if layout_matches_shape and not is_image_input_shape(
+                    int_shape, resolved_layout
+                ):
+                    data["encoding"] = {
+                        "from": "NONE",
+                        "to": "NONE",
+                    }
+                    return data
             data["encoding"] = {"from": "RGB", "to": "BGR"}
             return data
         if isinstance(encoding, str):

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -293,7 +293,12 @@ class InputConfig(OutputConfig):
         assert self.shape is not None
 
         channels = self.shape[self.layout.index("C")]
-        if channels == 1:
+        encodings = {self.encoding.from_, self.encoding.to}
+        if channels == 1 and encodings <= {
+            Encoding.RGB,
+            Encoding.BGR,
+            Encoding.GRAY,
+        }:
             logger.info("Detected grayscale input. Setting encoding to GRAY.")
             self.encoding.from_ = self.encoding.to = Encoding.GRAY
 

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -340,7 +340,10 @@ class InputConfig(OutputConfig):
                     if layout is None
                     else layout.upper()
                 )
-                if "C" in resolved_layout:
+                if (
+                    len(resolved_layout) == len(int_shape)
+                    and "C" in resolved_layout
+                ):
                     channels = int_shape[resolved_layout.index("C")]
                     if channels > 0 and channels not in {1, 3}:
                         data["encoding"] = {

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -295,17 +295,8 @@ class InputConfig(OutputConfig):
 
     @model_validator(mode="after")
     def _validate_grayscale_inputs(self) -> Self:
-        if self.layout is None:
-            return self
-
-        if "C" not in self.layout:
-            return self
-
-        assert self.shape is not None
-
-        channels = self.shape[self.layout.index("C")]
         encodings = {self.encoding.from_, self.encoding.to}
-        if channels == 1 and encodings <= {
+        if self.channel_count == 1 and encodings <= {
             Encoding.RGB,
             Encoding.BGR,
             Encoding.GRAY,
@@ -423,11 +414,8 @@ class InputConfig(OutputConfig):
                 "must be non-zero."
             )
 
-        if self.shape is None or self.layout is None or "C" not in self.layout:
-            return
-
-        channels = self.shape[self.layout.index("C")]
-        if channels <= 0:
+        channels = self.channel_count
+        if channels is None:
             return
 
         encodings = {self.encoding.from_, self.encoding.to}

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -373,6 +373,52 @@ class InputConfig(OutputConfig):
 
         return self
 
+    def validate_input_contract(self, *, validate_values: bool = True) -> None:
+        """Validate encoding and preprocessing against a known channel axis."""
+        if (
+            validate_values
+            and self.scale_values is not None
+            and any(value == 0 for value in self.scale_values)
+        ):
+            raise ValueError(
+                f"Input '{self.name}' has a zero scale value; scale values "
+                "must be non-zero."
+            )
+
+        if self.shape is None or self.layout is None or "C" not in self.layout:
+            return
+
+        channels = self.shape[self.layout.index("C")]
+        if channels <= 0:
+            return
+
+        encodings = {self.encoding.from_, self.encoding.to}
+        if encodings & {Encoding.RGB, Encoding.BGR} and channels != 3:
+            raise ValueError(
+                f"Input '{self.name}' has {channels} channels and cannot use "
+                "RGB/BGR encoding; use `encoding: NONE` for a packed or "
+                "non-image tensor input."
+            )
+        if Encoding.GRAY in encodings and channels != 1:
+            raise ValueError(
+                f"Input '{self.name}' has {channels} channels and cannot use "
+                "GRAY encoding; grayscale image inputs require exactly one "
+                "channel."
+            )
+
+        if validate_values:
+            for values_name, values in (
+                ("mean_values", self.mean_values),
+                ("scale_values", self.scale_values),
+            ):
+                if values is not None and len(values) not in {1, channels}:
+                    raise ValueError(
+                        f"Input '{self.name}' has {channels} channels, but "
+                        f"'{values_name}' contains {len(values)} values; "
+                        "provide one value to broadcast or one value per "
+                        "channel."
+                    )
+
     def requires_input_preprocessing(
         self, *, reverse_only: bool = False
     ) -> bool:
@@ -420,6 +466,8 @@ class InputConfig(OutputConfig):
             ValueError: If the input contract is insufficient or inconsistent.
 
         """
+        self.validate_input_contract(validate_values=not reverse_only)
+
         if self.shape is None or self.layout is None or "C" not in self.layout:
             raise ValueError(
                 f"Cannot apply preprocessing to input '{self.name}' without "
@@ -447,26 +495,6 @@ class InputConfig(OutputConfig):
                     f"Cannot reverse channels for input '{self.name}' with "
                     f"{channels} channels; RGB/BGR reversal requires exactly "
                     "3 channels."
-                )
-
-        if not reverse_only:
-            for values_name, values in (
-                ("mean_values", self.mean_values),
-                ("scale_values", self.scale_values),
-            ):
-                if values is not None and len(values) not in {1, channels}:
-                    raise ValueError(
-                        f"Input '{self.name}' has {channels} channels, but "
-                        f"'{values_name}' contains {len(values)} values; "
-                        "provide one value to broadcast or one value per "
-                        "channel."
-                    )
-            if self.scale_values is not None and any(
-                value == 0 for value in self.scale_values
-            ):
-                raise ValueError(
-                    f"Input '{self.name}' has a zero scale value; scale "
-                    "values must be non-zero."
                 )
 
         return channels

--- a/modelconverter/utils/config.py
+++ b/modelconverter/utils/config.py
@@ -319,6 +319,26 @@ class InputConfig(OutputConfig):
     def _validate_encoding(cls, data: Params) -> Params:
         encoding = data.get("encoding")
         if encoding is None or encoding == {}:
+            shape = data.get("shape")
+            layout = data.get("layout")
+            if (
+                isinstance(shape, list)
+                and all(isinstance(dim, int) for dim in shape)
+                and (layout is None or isinstance(layout, str))
+            ):
+                resolved_layout = (
+                    make_default_layout(shape)
+                    if layout is None
+                    else layout.upper()
+                )
+                if "C" in resolved_layout:
+                    channels = shape[resolved_layout.index("C")]
+                    if channels > 0 and channels not in {1, 3}:
+                        data["encoding"] = {
+                            "from": "NONE",
+                            "to": "NONE",
+                        }
+                        return data
             data["encoding"] = {"from": "RGB", "to": "BGR"}
             return data
         if isinstance(encoding, str):

--- a/modelconverter/utils/exceptions.py
+++ b/modelconverter/utils/exceptions.py
@@ -25,6 +25,10 @@ class ONNXException(ModelconverterException):
     """Raised when an ONNX model cannot be inspected or modified."""
 
 
+class PreprocessingEmbeddingError(ModelconverterException):
+    """Raised when valid preprocessing cannot be embedded into a model."""
+
+
 def exit_with(exception: BaseException, code: int = 1) -> NoReturn:
     """Log the exception and terminate the process.
 

--- a/modelconverter/utils/layout.py
+++ b/modelconverter/utils/layout.py
@@ -32,7 +32,7 @@ def make_default_layout(shape: list[int]) -> str:
     """
     layout = []
     i = 0
-    if shape[0] == 1:
+    if shape[0] in {0, 1}:
         layout.append("N")
         i += 1
     if len(shape) - i == 3:

--- a/modelconverter/utils/layout.py
+++ b/modelconverter/utils/layout.py
@@ -50,6 +50,20 @@ def make_default_layout(shape: list[int]) -> str:
     return "".join(layout)
 
 
+def is_image_input_shape(shape: list[int], layout: str) -> bool:
+    """Return whether a shape and layout describe a supported image input.
+
+    Unknown channel counts are accepted for standard image layouts so they can
+    be resolved later. Known channel counts must represent grayscale or color
+    image data.
+    """
+    if len(shape) != len(layout) or layout not in {"NCHW", "NHWC"}:
+        return False
+
+    channels = shape[layout.index("C")]
+    return channels <= 0 or channels in {1, 3}
+
+
 def guess_new_layout(
     old_layout: str, old_shape: list[int], new_shape: list[int]
 ) -> str:

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -35,7 +35,11 @@ from modelconverter.utils.config import (
     broadcast_preprocessing_values,
 )
 from modelconverter.utils.constants import MISC_DIR
-from modelconverter.utils.layout import guess_new_layout, make_default_layout
+from modelconverter.utils.layout import (
+    guess_new_layout,
+    is_image_input_shape,
+    make_default_layout,
+)
 from modelconverter.utils.metadata import Metadata, get_metadata
 from modelconverter.utils.types import (
     DataType,
@@ -566,10 +570,10 @@ def _default_archive_preprocessing(
 def archive_from_model(model_path: Path) -> NNArchiveConfig:
     """Build a bare archive config out of a model file alone.
 
-    The inputs and outputs come from the model's own metadata, every
-    input is declared as an image with a default layout and no
-    preprocessing, and no heads are declared. This is what packing an
-    unconverted model into an archive starts from.
+    The inputs and outputs come from the model's own metadata. Inputs with a
+    supported image shape and layout are declared as images; all others are
+    raw tensors. No preprocessing or heads are declared. This is what packing
+    an unconverted model into an archive starts from.
 
     Args:
         model_path: Path to the model file to describe.
@@ -594,13 +598,15 @@ def archive_from_model(model_path: Path) -> NNArchiveConfig:
     }
 
     for name, shape in metadata.input_shapes.items():
+        layout = make_default_layout(shape)
+        input_type = "image" if is_image_input_shape(shape, layout) else "raw"
         archive_cfg["model"]["inputs"].append(
             {
                 "name": name,
                 "shape": shape,
-                "layout": make_default_layout(shape),
+                "layout": layout,
                 "dtype": metadata.input_dtypes[name].value,
-                "input_type": "image",
+                "input_type": input_type,
                 "preprocessing": {
                     "mean": None,
                     "scale": None,

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -484,28 +484,6 @@ def modelconverter_config_to_nn(
     return archive
 
 
-def find_archive_input(
-    cfg: NNArchiveConfig | None, name: str
-) -> NNArchiveInput | None:
-    """Look up an input of an archive config, tolerating its absence.
-
-    Args:
-        cfg: Archive config to search, or ``None`` if there is none.
-        name: Name of the input to look for.
-
-    Returns:
-        The matching archive input, or ``None`` if there is no config or
-        it declares no input of that name.
-
-    """
-    if cfg is None:
-        return None
-    for inp in cfg.model.inputs:
-        if inp.name == name:
-            return inp
-    return None
-
-
 def _default_archive_input_type(
     *, is_raw_input: bool
 ) -> Literal["raw", "image"]:

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -282,9 +282,11 @@ def modelconverter_config_to_nn(
     Shapes and data types are taken from the converted model itself,
     layouts are guessed from the original ones, and the precision is
     derived from the platform together with its quantization settings.
-    Of the original archive config, the heads and input types are carried
-    over. Archive preprocessing is identity unless it is supplied explicitly
-    through ``preprocessing`` after being externalized before conversion.
+    Of the original archive config, the heads are carried over. Input types
+    are derived from the effective conversion config, or restored from the
+    values captured before preprocessing was externalized. Archive
+    preprocessing is identity unless supplied explicitly through
+    ``preprocessing``.
 
     Args:
         config: Config the conversion was run with.
@@ -300,8 +302,7 @@ def modelconverter_config_to_nn(
         platform: Platform the model was built for.
         preprocessing_input_types: Original input types captured before
             externalized preprocessing cleared the conversion config's
-            encodings. Only used when there is no original archive input to
-            preserve.
+            encodings.
 
     Returns:
         The archive config for the converted model.
@@ -394,20 +395,23 @@ def modelconverter_config_to_nn(
             mode="input",
         )
 
-        orig_inp = find_archive_input(orig_nn, inp.name)
         input_type = (
-            orig_inp.input_type.value
-            if orig_inp is not None
-            else (
-                preprocessing_input_types[inp.name]
-                if preprocessing_input_types is not None
-                and inp.name in preprocessing_input_types
-                else _default_archive_input_type(is_raw_input=inp.is_raw_input)
+            preprocessing_input_types[inp.name]
+            if preprocessing_input_types is not None
+            and inp.name in preprocessing_input_types
+            else _default_archive_input_type(is_raw_input=inp.is_raw_input)
+        )
+        preprocessing_block = preprocessing.get(inp.name)
+        if preprocessing_block is None:
+            preprocessing_cfg = _default_archive_preprocessing(
+                inp, layout, input_type=input_type
             )
-        )
-        preprocessing_cfg = _default_archive_preprocessing(
-            inp, layout, input_type=input_type
-        )
+        else:
+            if input_type == "image":
+                preprocessing_block = _adapt_preprocessing_to_layout(
+                    preprocessing_block, layout
+                )
+            preprocessing_cfg = preprocessing_block.model_dump(mode="json")
 
         archive_cfg["model"]["inputs"].append(
             {
@@ -452,13 +456,13 @@ def modelconverter_config_to_nn(
             }
         )
 
-    archive = NNArchiveConfig(**archive_cfg)
+    input_names = {inp.name for inp in cfg.inputs}
+    unknown_preprocessing = preprocessing.keys() - input_names
+    if unknown_preprocessing:
+        names = ", ".join(sorted(unknown_preprocessing))
+        raise ValueError(f"Preprocessing input(s) not found: {names}")
 
-    for name, block in preprocessing.items():
-        nn_inp = get_archive_input(archive, name)
-        if nn_inp.input_type == InputType.IMAGE:
-            block = _adapt_preprocessing_to_layout(block, nn_inp.layout)
-        nn_inp.preprocessing = block
+    archive = NNArchiveConfig(**archive_cfg)
 
     if is_multistage:
         if len(config.stages) > 2:
@@ -513,6 +517,11 @@ def make_dai_type(
     encoding: Encoding, data_type: DataType, layout: str | None
 ) -> str:
     """Build a DepthAI image type for an archive preprocessing block."""
+    if encoding == Encoding.NONE:
+        raise ValueError(
+            "Cannot build a DepthAI image type for Encoding.NONE."
+        )
+
     if encoding == Encoding.GRAY:
         channel_format = "F16" if data_type == DataType.FLOAT16 else "8"
         return f"{encoding.value}{channel_format}"

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -280,8 +280,9 @@ def modelconverter_config_to_nn(
     Shapes and data types are taken from the converted model itself,
     layouts are guessed from the original ones, and the precision is
     derived from the platform together with its quantization settings.
-    Of the original archive config, the heads are carried over, as is
-    the type of every input and the preprocessing block of a raw one.
+    Of the original archive config, the heads and input types are carried
+    over. Archive preprocessing is identity unless it is supplied explicitly
+    through ``preprocessing`` after being externalized before conversion.
 
     Args:
         config: Config the conversion was run with.
@@ -393,12 +394,8 @@ def modelconverter_config_to_nn(
             if orig_inp is not None
             else _default_archive_input_type(is_raw_input=inp.is_raw_input)
         )
-        preprocessing_cfg = (
-            orig_inp.preprocessing.model_dump(mode="json")
-            if input_type == "raw" and orig_inp is not None
-            else _default_archive_preprocessing(
-                inp, layout, input_type=input_type
-            )
+        preprocessing_cfg = _default_archive_preprocessing(
+            inp, layout, input_type=input_type
         )
 
         archive_cfg["model"]["inputs"].append(

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -456,6 +456,8 @@ def modelconverter_config_to_nn(
 
     for name, block in preprocessing.items():
         nn_inp = get_archive_input(archive, name)
+        if nn_inp.input_type == InputType.IMAGE:
+            block = _adapt_preprocessing_to_layout(block, nn_inp.layout)
         nn_inp.preprocessing = block
 
     if is_multistage:
@@ -518,6 +520,24 @@ def make_dai_type(
     channel_format = "F16F16F16" if data_type == DataType.FLOAT16 else "888"
     storage = "i" if layout == "NHWC" else "p"
     return f"{encoding.value}{channel_format}{storage}"
+
+
+def _adapt_preprocessing_to_layout(
+    block: PreprocessingBlock, layout: str
+) -> PreprocessingBlock:
+    """Return externalized image preprocessing for the converted layout."""
+    dai_type = block.dai_type
+    if dai_type is not None and dai_type.startswith(("RGB", "BGR")):
+        if dai_type.endswith(("i", "p")):
+            dai_type = dai_type[:-1]
+        dai_type += "i" if layout == "NHWC" else "p"
+
+    return block.model_copy(
+        update={
+            "interleaved_to_planar": layout == "NHWC",
+            "dai_type": dai_type,
+        }
+    )
 
 
 def _default_archive_preprocessing(

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -513,6 +513,7 @@ def _default_archive_preprocessing(
     *,
     input_type: Literal["raw", "image"],
 ) -> Params:
+    inp.validate_input_contract()
     if input_type == "raw":
         return {
             "mean": None,

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -274,6 +274,8 @@ def modelconverter_config_to_nn(
     main_stage_key: str,
     model_path: Path,
     platform: Platform,
+    preprocessing_input_types: dict[str, Literal["raw", "image"]]
+    | None = None,
 ) -> NNArchiveConfig:
     """Build the archive config describing a converted model.
 
@@ -296,6 +298,10 @@ def modelconverter_config_to_nn(
         model_path: Path to the model whose metadata the shapes and
             data types are read from.
         platform: Platform the model was built for.
+        preprocessing_input_types: Original input types captured before
+            externalized preprocessing cleared the conversion config's
+            encodings. Only used when there is no original archive input to
+            preserve.
 
     Returns:
         The archive config for the converted model.
@@ -392,7 +398,12 @@ def modelconverter_config_to_nn(
         input_type = (
             orig_inp.input_type.value
             if orig_inp is not None
-            else _default_archive_input_type(is_raw_input=inp.is_raw_input)
+            else (
+                preprocessing_input_types[inp.name]
+                if preprocessing_input_types is not None
+                and inp.name in preprocessing_input_types
+                else _default_archive_input_type(is_raw_input=inp.is_raw_input)
+            )
         )
         preprocessing_cfg = _default_archive_preprocessing(
             inp, layout, input_type=input_type
@@ -599,6 +610,8 @@ def generate_archive(
     preprocessing: dict[str, PreprocessingBlock],
     inference_model_path: Path,
     archive_name: str | None,
+    preprocessing_input_types: dict[str, Literal["raw", "image"]]
+    | None = None,
 ) -> Path:
     """Pack the converted models into an NN Archive.
 
@@ -621,6 +634,8 @@ def generate_archive(
             shapes and data types are read from.
         archive_name: Base name for the archive. If ``None``, the
             config's name is used.
+        preprocessing_input_types: Original input types captured before
+            externalizing preprocessing from the conversion config.
 
     Returns:
         Path to the created archive.
@@ -639,6 +654,7 @@ def generate_archive(
         main_stage,
         inference_model_path,
         platform,
+        preprocessing_input_types=preprocessing_input_types,
     )
     generator = ArchiveGenerator(
         archive_name=f"{archive_name or cfg.name}.{platform.value.lower()}",

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -32,6 +32,7 @@ from modelconverter.utils.config import (
     Config,
     InputConfig,
     PlatformConfig,
+    broadcast_preprocessing_values,
 )
 from modelconverter.utils.constants import MISC_DIR
 from modelconverter.utils.layout import guess_new_layout, make_default_layout
@@ -568,8 +569,16 @@ def _default_archive_preprocessing(
     dai_type = make_dai_type(inp.encoding.to, inp.data_type, layout)
 
     return {
-        "mean": [0 for _ in inp.mean_values] if inp.mean_values else None,
-        "scale": ([1 for _ in inp.scale_values] if inp.scale_values else None),
+        "mean": (
+            broadcast_preprocessing_values([0], inp.channel_count)
+            if inp.mean_values
+            else None
+        ),
+        "scale": (
+            broadcast_preprocessing_values([1], inp.channel_count)
+            if inp.scale_values
+            else None
+        ),
         "reverse_channels": inp.encoding.to == Encoding.RGB,
         "interleaved_to_planar": layout == "NHWC",
         "dai_type": dai_type,

--- a/modelconverter/utils/nn_archive.py
+++ b/modelconverter/utils/nn_archive.py
@@ -507,6 +507,19 @@ def _default_archive_input_type(
     return "image"
 
 
+def make_dai_type(
+    encoding: Encoding, data_type: DataType, layout: str | None
+) -> str:
+    """Build a DepthAI image type for an archive preprocessing block."""
+    if encoding == Encoding.GRAY:
+        channel_format = "F16" if data_type == DataType.FLOAT16 else "8"
+        return f"{encoding.value}{channel_format}"
+
+    channel_format = "F16F16F16" if data_type == DataType.FLOAT16 else "888"
+    storage = "i" if layout == "NHWC" else "p"
+    return f"{encoding.value}{channel_format}{storage}"
+
+
 def _default_archive_preprocessing(
     inp: InputConfig,
     layout: str,
@@ -523,13 +536,7 @@ def _default_archive_preprocessing(
             "dai_type": None,
         }
 
-    dai_type = inp.encoding.to.value
-    if inp.data_type == DataType.FLOAT16:
-        channel_format = "F16F16F16"
-    else:
-        channel_format = "888"
-    dai_type += channel_format
-    dai_type += "i" if layout == "NHWC" else "p"
+    dai_type = make_dai_type(inp.encoding.to, inp.data_type, layout)
 
     return {
         "mean": [0 for _ in inp.mean_values] if inp.mean_values else None,

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -110,6 +110,7 @@ def onnx_attach_normalization_to_inputs(
     new_nodes = []
     new_initializers = []
     input_names = [input_tensor.name for input_tensor in graph.input]
+    output_names = {output_tensor.name for output_tensor in graph.output}
     if not all(name in input_names for name in input_configs):
         raise ONNXException(
             "You either used an invalid input name, or you're attempting "
@@ -126,6 +127,12 @@ def onnx_attach_normalization_to_inputs(
         cfg = input_configs[input_name]
         if not cfg.requires_onnx_input_modification(reverse_only=reverse_only):
             continue
+
+        if input_name in output_names:
+            raise PreprocessingEmbeddingError(
+                f"Cannot embed preprocessing for input '{input_name}' because "
+                "the same tensor is exposed directly as a graph output."
+            )
 
         try:
             n_channels = cfg.validate_preprocessing(reverse_only=reverse_only)

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -25,7 +25,7 @@ from modelconverter.utils.onnx_compatibility import (
     save_onnx_model,
 )
 
-from .exceptions import ONNXException
+from .exceptions import ONNXException, PreprocessingEmbeddingError
 
 ensure_onnx_helper_compatibility()
 
@@ -99,7 +99,9 @@ def onnx_attach_normalization_to_inputs(
         unmodified ``model_path``.
 
     Raises:
-        ONNXException: If an input or requested operation cannot be applied.
+        ONNXException: If the preprocessing request or source model is invalid.
+        PreprocessingEmbeddingError: If valid preprocessing cannot be embedded
+            into this ONNX graph.
 
     """
     if not any(
@@ -136,16 +138,17 @@ def onnx_attach_normalization_to_inputs(
         if not cfg.requires_onnx_input_modification(reverse_only=reverse_only):
             continue
 
-        layout = cfg.layout
-        if layout not in ["NCHW", "NHWC"]:
-            raise ONNXException(
-                f"Cannot embed preprocessing for input '{input_name}' with "
-                f"layout '{layout}'; only 'NCHW' and 'NHWC' are supported."
-            )
         try:
             n_channels = cfg.validate_preprocessing(reverse_only=reverse_only)
         except ValueError as e:
             raise ONNXException(str(e)) from e
+
+        layout = cfg.layout
+        if layout not in ["NCHW", "NHWC"]:
+            raise PreprocessingEmbeddingError(
+                f"Cannot embed preprocessing for input '{input_name}' with "
+                f"layout '{layout}'; only 'NCHW' and 'NHWC' are supported."
+            )
 
         mean_values = (
             None
@@ -168,7 +171,13 @@ def onnx_attach_normalization_to_inputs(
 
         # 1. Reverse channels if needed
         if cfg.encoding_mismatch:
-            opset = get_opset_version(model)
+            try:
+                opset = get_opset_version(model)
+            except ONNXException as e:
+                raise PreprocessingEmbeddingError(
+                    f"Cannot embed channel reversal for input '{input_name}': "
+                    f"{e}"
+                ) from e
             split_names = [f"split_{i}_{input_name}" for i in range(3)]
             axis = 1 if layout == "NCHW" else 3
 
@@ -295,7 +304,13 @@ def onnx_attach_normalization_to_inputs(
         location=f"{save_path.name}_data",
     )
 
-    checker.check_model(str(save_path))
+    try:
+        checker.check_model(str(save_path))
+    except checker.ValidationError as e:
+        raise PreprocessingEmbeddingError(
+            "The ONNX graph produced while embedding preprocessing failed "
+            f"validation: {e}"
+        ) from e
 
     return save_path
 

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -53,6 +53,17 @@ def get_opset_version(model: onnx.ModelProto) -> int:
     raise ONNXException("No opset version found in the ONNX model.")
 
 
+def _reorder_normalization_values(
+    values: list[float] | None,
+    *,
+    reverse: bool,
+) -> list[float] | None:
+    """Return a local, optionally reversed normalization vector."""
+    if values is None:
+        return None
+    return values[::-1] if reverse else list(values)
+
+
 def onnx_attach_normalization_to_inputs(
     model_path: Path,
     save_path: Path,
@@ -72,14 +83,9 @@ def onnx_attach_normalization_to_inputs(
         y_c = (x_c - \mathrm{mean}_c) \cdot \frac{1}{\mathrm{scale}_c}
 
     for every channel :math:`c`. The resulting model is saved and
-    validated with the ONNX checker. Inputs whose layout is neither
-    ``"NCHW"`` nor ``"NHWC"``, and inputs with a known channel count
-    other than 3, are skipped with a warning.
-
-    .. warning::
-        The mean and scale values of an input whose channels are
-        reversed are reversed in place, so the `InputConfig` objects
-        the caller passed in are modified.
+    validated with the ONNX checker. Mean and scale normalization supports
+    any known channel count; color-channel reversal requires exactly three
+    channels. A scalar mean or scale broadcasts to every channel.
 
     Args:
         model_path: Path to the source ONNX model.
@@ -93,8 +99,7 @@ def onnx_attach_normalization_to_inputs(
         unmodified ``model_path``.
 
     Raises:
-        ONNXException: If ``input_configs`` names a tensor that is not
-            an input of the graph.
+        ONNXException: If an input or requested operation cannot be applied.
 
     """
     if not any(
@@ -131,25 +136,33 @@ def onnx_attach_normalization_to_inputs(
         if not cfg.requires_onnx_input_modification(reverse_only=reverse_only):
             continue
 
-        shape = cfg.shape
-        layout = cfg.layout or "NCHW"
+        layout = cfg.layout
         if layout not in ["NCHW", "NHWC"]:
-            logger.warning(
-                f"Input '{input_name}' has layout '{layout}', "
-                "but only 'NCHW' and 'NHWC' are supported for normalization. "
-                "Skipping."
+            raise ONNXException(
+                f"Cannot embed preprocessing for input '{input_name}' with "
+                f"layout '{layout}'; only 'NCHW' and 'NHWC' are supported."
             )
-            continue
+        try:
+            n_channels = cfg.validate_preprocessing(reverse_only=reverse_only)
+        except ValueError as e:
+            raise ONNXException(str(e)) from e
 
-        if shape is not None:
-            n_channels = shape[layout.index("C")]
-            if n_channels != 3:
-                logger.warning(
-                    f"Input '{input_name}' has {n_channels} channels, "
-                    "but normalization is only supported for 3 channels. "
-                    "Skipping."
-                )
-                continue
+        mean_values = (
+            None
+            if reverse_only
+            else _reorder_normalization_values(
+                cfg.mean_values,
+                reverse=cfg.encoding_mismatch,
+            )
+        )
+        scale_values = (
+            None
+            if reverse_only
+            else _reorder_normalization_values(
+                cfg.scale_values,
+                reverse=cfg.encoding_mismatch,
+            )
+        )
 
         last_output = input_name
 
@@ -199,12 +212,9 @@ def onnx_attach_normalization_to_inputs(
         # 2. Subtract (mean) if mean_values is not None and not all 0
         if (
             not reverse_only
-            and cfg.mean_values is not None
-            and any(v != 0 for v in cfg.mean_values)
+            and mean_values is not None
+            and any(v != 0 for v in mean_values)
         ):
-            if cfg.encoding_mismatch:
-                cfg.mean_values = cfg.mean_values[::-1]
-
             sub_out = f"sub_out_{input_name}"
             sub_node = helper.make_node(
                 "Sub",
@@ -218,22 +228,19 @@ def onnx_attach_normalization_to_inputs(
             mean_tensor = helper.make_tensor(
                 f"mean_{input_name}",
                 input_dtype,
-                [1, len(cfg.mean_values), 1, 1]
+                [1, len(mean_values), 1, 1]
                 if layout == "NCHW"
-                else [1, 1, 1, len(cfg.mean_values)],
-                cfg.mean_values,
+                else [1, 1, 1, len(mean_values)],
+                mean_values,
             )
             new_initializers.append(mean_tensor)
 
         # 3. Divide (scale) if scale_values is not None and not all 1
         if (
             not reverse_only
-            and cfg.scale_values is not None
-            and any(v != 1 for v in cfg.scale_values)
+            and scale_values is not None
+            and any(v != 1 for v in scale_values)
         ):
-            if cfg.encoding_mismatch:
-                cfg.scale_values = cfg.scale_values[::-1]
-
             div_out = f"div_out_{input_name}"
             div_node = helper.make_node(
                 "Mul",
@@ -247,10 +254,10 @@ def onnx_attach_normalization_to_inputs(
             scale_tensor = helper.make_tensor(
                 f"scale_{input_name}",
                 input_dtype,
-                [1, len(cfg.scale_values), 1, 1]
+                [1, len(scale_values), 1, 1]
                 if layout == "NCHW"
-                else [1, 1, 1, len(cfg.scale_values)],
-                [1 / v for v in cfg.scale_values],
+                else [1, 1, 1, len(scale_values)],
+                [1 / v for v in scale_values],
             )
             new_initializers.append(scale_tensor)
 

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -18,7 +18,10 @@ from loguru import logger
 from onnx import TensorProto, checker, helper
 from onnxsim import simplify
 
-from modelconverter.utils.config import InputConfig
+from modelconverter.utils.config import (
+    InputConfig,
+    broadcast_preprocessing_values,
+)
 from modelconverter.utils.onnx_compatibility import (
     ensure_onnx_helper_compatibility,
     has_external_data,
@@ -149,12 +152,12 @@ def onnx_attach_normalization_to_inputs(
         mean_values = (
             None
             if reverse_only or cfg.mean_values is None
-            else list(cfg.mean_values)
+            else broadcast_preprocessing_values(cfg.mean_values, n_channels)
         )
         scale_values = (
             None
             if reverse_only or cfg.scale_values is None
-            else list(cfg.scale_values)
+            else broadcast_preprocessing_values(cfg.scale_values, n_channels)
         )
 
         normalization_requested = (

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -94,7 +94,7 @@ def onnx_attach_normalization_to_inputs(
 
     """
     if not any(
-        cfg.requires_onnx_input_modification(reverse_only=reverse_only)
+        cfg.requires_input_preprocessing(reverse_only=reverse_only)
         for cfg in input_configs.values()
     ):
         logger.info(
@@ -125,7 +125,7 @@ def onnx_attach_normalization_to_inputs(
         if input_name not in input_configs:
             continue
         cfg = input_configs[input_name]
-        if not cfg.requires_onnx_input_modification(reverse_only=reverse_only):
+        if not cfg.requires_input_preprocessing(reverse_only=reverse_only):
             continue
 
         if input_name in output_names:

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -229,11 +229,7 @@ def onnx_attach_normalization_to_inputs(
             last_output = f"normalized_{input_name}"
 
         # 2. Subtract (mean) if mean_values is not None and not all 0
-        if (
-            not reverse_only
-            and mean_values is not None
-            and any(v != 0 for v in mean_values)
-        ):
+        if mean_values is not None and any(v != 0 for v in mean_values):
             sub_out = f"sub_out_{input_name}"
             sub_node = helper.make_node(
                 "Sub",
@@ -255,11 +251,7 @@ def onnx_attach_normalization_to_inputs(
             new_initializers.append(mean_tensor)
 
         # 3. Divide (scale) if scale_values is not None and not all 1
-        if (
-            not reverse_only
-            and scale_values is not None
-            and any(v != 1 for v in scale_values)
-        ):
+        if scale_values is not None and any(v != 1 for v in scale_values):
             div_out = f"div_out_{input_name}"
             div_node = helper.make_node(
                 "Mul",

--- a/modelconverter/utils/onnx_tools.py
+++ b/modelconverter/utils/onnx_tools.py
@@ -53,17 +53,6 @@ def get_opset_version(model: onnx.ModelProto) -> int:
     raise ONNXException("No opset version found in the ONNX model.")
 
 
-def _reorder_normalization_values(
-    values: list[float] | None,
-    *,
-    reverse: bool,
-) -> list[float] | None:
-    """Return a local, optionally reversed normalization vector."""
-    if values is None:
-        return None
-    return values[::-1] if reverse else list(values)
-
-
 def onnx_attach_normalization_to_inputs(
     model_path: Path,
     save_path: Path,
@@ -152,20 +141,31 @@ def onnx_attach_normalization_to_inputs(
 
         mean_values = (
             None
-            if reverse_only
-            else _reorder_normalization_values(
-                cfg.mean_values,
-                reverse=cfg.encoding_mismatch,
-            )
+            if reverse_only or cfg.mean_values is None
+            else list(cfg.mean_values)
         )
         scale_values = (
             None
-            if reverse_only
-            else _reorder_normalization_values(
-                cfg.scale_values,
-                reverse=cfg.encoding_mismatch,
-            )
+            if reverse_only or cfg.scale_values is None
+            else list(cfg.scale_values)
         )
+
+        normalization_requested = (
+            mean_values is not None and any(v != 0 for v in mean_values)
+        ) or (scale_values is not None and any(v != 1 for v in scale_values))
+        floating_types = {
+            TensorProto.FLOAT16,
+            TensorProto.FLOAT,
+            TensorProto.DOUBLE,
+            TensorProto.BFLOAT16,
+        }
+        if normalization_requested and input_dtype not in floating_types:
+            dtype_name = TensorProto.DataType.Name(input_dtype)
+            raise PreprocessingEmbeddingError(
+                f"Cannot embed mean/scale preprocessing for input "
+                f"'{input_name}' with ONNX data type '{dtype_name}'; "
+                "normalization requires a floating-point input."
+            )
 
         last_output = input_name
 

--- a/tests/conversion/test_conversion.py
+++ b/tests/conversion/test_conversion.py
@@ -86,6 +86,11 @@ SCENARIOS: list[Scenario] = [
 def _scenario_options(
     platform_name: str, scenario: Scenario
 ) -> tuple[str, ...]:
+    if scenario.id == "tflite-to-native" and platform_name == "rvc4":
+        # RVC4 cannot bake preprocessing into a TFLite model. The source
+        # model already expects RGB, so make that no-op contract explicit.
+        return (*scenario.opts, "encoding", "RGB")
+
     if scenario.id != "ir-to-archive":
         return scenario.opts
 

--- a/tests/conversion/test_conversion_variants.py
+++ b/tests/conversion/test_conversion_variants.py
@@ -134,8 +134,6 @@ def test_rvc4_ncd_layout(tmp_path: Path):
     output_name = "_rvc4-ncd"
     convert(
         Platform.RVC4,
-        "encoding",
-        "NONE",
         "rvc4.disable_calibration",
         "True",
         path=str(onnx_path),

--- a/tests/conversion/test_conversion_variants.py
+++ b/tests/conversion/test_conversion_variants.py
@@ -43,7 +43,25 @@ def test_rvc4_raw_calibration(tmp_path: Path):
 @pytest.mark.hailo
 def test_hailo_without_calibration(tmp_path: Path):
     # No calibration data at all; `disable_calibration` returns the float HAR.
-    config = write_toy_conv_config(tmp_path, calibration="none")
+    # The input is explicitly raw because without calibration Hailo does not
+    # execute the model script that would embed requested preprocessing.
+    onnx_path = build_relu_onnx(tmp_path / "no-calib.onnx", [1, 3, 8, 8])
+    config = write_config(
+        tmp_path,
+        "no-calib",
+        {
+            "input_model": str(onnx_path),
+            "inputs": [
+                {
+                    "name": "data",
+                    "shape": [1, 3, 8, 8],
+                    "layout": "NCHW",
+                    "encoding": "NONE",
+                }
+            ],
+            "outputs": [{"name": "out"}],
+        },
+    )
     output_name = "_hailo-no-calib"
     convert(
         Platform.HAILO,

--- a/tests/conversion/test_conversion_variants.py
+++ b/tests/conversion/test_conversion_variants.py
@@ -134,6 +134,8 @@ def test_rvc4_ncd_layout(tmp_path: Path):
     output_name = "_rvc4-ncd"
     convert(
         Platform.RVC4,
+        "encoding",
+        "NONE",
         "rvc4.disable_calibration",
         "True",
         path=str(onnx_path),

--- a/tests/conversion/test_toy_tflite.py
+++ b/tests/conversion/test_toy_tflite.py
@@ -46,6 +46,14 @@ _CHANNEL_VALUES = (90, 130, 170)
 _PARAMS = platform_params(PLATFORMS)
 
 
+def _conversion_options(platform: Platform) -> tuple[str, ...]:
+    """Use the source TFLite model's RGB contract on RVC4."""
+    options = platform_options(platform)
+    if platform is Platform.RVC4:
+        return (*options, "encoding", "RGB")
+    return options
+
+
 @pytest.fixture(scope="module")
 def toy_tflite(tmp_path_factory: pytest.TempPathFactory) -> Path:
     workdir = tmp_path_factory.mktemp("toy_tflite")
@@ -66,7 +74,7 @@ def test_toy_tflite_conversion(platform_name: str, toy_tflite: Path):
     output_name = f"_toy-tflite-{platform_name}"
     convert(
         platform,
-        *platform_options(platform),
+        *_conversion_options(platform),
         path=str(toy_tflite),
         output_dir=output_name,
         to="native",
@@ -79,7 +87,7 @@ def test_toy_tflite_precision(
     platform_name: str, toy_tflite: Path, solid_image: Path
 ):
     platform = Platform(platform_name)
-    options = platform_options(platform)
+    options = _conversion_options(platform)
     output_name = f"_toy-tflite-prec-{platform_name}"
     convert(
         platform,

--- a/tests/conversion/test_toy_tflite.py
+++ b/tests/conversion/test_toy_tflite.py
@@ -101,7 +101,23 @@ def test_toy_tflite_precision(
     converted = inferer.infer({stage.inputs[0].name: solid_image})
 
     (output,) = converted.values()
-    values = np.sort(np.asarray(output, dtype=np.float32).ravel())
+    output_array = np.asarray(output, dtype=np.float32)
+    if platform is Platform.RVC4:
+        # RVC4Inferer exposes four-dimensional outputs as NCHW. OpenCV writes
+        # the fixture as BGR, while the RVC4 input contract reads it as RGB,
+        # so the identity model must preserve the reversed channel order.
+        assert output_array.ndim == 4
+        assert output_array.shape[1] == 3
+        channel_means = output_array.mean(axis=(0, 2, 3))
+        expected_rgb = np.asarray(_CHANNEL_VALUES[::-1], dtype=np.float32)
+        assert np.array_equal(
+            np.argsort(channel_means), np.argsort(expected_rgb)
+        ), (
+            "rvc4 tflite changed RGB channel order: "
+            f"expected {expected_rgb.tolist()}, got {channel_means.tolist()}"
+        )
+
+    values = np.sort(output_array.ravel())
     per_channel = values.size // len(_CHANNEL_VALUES)
     reference = np.sort(
         np.repeat(np.array(_CHANNEL_VALUES, dtype=np.float32), per_channel)

--- a/tests/conversion/test_toy_tflite.py
+++ b/tests/conversion/test_toy_tflite.py
@@ -30,7 +30,6 @@ from modelconverter.cli.utils import get_configs
 from modelconverter.platforms.getters import get_inferer
 from modelconverter.utils.constants import OUTPUTS_DIR
 from modelconverter.utils.types import Platform
-from tests.helpers.conversion import assert_produced
 from tests.helpers.platform_options import platform_options
 from tests.helpers.platforms import platform_params
 from tests.helpers.precision import cosine_similarity, locate_converted_model
@@ -66,20 +65,6 @@ def solid_image(tmp_path_factory: pytest.TempPathFactory) -> Path:
     path = tmp_path_factory.mktemp("toy_tflite_img") / "solid.png"
     cv2.imwrite(str(path), np.full((8, 8, 3), _CHANNEL_VALUES, dtype=np.uint8))
     return path
-
-
-@pytest.mark.parametrize("platform_name", _PARAMS)
-def test_toy_tflite_conversion(platform_name: str, toy_tflite: Path):
-    platform = Platform(platform_name)
-    output_name = f"_toy-tflite-{platform_name}"
-    convert(
-        platform,
-        *_conversion_options(platform),
-        path=str(toy_tflite),
-        output_dir=output_name,
-        to="native",
-    )
-    assert_produced(output_name)
 
 
 @pytest.mark.parametrize("platform_name", _PARAMS)

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -328,6 +328,23 @@ def test_externalized_preprocessing_uses_model_side_encoding(
     assert block.reverse_channels is True
 
 
+def test_externalized_scalar_preprocessing_expands_per_channel(
+    dummy_onnx: Path,
+):
+    cfg = _single_stage_config(
+        dummy_onnx,
+        encoding="RGB",
+        mean_values=127.5,
+        scale_values=255.0,
+    )
+
+    _cfg, preprocessing = extract_preprocessing(cfg)
+
+    block = preprocessing["input0"]
+    assert block.mean == [127.5, 127.5, 127.5]
+    assert block.scale == [255.0, 255.0, 255.0]
+
+
 def test_raw_input_with_mean_scale(dummy_onnx: Path):
     cfg = _single_stage_config(
         dummy_onnx,

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -314,6 +314,28 @@ def test_image_input_rgb_planar(dummy_onnx: Path):
     assert stage.inputs[0].encoding.from_ == Encoding.NONE
 
 
+@pytest.mark.parametrize(
+    ("encoding", "expected_dai_type", "expected_reverse_channels"),
+    [
+        ({"from": "RGB", "to": "BGR"}, "RGB888p", True),
+        ({"from": "BGR", "to": "RGB"}, "BGR888p", False),
+    ],
+)
+def test_externalized_preprocessing_uses_model_side_encoding(
+    dummy_onnx: Path,
+    encoding: dict[str, str],
+    expected_dai_type: str,
+    expected_reverse_channels: bool,
+):
+    cfg = _single_stage_config(dummy_onnx, encoding=encoding)
+
+    _cfg, preprocessing = extract_preprocessing(cfg)
+
+    block = preprocessing["input0"]
+    assert block.dai_type == expected_dai_type
+    assert block.reverse_channels is expected_reverse_channels
+
+
 def test_raw_input_with_mean_scale(dummy_onnx: Path):
     cfg = _single_stage_config(
         dummy_onnx,

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -27,7 +27,7 @@ from tests.helpers.archive_factory import (
     default_archive_config,
     pack_archive,
 )
-from tests.helpers.onnx_factory import standard_dummy_onnx
+from tests.helpers.onnx_factory import grayscale_onnx, standard_dummy_onnx
 
 
 def _single_stage_config(dummy_onnx: Path, **overrides) -> Config:
@@ -365,3 +365,28 @@ def test_image_input_float16_channel_type(dummy_onnx: Path):
     dai_type = preprocessing["input0"].dai_type
     assert dai_type is not None
     assert dai_type.startswith("RGBF16F16F16")
+
+
+@pytest.mark.parametrize(
+    ("data_type", "expected_dai_type"),
+    [("float32", "GRAY8"), ("float16", "GRAYF16")],
+)
+def test_externalized_grayscale_uses_valid_dai_type(
+    tmp_path: Path, data_type: str, expected_dai_type: str
+):
+    model = grayscale_onnx(tmp_path / "gray.onnx")
+    cfg = Config.get_config(
+        None,
+        {
+            "input_model": str(model),
+            "encoding": "GRAY",
+            "data_type": data_type,
+        },
+    )
+
+    _cfg, preprocessing = extract_preprocessing(cfg)
+
+    block = next(iter(preprocessing.values()))
+    assert block.dai_type == expected_dai_type
+    assert block.mean == [0]
+    assert block.scale == [1]

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -314,26 +314,18 @@ def test_image_input_rgb_planar(dummy_onnx: Path):
     assert stage.inputs[0].encoding.from_ == Encoding.NONE
 
 
-@pytest.mark.parametrize(
-    ("encoding", "expected_dai_type", "expected_reverse_channels"),
-    [
-        ({"from": "RGB", "to": "BGR"}, "RGB888p", True),
-        ({"from": "BGR", "to": "RGB"}, "BGR888p", False),
-    ],
-)
 def test_externalized_preprocessing_uses_model_side_encoding(
     dummy_onnx: Path,
-    encoding: dict[str, str],
-    expected_dai_type: str,
-    expected_reverse_channels: bool,
 ):
-    cfg = _single_stage_config(dummy_onnx, encoding=encoding)
+    cfg = _single_stage_config(
+        dummy_onnx, encoding={"from": "RGB", "to": "BGR"}
+    )
 
     _cfg, preprocessing = extract_preprocessing(cfg)
 
     block = preprocessing["input0"]
-    assert block.dai_type == expected_dai_type
-    assert block.reverse_channels is expected_reverse_channels
+    assert block.dai_type == "RGB888p"
+    assert block.reverse_channels is True
 
 
 def test_raw_input_with_mean_scale(dummy_onnx: Path):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -458,8 +458,12 @@ def test_layout_without_channel_dim_keeps_rgb():
 
 
 def test_dynamic_batch_size_set_to_one():
-    inp = InputConfig(name="i", shape=[0, 3, 64, 64], layout="NCHW")
+    inp = InputConfig(name="i", shape=[0, 3, 64, 64])
     assert inp.shape == [1, 3, 64, 64]
+    assert inp.layout == "NCHW"
+    assert inp.encoding.from_ == Encoding.RGB
+    assert inp.encoding.to == Encoding.BGR
+    inp.validate_input_contract()
 
 
 def test_no_layout_short_circuits_grayscale():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -427,6 +427,11 @@ def test_implicit_non_image_encoding_uses_inferred_layout():
     assert inp.encoding.from_ == inp.encoding.to == Encoding.NONE
 
 
+def test_invalid_input_layout_reaches_layout_validation():
+    with pytest.raises(ValueError, match="Length of `layout`"):
+        InputConfig(name="i", shape=[1], layout="NC")
+
+
 def test_non_three_channel_input_rejects_color_encoding():
     inp = _input_config(
         name="i",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -390,7 +390,7 @@ def test_grayscale_input_sets_gray_encoding():
 
 
 def test_explicit_raw_one_channel_input_stays_raw():
-    inp = InputConfig(
+    inp = _input_config(
         name="i",
         shape=[1, 1, 64, 64],
         layout="NCHW",
@@ -407,7 +407,7 @@ def test_non_grayscale_channel_kept():
 
 
 def test_non_three_channel_input_rejects_color_encoding():
-    inp = InputConfig(
+    inp = _input_config(
         name="i",
         shape=[1, 10],
         layout="NC",
@@ -418,7 +418,7 @@ def test_non_three_channel_input_rejects_color_encoding():
 
 
 def test_multichannel_input_rejects_gray_encoding():
-    inp = InputConfig(
+    inp = _input_config(
         name="i", shape=[1, 3, 64, 64], layout="NCHW", encoding="GRAY"
     )
     with pytest.raises(ValueError, match="cannot use GRAY encoding"):
@@ -468,7 +468,7 @@ def test_zero_scale_value_is_rejected():
 def test_neutral_preprocessing_value_count_is_validated(
     field: str, values: list[int]
 ):
-    inp = InputConfig(
+    inp = _input_config(
         name="i",
         shape=[1, 3, 64, 64],
         layout="NCHW",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -406,21 +406,15 @@ def test_non_grayscale_channel_kept():
     assert inp.encoding.from_ == Encoding.RGB
 
 
-@pytest.mark.parametrize("encoding", ["RGB", "BGR"])
-def test_non_three_channel_input_rejects_color_encoding(encoding: str):
+def test_non_three_channel_input_rejects_color_encoding():
     inp = InputConfig(
         name="i",
         shape=[1, 10],
         layout="NC",
-        encoding=encoding,
+        encoding="RGB",
     )
     with pytest.raises(ValueError, match="cannot use RGB/BGR encoding"):
         inp.validate_input_contract()
-
-
-def test_nonstandard_channel_input_accepts_raw_encoding():
-    inp = InputConfig(name="i", shape=[1, 10], layout="NC", encoding="NONE")
-    assert inp.is_raw_input
 
 
 def test_multichannel_input_rejects_gray_encoding():
@@ -457,7 +451,7 @@ def test_named_scale_values():
     assert inp.scale_values == [58.395, 57.12, 57.375]
 
 
-def test_scalar_mean_value_broadcasts_over_channels():
+def test_scalar_mean_value_is_preserved_for_later_broadcast():
     inp = _input_config(name="i", mean_values=127)
     assert inp.mean_values == [127]
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -389,6 +389,18 @@ def test_grayscale_input_sets_gray_encoding():
     assert inp.encoding.from_ == inp.encoding.to == Encoding.GRAY
 
 
+def test_explicit_raw_one_channel_input_stays_raw():
+    inp = InputConfig(
+        name="i",
+        shape=[1, 1, 64, 64],
+        layout="NCHW",
+        encoding="NONE",
+    )
+
+    assert inp.encoding.from_ == inp.encoding.to == Encoding.NONE
+    assert inp.is_raw_input
+
+
 def test_non_grayscale_channel_kept():
     inp = InputConfig(name="i", shape=[1, 3, 64, 64], layout="NCHW")
     assert inp.encoding.from_ == Encoding.RGB

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -394,10 +394,29 @@ def test_non_grayscale_channel_kept():
     assert inp.encoding.from_ == Encoding.RGB
 
 
-def test_multichannel_with_channel_dim_keeps_rgb():
-    # "C" present but the channel dim is not 1 -> not grayscale, stays RGB.
-    inp = InputConfig(name="i", shape=[1, 10], layout="NC")
-    assert inp.encoding.from_ == Encoding.RGB
+@pytest.mark.parametrize("encoding", ["RGB", "BGR"])
+def test_non_three_channel_input_rejects_color_encoding(encoding: str):
+    inp = InputConfig(
+        name="i",
+        shape=[1, 10],
+        layout="NC",
+        encoding=encoding,
+    )
+    with pytest.raises(ValueError, match="cannot use RGB/BGR encoding"):
+        inp.validate_input_contract()
+
+
+def test_nonstandard_channel_input_accepts_raw_encoding():
+    inp = InputConfig(name="i", shape=[1, 10], layout="NC", encoding="NONE")
+    assert inp.is_raw_input
+
+
+def test_multichannel_input_rejects_gray_encoding():
+    inp = InputConfig(
+        name="i", shape=[1, 3, 64, 64], layout="NCHW", encoding="GRAY"
+    )
+    with pytest.raises(ValueError, match="cannot use GRAY encoding"):
+        inp.validate_input_contract()
 
 
 def test_layout_without_channel_dim_keeps_rgb():
@@ -434,6 +453,24 @@ def test_scalar_mean_value_broadcasts_over_channels():
 def test_zero_scale_value_is_rejected():
     with pytest.raises(ValueError, match="zero scale value"):
         _input_config(name="i", scale_values=[1, 0, 2])
+
+
+@pytest.mark.parametrize(
+    ("field", "values"),
+    [("mean_values", [0, 0]), ("scale_values", [1, 1])],
+)
+def test_neutral_preprocessing_value_count_is_validated(
+    field: str, values: list[int]
+):
+    inp = InputConfig(
+        name="i",
+        shape=[1, 3, 64, 64],
+        layout="NCHW",
+        encoding="BGR",
+        **{field: values},
+    )
+    with pytest.raises(ValueError, match="one value per channel"):
+        inp.validate_input_contract()
 
 
 def test_explicit_scale_values_pass_through():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -407,6 +407,22 @@ def test_non_grayscale_channel_kept():
     assert inp.encoding.to == Encoding.BGR
 
 
+@pytest.mark.parametrize(
+    ("shape", "layout", "expected"),
+    [
+        ([1, 3, 64, 64], "NCHW", 3),
+        ([1, 0, 64, 64], "NCHW", None),
+        ([1, 3], "NA", None),
+        (None, None, None),
+    ],
+)
+def test_channel_count(
+    shape: list[int] | None, layout: str | None, expected: int | None
+):
+    inp = InputConfig(name="i", shape=shape, layout=layout)
+    assert inp.channel_count == expected
+
+
 @pytest.mark.parametrize("channels", [2, 4, 6])
 def test_implicit_non_image_encoding_defaults_to_none(channels: int):
     inp = InputConfig(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -404,6 +404,27 @@ def test_explicit_raw_one_channel_input_stays_raw():
 def test_non_grayscale_channel_kept():
     inp = InputConfig(name="i", shape=[1, 3, 64, 64], layout="NCHW")
     assert inp.encoding.from_ == Encoding.RGB
+    assert inp.encoding.to == Encoding.BGR
+
+
+@pytest.mark.parametrize("channels", [2, 4, 6])
+def test_implicit_non_image_encoding_defaults_to_none(channels: int):
+    inp = InputConfig(
+        name="i",
+        shape=[1, channels, 64, 64],
+        layout="NCHW",
+    )
+
+    assert inp.encoding.from_ == inp.encoding.to == Encoding.NONE
+    assert inp.is_raw_input
+    inp.validate_input_contract()
+
+
+def test_implicit_non_image_encoding_uses_inferred_layout():
+    inp = InputConfig(name="i", shape=[1, 4, 64, 64])
+
+    assert inp.layout == "NCHW"
+    assert inp.encoding.from_ == inp.encoding.to == Encoding.NONE
 
 
 def test_non_three_channel_input_rejects_color_encoding():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -427,6 +427,26 @@ def test_implicit_non_image_encoding_uses_inferred_layout():
     assert inp.encoding.from_ == inp.encoding.to == Encoding.NONE
 
 
+@pytest.mark.parametrize(
+    ("shape", "layout", "expected_layout"),
+    [
+        ([1, 3, 8400], None, "NCD"),
+        ([32, 32, 3], "HWC", "HWC"),
+        ([1, 3, 4, 224, 224], None, "NCDEF"),
+        ([1, 10], "NA", "NA"),
+    ],
+)
+def test_implicit_non_image_layout_defaults_to_none(
+    shape: list[int], layout: str | None, expected_layout: str
+):
+    inp = InputConfig(name="i", shape=shape, layout=layout)
+
+    assert inp.layout == expected_layout
+    assert inp.encoding.from_ == inp.encoding.to == Encoding.NONE
+    assert inp.is_raw_input
+    inp.validate_input_contract()
+
+
 def test_invalid_input_layout_reaches_layout_validation():
     with pytest.raises(ValueError, match="Length of `layout`"):
         InputConfig(name="i", shape=[1], layout="NC")
@@ -449,12 +469,6 @@ def test_multichannel_input_rejects_gray_encoding():
     )
     with pytest.raises(ValueError, match="cannot use GRAY encoding"):
         inp.validate_input_contract()
-
-
-def test_layout_without_channel_dim_keeps_rgb():
-    # No "C" in the layout -> the grayscale check early-returns, RGB stays.
-    inp = InputConfig(name="i", shape=[1, 10], layout="NA")
-    assert inp.encoding.from_ == Encoding.RGB
 
 
 def test_dynamic_batch_size_set_to_one():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -482,6 +482,14 @@ def test_zero_scale_value_is_rejected():
         _input_config(name="i", scale_values=[1, 0, 2])
 
 
+def test_zero_scale_value_is_rejected_after_assignment():
+    inp = _input_config(name="i", scale_values=[1, 2, 3])
+    inp.scale_values = [1, 0, 3]
+
+    with pytest.raises(ValueError, match="zero scale value"):
+        inp.validate_input_contract()
+
+
 @pytest.mark.parametrize(
     ("field", "values"),
     [("mean_values", [0, 0]), ("scale_values", [1, 1])],

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -489,24 +489,24 @@ def test_unset_mean_values_stay_none():
     assert inp.mean_values is None
 
 
-def test_encoding_mismatch_requires_onnx_modification():
+def test_encoding_mismatch_requires_preprocessing():
     inp = _input_config(name="i", encoding={"from": "RGB", "to": "BGR"})
-    assert inp.requires_onnx_input_modification()
+    assert inp.requires_input_preprocessing()
 
 
 def test_reverse_only_ignores_mean_and_scale():
     inp = _input_config(name="i", encoding="RGB", mean_values=[1, 2, 3])
-    assert not inp.requires_onnx_input_modification(reverse_only=True)
+    assert not inp.requires_input_preprocessing(reverse_only=True)
 
 
-def test_normalization_requires_onnx_modification():
+def test_normalization_requires_preprocessing():
     inp = _input_config(name="i", encoding="RGB", scale_values=[2, 2, 2])
-    assert inp.requires_onnx_input_modification()
+    assert inp.requires_input_preprocessing()
 
 
-def test_plain_input_needs_no_onnx_modification():
+def test_plain_input_needs_no_preprocessing():
     inp = _input_config(name="i", encoding="RGB")
-    assert not inp.requires_onnx_input_modification()
+    assert not inp.requires_input_preprocessing()
 
 
 def test_raw_and_colour_input_properties():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -428,7 +428,12 @@ def test_named_scale_values():
 
 def test_scalar_mean_value_broadcasts_over_channels():
     inp = _input_config(name="i", mean_values=127)
-    assert inp.mean_values == [127, 127, 127]
+    assert inp.mean_values == [127]
+
+
+def test_zero_scale_value_is_rejected():
+    with pytest.raises(ValueError, match="zero scale value"):
+        _input_config(name="i", scale_values=[1, 0, 2])
 
 
 def test_explicit_scale_values_pass_through():

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -1,7 +1,7 @@
 """Tests for final conversion artifact logging."""
 
 from pathlib import Path
-from typing import Literal
+from typing import Literal, NoReturn
 
 import pytest
 from luxonis_ml.typing import Params
@@ -9,7 +9,7 @@ from luxonis_ml.typing import Params
 import modelconverter.__main__ as main_module
 from modelconverter.platforms.base_exporter import Exporter
 from modelconverter.utils.config import Config, SingleStageConfig
-from modelconverter.utils.types import Platform
+from modelconverter.utils.types import InputFileType, Platform
 
 
 class _FakeTelemetry:
@@ -56,11 +56,12 @@ class _FakeMultiStageExporter:
 
 
 @pytest.mark.parametrize(
-    ("output_mode", "expected_names", "multistage"),
+    ("output_mode", "expected_names", "multistage", "archive_preprocess"),
     [
-        ("native", ["model.dlc"], False),
-        ("nn_archive", ["model.rvc4.tar.xz"], False),
-        ("native", ["first.dlc", "second.dlc"], True),
+        ("native", ["model.dlc"], False, False),
+        ("nn_archive", ["model.rvc4.tar.xz"], False, False),
+        ("nn_archive", ["model.rvc4.tar.xz"], False, True),
+        ("native", ["first.dlc", "second.dlc"], True, False),
     ],
 )
 def test_convert_logs_final_artifact_for_each_output_mode(
@@ -70,6 +71,7 @@ def test_convert_logs_final_artifact_for_each_output_mode(
     output_mode: Literal["native", "nn_archive"],
     expected_names: list[str],
     multistage: bool,
+    archive_preprocess: bool,
 ) -> None:
     if multistage:
         cfg = Config.get_config(
@@ -161,6 +163,7 @@ def test_convert_logs_final_artifact_for_each_output_mode(
         Platform.RVC4,
         path=str(dummy_onnx),
         to=output_mode,
+        archive_preprocess=archive_preprocess,
     )
 
     export_messages = [
@@ -172,3 +175,153 @@ def test_convert_logs_final_artifact_for_each_output_mode(
     assert export_messages == [
         f"Model exported to /host/output/{name}" for name in expected_names
     ]
+
+
+def test_archive_preprocess_is_rejected_for_native_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_was_loaded = False
+
+    def fail_if_called(*_args: object, **_kwargs: object) -> NoReturn:
+        nonlocal config_was_loaded
+        config_was_loaded = True
+        raise AssertionError("configuration must not be loaded")
+
+    monkeypatch.setattr(main_module.signal, "signal", lambda *_args: None)
+    monkeypatch.setattr(main_module, "get_configs", fail_if_called)
+    monkeypatch.setattr(
+        main_module,
+        "get_component_telemetry",
+        _FakeTelemetry,
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_conversion_run_id",
+        lambda: "test-run",
+    )
+    monkeypatch.setattr(main_module, "peak_ram_usage_bytes", lambda: 0)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_module.convert(
+            Platform.RVC4,
+            to="native",
+            archive_preprocess=True,
+        )
+
+    assert exc_info.value.code == 1
+    assert not config_was_loaded
+
+
+@pytest.mark.parametrize(
+    ("platform", "input_file_type", "disable_calibration", "reason"),
+    [
+        (
+            Platform.RVC4,
+            InputFileType.TFLITE,
+            False,
+            "RVC4 can only bake preprocessing into ONNX source models",
+        ),
+        (
+            Platform.RVC2,
+            InputFileType.IR,
+            False,
+            "cannot add preprocessing to an existing OpenVINO IR",
+        ),
+        (
+            Platform.RVC3,
+            InputFileType.IR,
+            False,
+            "cannot add preprocessing to an existing OpenVINO IR",
+        ),
+        (
+            Platform.HAILO,
+            InputFileType.ONNX,
+            True,
+            "Hailo cannot bake preprocessing when calibration is disabled",
+        ),
+    ],
+)
+def test_nn_archive_automatically_externalizes_unembeddable_preprocessing(
+    dummy_onnx: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    platform: Platform,
+    input_file_type: InputFileType,
+    disable_calibration: bool,
+    reason: str,
+) -> None:
+    cfg = Config.get_config(
+        None,
+        {
+            "input_model": str(dummy_onnx),
+            "shape": [1, 3, 64, 64],
+            "encoding": "NONE",
+            "mean_values": [1, 2, 3],
+        },
+    )
+    stage = next(iter(cfg.stages.values()))
+    stage.input_file_type = input_file_type
+    stage.get_platform_config(
+        platform
+    ).disable_calibration = disable_calibration
+    main_stage = next(iter(cfg.stages))
+    output_dir = tmp_path / f"output-{platform.value}"
+    warnings: list[str] = []
+    exporter_configs: list[SingleStageConfig] = []
+    archive_kwargs: dict[str, object] = {}
+
+    def make_exporter(
+        _platform: Platform,
+        config: SingleStageConfig,
+        output_dir: Path,
+    ) -> _FakeExporter:
+        exporter_configs.append(config)
+        return _FakeExporter(config, output_dir)
+
+    def generate_archive(**kwargs: object) -> Path:
+        archive_kwargs.update(kwargs)
+        return output_dir / f"model.{platform.value}.tar.xz"
+
+    monkeypatch.setattr(main_module.signal, "signal", lambda *_args: None)
+    monkeypatch.setattr(main_module, "init_dirs", lambda: None)
+    monkeypatch.setattr(
+        main_module,
+        "get_configs",
+        lambda *_args, **_kwargs: (cfg, None, main_stage),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_output_dir_name",
+        lambda *_args, **_kwargs: output_dir,
+    )
+    monkeypatch.setattr(main_module, "setup_logging", lambda **_kwargs: None)
+    monkeypatch.setattr(main_module, "get_exporter", make_exporter)
+    monkeypatch.setattr(
+        main_module,
+        "get_component_telemetry",
+        _FakeTelemetry,
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_conversion_run_id",
+        lambda: "test-run",
+    )
+    monkeypatch.setattr(main_module, "peak_ram_usage_bytes", lambda: 0)
+    monkeypatch.setattr(main_module, "is_nn_archive", lambda _path: False)
+    monkeypatch.setattr(main_module, "generate_archive", generate_archive)
+    monkeypatch.setattr(main_module.logger, "warning", warnings.append)
+
+    main_module.convert(
+        platform,
+        path=str(dummy_onnx),
+        to="nn_archive",
+    )
+
+    assert exporter_configs[0].inputs[0].mean_values is None
+    preprocessing = archive_kwargs["preprocessing"]
+    assert isinstance(preprocessing, dict)
+    assert preprocessing["input0"].mean == [1.0, 2.0, 3.0]
+    assert len(warnings) == 1
+    assert "Automatic NN Archive preprocessing fallback" in warnings[0]
+    assert reason in warnings[0]
+    assert "input0" in warnings[0]

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -8,8 +8,9 @@ from luxonis_ml.typing import Params
 
 import modelconverter.__main__ as main_module
 from modelconverter.platforms.base_exporter import Exporter
+from modelconverter.utils import ONNXException, PreprocessingEmbeddingError
 from modelconverter.utils.config import Config, SingleStageConfig
-from modelconverter.utils.types import InputFileType, Platform
+from modelconverter.utils.types import Platform
 
 
 class _FakeTelemetry:
@@ -35,6 +36,15 @@ class _FakeExporter(Exporter):
 
     def run(self) -> Path:
         return self.inference_model_path
+
+
+class _FakeRunEmbeddingFailureExporter(_FakeExporter):
+    def run(self) -> Path:
+        if any(
+            inp.requires_input_preprocessing() for inp in self.config.inputs
+        ):
+            raise PreprocessingEmbeddingError("test embedding failure")
+        return super().run()
 
 
 class _FakeMultiStageExporter:
@@ -213,42 +223,18 @@ def test_archive_preprocess_is_rejected_for_native_output(
 
 
 @pytest.mark.parametrize(
-    ("platform", "input_file_type", "disable_calibration", "reason"),
+    ("platform", "failure_phase"),
     [
-        (
-            Platform.RVC4,
-            InputFileType.TFLITE,
-            False,
-            "RVC4 can only bake preprocessing into ONNX source models",
-        ),
-        (
-            Platform.RVC2,
-            InputFileType.IR,
-            False,
-            "cannot add preprocessing to an existing OpenVINO IR",
-        ),
-        (
-            Platform.RVC3,
-            InputFileType.IR,
-            False,
-            "cannot add preprocessing to an existing OpenVINO IR",
-        ),
-        (
-            Platform.HAILO,
-            InputFileType.ONNX,
-            True,
-            "Hailo cannot bake preprocessing when calibration is disabled",
-        ),
+        (Platform.RVC4, "construction"),
+        (Platform.RVC3, "run"),
     ],
 )
-def test_nn_archive_automatically_externalizes_unembeddable_preprocessing(
+def test_nn_archive_retries_after_preprocessing_embedding_failure(
     dummy_onnx: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     platform: Platform,
-    input_file_type: InputFileType,
-    disable_calibration: bool,
-    reason: str,
+    failure_phase: Literal["construction", "run"],
 ) -> None:
     cfg = Config.get_config(
         None,
@@ -259,11 +245,6 @@ def test_nn_archive_automatically_externalizes_unembeddable_preprocessing(
             "mean_values": [1, 2, 3],
         },
     )
-    stage = next(iter(cfg.stages.values()))
-    stage.input_file_type = input_file_type
-    stage.get_platform_config(
-        platform
-    ).disable_calibration = disable_calibration
     main_stage = next(iter(cfg.stages))
     output_dir = tmp_path / f"output-{platform.value}"
     warnings: list[str] = []
@@ -276,7 +257,16 @@ def test_nn_archive_automatically_externalizes_unembeddable_preprocessing(
         output_dir: Path,
     ) -> _FakeExporter:
         exporter_configs.append(config)
-        return _FakeExporter(config, output_dir)
+        if failure_phase == "construction" and any(
+            inp.requires_input_preprocessing() for inp in config.inputs
+        ):
+            raise PreprocessingEmbeddingError("test embedding failure")
+        exporter_type = (
+            _FakeRunEmbeddingFailureExporter
+            if failure_phase == "run"
+            else _FakeExporter
+        )
+        return exporter_type(config, output_dir)
 
     def generate_archive(**kwargs: object) -> Path:
         archive_kwargs.update(kwargs)
@@ -317,11 +307,135 @@ def test_nn_archive_automatically_externalizes_unembeddable_preprocessing(
         to="nn_archive",
     )
 
-    assert exporter_configs[0].inputs[0].mean_values is None
+    assert len(exporter_configs) == 2
+    assert exporter_configs[-1].inputs[0].mean_values is None
     preprocessing = archive_kwargs["preprocessing"]
     assert isinstance(preprocessing, dict)
     assert preprocessing["input0"].mean == [1.0, 2.0, 3.0]
     assert len(warnings) == 1
-    assert "Automatic NN Archive preprocessing fallback" in warnings[0]
-    assert reason in warnings[0]
+    assert "test embedding failure" in warnings[0]
+    assert "Falling back to NN Archive preprocessing" in warnings[0]
     assert "input0" in warnings[0]
+
+
+@pytest.mark.parametrize(
+    ("output_mode", "error_type"),
+    [
+        ("native", PreprocessingEmbeddingError),
+        ("nn_archive", ONNXException),
+    ],
+)
+def test_conversion_does_not_fallback_for_nonrecoverable_errors(
+    dummy_onnx: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    output_mode: Literal["native", "nn_archive"],
+    error_type: type[BaseException],
+) -> None:
+    cfg = Config.get_config(
+        None,
+        {
+            "input_model": str(dummy_onnx),
+            "shape": [1, 3, 64, 64],
+            "encoding": "NONE",
+            "mean_values": [1, 2, 3],
+        },
+    )
+    output_dir = tmp_path / "output-no-fallback"
+    attempts = 0
+
+    def fail_exporter(*_args: object, **_kwargs: object) -> NoReturn:
+        nonlocal attempts
+        attempts += 1
+        raise error_type("not recoverable")
+
+    monkeypatch.setattr(main_module.signal, "signal", lambda *_args: None)
+    monkeypatch.setattr(main_module, "init_dirs", lambda: None)
+    monkeypatch.setattr(
+        main_module,
+        "get_configs",
+        lambda *_args, **_kwargs: (cfg, None, next(iter(cfg.stages))),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_output_dir_name",
+        lambda *_args, **_kwargs: output_dir,
+    )
+    monkeypatch.setattr(main_module, "setup_logging", lambda **_kwargs: None)
+    monkeypatch.setattr(main_module, "get_exporter", fail_exporter)
+    monkeypatch.setattr(
+        main_module,
+        "get_component_telemetry",
+        _FakeTelemetry,
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_conversion_run_id",
+        lambda: "test-run",
+    )
+    monkeypatch.setattr(main_module, "peak_ram_usage_bytes", lambda: 0)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_module.convert(
+            Platform.RVC4,
+            path=str(dummy_onnx),
+            to=output_mode,
+        )
+
+    assert exc_info.value.code == 1
+    assert attempts == 1
+    stage = next(iter(cfg.stages.values()))
+    assert stage.inputs[0].mean_values == [1.0, 2.0, 3.0]
+
+
+def test_invalid_preprocessing_is_rejected_before_fallback(
+    dummy_onnx: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = Config.get_config(
+        None,
+        {
+            "input_model": str(dummy_onnx),
+            "shape": [1, 3, 64, 64],
+            "encoding": "NONE",
+            "mean_values": [1, 2],
+        },
+    )
+    exporter_was_created = False
+
+    def fail_if_called(*_args: object, **_kwargs: object) -> NoReturn:
+        nonlocal exporter_was_created
+        exporter_was_created = True
+        raise AssertionError("invalid preprocessing must fail first")
+
+    monkeypatch.setattr(main_module.signal, "signal", lambda *_args: None)
+    monkeypatch.setattr(main_module, "init_dirs", lambda: None)
+    monkeypatch.setattr(
+        main_module,
+        "get_configs",
+        lambda *_args, **_kwargs: (cfg, None, next(iter(cfg.stages))),
+    )
+    monkeypatch.setattr(main_module, "get_exporter", fail_if_called)
+    monkeypatch.setattr(
+        main_module,
+        "get_component_telemetry",
+        _FakeTelemetry,
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_conversion_run_id",
+        lambda: "test-run",
+    )
+    monkeypatch.setattr(main_module, "peak_ram_usage_bytes", lambda: 0)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_module.convert(
+            Platform.RVC4,
+            path=str(dummy_onnx),
+            output_dir=str(tmp_path / "invalid-preprocessing"),
+            to="nn_archive",
+        )
+
+    assert exc_info.value.code == 1
+    assert not exporter_was_created

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -14,8 +14,15 @@ from modelconverter.utils.types import Platform
 
 
 class _FakeTelemetry:
+    def __init__(self) -> None:
+        self.captures: list[tuple[str, dict[str, object]]] = []
+
     def capture(self, *_args: object, **_kwargs: object) -> None:
-        pass
+        event = _args[0]
+        properties = _args[1]
+        assert isinstance(event, str)
+        assert isinstance(properties, dict)
+        self.captures.append((event, properties))
 
 
 class _FakeExporter(Exporter):
@@ -250,6 +257,7 @@ def test_nn_archive_retries_after_preprocessing_embedding_failure(
     warnings: list[str] = []
     exporter_configs: list[SingleStageConfig] = []
     archive_kwargs: dict[str, object] = {}
+    telemetry = _FakeTelemetry()
 
     def make_exporter(
         _platform: Platform,
@@ -289,7 +297,7 @@ def test_nn_archive_retries_after_preprocessing_embedding_failure(
     monkeypatch.setattr(
         main_module,
         "get_component_telemetry",
-        _FakeTelemetry,
+        lambda: telemetry,
     )
     monkeypatch.setattr(
         main_module,
@@ -319,6 +327,13 @@ def test_nn_archive_retries_after_preprocessing_embedding_failure(
     assert "test embedding failure" in warnings[0]
     assert "Falling back to NN Archive preprocessing" in warnings[0]
     assert "input0" in warnings[0]
+    configured_properties = [
+        properties
+        for event, properties in telemetry.captures
+        if event == main_module.CONFIGURED_EVENT
+    ]
+    assert len(configured_properties) == 1
+    assert configured_properties[0]["archive_preprocess"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -241,7 +241,7 @@ def test_nn_archive_retries_after_preprocessing_embedding_failure(
         {
             "input_model": str(dummy_onnx),
             "shape": [1, 3, 64, 64],
-            "encoding": "NONE",
+            "encoding": "BGR",
             "mean_values": [1, 2, 3],
         },
     )
@@ -312,6 +312,9 @@ def test_nn_archive_retries_after_preprocessing_embedding_failure(
     preprocessing = archive_kwargs["preprocessing"]
     assert isinstance(preprocessing, dict)
     assert preprocessing["input0"].mean == [1.0, 2.0, 3.0]
+    preprocessing_input_types = archive_kwargs["preprocessing_input_types"]
+    assert isinstance(preprocessing_input_types, dict)
+    assert preprocessing_input_types["input0"] == "image"
     assert len(warnings) == 1
     assert "test embedding failure" in warnings[0]
     assert "Falling back to NN Archive preprocessing" in warnings[0]

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -410,19 +410,12 @@ def test_conversion_does_not_fallback_for_nonrecoverable_errors(
     "input_options",
     [
         {
-            "shape": [1, 3, 64, 64],
             "encoding": "NONE",
             "mean_values": [1, 2],
         },
         {
-            "shape": [1, 3, 64, 64],
             "encoding": "BGR",
             "mean_values": [0, 0],
-        },
-        {
-            "shape": [1, 2, 64, 64],
-            "encoding": "RGB",
-            "mean_values": [1, 2],
         },
     ],
 )
@@ -436,6 +429,7 @@ def test_invalid_preprocessing_is_rejected_before_fallback(
         None,
         {
             "input_model": str(dummy_onnx),
+            "shape": [1, 3, 64, 64],
             **input_options,
         },
     )

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -391,18 +391,37 @@ def test_conversion_does_not_fallback_for_nonrecoverable_errors(
     assert stage.inputs[0].mean_values == [1.0, 2.0, 3.0]
 
 
+@pytest.mark.parametrize(
+    "input_options",
+    [
+        {
+            "shape": [1, 3, 64, 64],
+            "encoding": "NONE",
+            "mean_values": [1, 2],
+        },
+        {
+            "shape": [1, 3, 64, 64],
+            "encoding": "BGR",
+            "mean_values": [0, 0],
+        },
+        {
+            "shape": [1, 2, 64, 64],
+            "encoding": "RGB",
+            "mean_values": [1, 2],
+        },
+    ],
+)
 def test_invalid_preprocessing_is_rejected_before_fallback(
     dummy_onnx: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    input_options: dict[str, object],
 ) -> None:
     cfg = Config.get_config(
         None,
         {
             "input_model": str(dummy_onnx),
-            "shape": [1, 3, 64, 64],
-            "encoding": "NONE",
-            "mean_values": [1, 2],
+            **input_options,
         },
     )
     exporter_was_created = False

--- a/tests/unit/test_inferer_from_config.py
+++ b/tests/unit/test_inferer_from_config.py
@@ -15,6 +15,7 @@ import pytest
 from luxonis_ml.typing import ParamValue
 
 from modelconverter.platforms.base_inferer import Inferer
+from modelconverter.platforms.rvc4.inferer import RVC4Inferer
 from modelconverter.utils.config import Config
 from modelconverter.utils.types import Encoding, ResizeMethod
 from tests.helpers.onnx_factory import single_io_onnx
@@ -99,6 +100,21 @@ def test_shapes_and_dtypes_are_mapped(work_dir: Path):
     inferer = _build(work_dir, [1, 3, 64, 64])
     assert inferer.in_shapes == {"input0": [1, 3, 64, 64]}
     assert inferer.out_shapes == {"output0": [1, 10]}
+
+
+def test_rvc4_output_layouts_are_cached_during_setup(work_dir: Path):
+    model = single_io_onnx(
+        work_dir / "rvc4.onnx",
+        output_shape=[1, 8, 8, 3],
+    ).resolve()
+    config = Config.get_config(None, {"input_model": str(model)})
+    stage = next(iter(config.stages.values()))
+
+    inferer = RVC4Inferer.from_config(
+        str(model), work_dir / "src", work_dir / "rvc4-dest", stage
+    )
+
+    assert inferer._output_layouts == {"output0": "NHWC"}
 
 
 def test_the_stand_in_reports_no_outputs(work_dir: Path):

--- a/tests/unit/test_layout.py
+++ b/tests/unit/test_layout.py
@@ -13,7 +13,11 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from modelconverter.utils.layout import guess_new_layout, make_default_layout
+from modelconverter.utils.layout import (
+    guess_new_layout,
+    is_image_input_shape,
+    make_default_layout,
+)
 from tests.helpers.strategies import shape_permutations, shapes
 
 
@@ -36,6 +40,24 @@ def test_no_leading_one():
     layout = make_default_layout([3, 4, 5])
     assert len(layout) == 3
     assert "N" not in layout
+
+
+@pytest.mark.parametrize(
+    ("shape", "layout", "expected"),
+    [
+        ([1, 3, 224, 224], "NCHW", True),
+        ([1, 224, 224, 3], "NHWC", True),
+        ([1, 1, 224, 224], "NCHW", True),
+        ([1, 0, 224, 224], "NCHW", True),
+        ([1, 4, 224, 224], "NCHW", False),
+        ([1, 512], "NC", False),
+        ([1, 3, 8400], "NCD", False),
+        ([224, 224, 3], "HWC", False),
+        ([1, 3, 224, 224], "NHWC", False),
+    ],
+)
+def test_image_input_shape(shape: list[int], layout: str, expected: bool):
+    assert is_image_input_shape(shape, layout) is expected
 
 
 def test_letter_collision_loop():

--- a/tests/unit/test_layout.py
+++ b/tests/unit/test_layout.py
@@ -21,6 +21,7 @@ from tests.helpers.strategies import shape_permutations, shapes
     ("shape", "expected"),
     [
         ([1, 3, 256, 256], "NCHW"),
+        ([0, 3, 256, 256], "NCHW"),
         ([1, 256, 256, 3], "NHWC"),
         # Leading 1 -> "N", remaining three dims are not min-channel
         # patterns, so the alphabet fallback (starting at "C") kicks in.
@@ -77,6 +78,11 @@ def test_every_dimension_gets_a_distinct_letter(shape: list[int]):
 @given(rest=shapes(max_rank=15))
 def test_leading_one_is_the_batch_dimension(rest: list[int]):
     assert make_default_layout([1, *rest]).startswith("N")
+
+
+@given(rest=shapes(max_rank=15))
+def test_leading_zero_is_the_batch_dimension(rest: list[int]):
+    assert make_default_layout([0, *rest]).startswith("N")
 
 
 @given(shape_and_permutation=shape_permutations())

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -795,6 +795,42 @@ def test_externalized_image_preprocessing_keeps_image_input_type(
     assert in0.preprocessing.dai_type == "BGR888p"
 
 
+def test_externalized_image_preprocessing_uses_converted_layout(
+    tmp_path: Path,
+):
+    source = single_io_onnx(tmp_path / "source.onnx", shape=[1, 3, 8, 8])
+    converted = single_io_onnx(tmp_path / "converted.onnx", shape=[1, 8, 8, 3])
+    config = Config.get_config(
+        None,
+        {
+            "input_model": str(source),
+            "encoding": {"from": "RGB", "to": "BGR"},
+            "mean_values": [1, 2, 3],
+            "scale_values": [4, 5, 6],
+        },
+    )
+    stage = next(iter(config.stages.values()))
+    input_types = {
+        inp.name: "raw" if inp.is_raw_input else "image"
+        for inp in stage.inputs
+    }
+    config, preprocessing = extract_preprocessing(config)
+
+    nn = _config_to_nn(
+        config,
+        converted,
+        preprocessing=preprocessing,
+        preprocessing_input_types=input_types,
+    )
+
+    inp = nn.model.inputs[0]
+    assert inp.layout == "NHWC"
+    assert inp.preprocessing.mean == [1, 2, 3]
+    assert inp.preprocessing.scale == [4, 5, 6]
+    assert inp.preprocessing.dai_type == "RGB888i"
+    assert inp.preprocessing.model_dump()["interleaved_to_planar"] is True
+
+
 def test_iop_input_and_output(dummy_onnx: Path):
     metadata = get_metadata(dummy_onnx)
     cfg = RVC2Config(

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -669,36 +669,11 @@ def test_raw_input_default_type_without_orig(dummy_onnx: Path):
     assert in0.preprocessing.dai_type is None
 
 
-def test_embedded_raw_input_preprocessing_is_identity(dummy_onnx: Path):
-    # The original raw preprocessing has already been represented in the
-    # successfully converted model and must not be applied twice.
-    config = Config.get_config(
-        None,
-        {
-            "input_model": str(dummy_onnx),
-            "inputs.0.name": "input0",
-            "inputs.0.encoding": "NONE",
-            "inputs.1.name": "input1",
-        },
-    )
-    orig = archive_from_model(dummy_onnx)
-    orig.model.inputs[0].input_type = InputType.RAW
-    orig.model.inputs[0].preprocessing = PreprocessingBlock(
-        mean=[9, 9, 9],
-        scale=None,
-        reverse_channels=None,
-        interleaved_to_planar=None,
-        dai_type=None,
-    )
-    nn = _config_to_nn(config, dummy_onnx, orig=orig)
-    in0 = next(i for i in nn.model.inputs if i.name == "input0")
-    assert in0.input_type == InputType.RAW
-    assert in0.preprocessing.mean is None
-
-
 def test_embedded_raw_preprocessing_is_identity_in_archive(
     dummy_onnx: Path,
 ):
+    # Original raw preprocessing is already represented in the converted
+    # model and must not be applied twice by the output archive.
     config = Config.get_config(
         None,
         {
@@ -938,18 +913,12 @@ def test_image_float16_interleaved_with_mean_scale():
     assert block["scale"] == [1, 1, 1]
 
 
-@pytest.mark.parametrize(
-    ("data_type", "expected_dai_type"),
-    [("float32", "GRAY8"), ("float16", "GRAYF16")],
-)
-def test_grayscale_image_uses_valid_dai_type(
-    data_type: str, expected_dai_type: str
-):
+def test_grayscale_image_uses_valid_dai_type():
     inp = _input_config(
         name="x",
         shape=[1, 1, 64, 64],
         layout="NCHW",
-        data_type=data_type,
+        data_type="float32",
         encoding="GRAY",
         mean_values=[2],
         scale_values=[3],
@@ -957,21 +926,9 @@ def test_grayscale_image_uses_valid_dai_type(
 
     block = _default_archive_preprocessing(inp, "NCHW", input_type="image")
 
-    assert block["dai_type"] == expected_dai_type
+    assert block["dai_type"] == "GRAY8"
     assert block["mean"] == [0]
     assert block["scale"] == [1]
-
-
-def test_image_preprocessing_rejects_nonstandard_channel_count():
-    inp = _input_config(
-        name="x",
-        shape=[1, 2, 64, 64],
-        layout="NCHW",
-        encoding="RGB",
-    )
-
-    with pytest.raises(ValueError, match="cannot use RGB/BGR encoding"):
-        _default_archive_preprocessing(inp, "NCHW", input_type="image")
 
 
 def test_image_uint8_planar_without_mean_scale():

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -750,7 +750,7 @@ def test_externalized_image_preprocessing_keeps_image_input_type(
         },
     )
     stage = next(iter(config.stages.values()))
-    input_types = {
+    input_types: dict[str, Literal["raw", "image"]] = {
         inp.name: "raw" if inp.is_raw_input else "image"
         for inp in stage.inputs
     }
@@ -785,7 +785,7 @@ def test_externalized_image_preprocessing_uses_converted_layout(
         },
     )
     stage = next(iter(config.stages.values()))
-    input_types = {
+    input_types: dict[str, Literal["raw", "image"]] = {
         inp.name: "raw" if inp.is_raw_input else "image"
         for inp in stage.inputs
     }

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -8,6 +8,7 @@ No network, cloud, Docker or vendor tooling: the dummy ONNX models and NN-archiv
 import shutil
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Literal
 
 import pytest
 from luxonis_ml.nn_archive.config import Config as NNArchiveConfig
@@ -19,6 +20,7 @@ from luxonis_ml.nn_archive.config_building_blocks import (
 )
 from luxonis_ml.typing import Params, ParamValue
 
+from modelconverter.cli.utils import extract_preprocessing
 from modelconverter.utils.config import (
     Config,
     InputConfig,
@@ -418,6 +420,8 @@ def _config_to_nn(
     preprocessing: dict[str, PreprocessingBlock] | None = None,
     main_stage: str | None = None,
     platform: Platform = Platform.RVC4,
+    preprocessing_input_types: dict[str, Literal["raw", "image"]]
+    | None = None,
 ) -> NNArchiveConfig:
     """``modelconverter_config_to_nn`` with the fixed test boilerplate (output
     name + model path) filled in, exposing only what tests vary.
@@ -430,6 +434,7 @@ def _config_to_nn(
         main_stage if main_stage is not None else next(iter(config.stages)),
         dummy_onnx,
         platform,
+        preprocessing_input_types=preprocessing_input_types,
     )
 
 
@@ -753,6 +758,41 @@ def test_externalized_raw_preprocessing_is_kept_in_archive(
     in0 = next(i for i in nn.model.inputs if i.name == "input0")
     assert in0.preprocessing.mean == [9, 9, 9]
     assert in0.preprocessing.scale == [2, 2, 2]
+
+
+def test_externalized_image_preprocessing_keeps_image_input_type(
+    dummy_onnx: Path,
+):
+    config = Config.get_config(
+        None,
+        {
+            "input_model": str(dummy_onnx),
+            "inputs.0.name": "input0",
+            "inputs.0.encoding": "BGR",
+            "inputs.0.mean_values": [1, 2, 3],
+            "inputs.0.scale_values": [4, 5, 6],
+            "inputs.1.name": "input1",
+        },
+    )
+    stage = next(iter(config.stages.values()))
+    input_types = {
+        inp.name: "raw" if inp.is_raw_input else "image"
+        for inp in stage.inputs
+    }
+    config, preprocessing = extract_preprocessing(config)
+
+    nn = _config_to_nn(
+        config,
+        dummy_onnx,
+        preprocessing=preprocessing,
+        preprocessing_input_types=input_types,
+    )
+
+    in0 = next(i for i in nn.model.inputs if i.name == "input0")
+    assert in0.input_type == InputType.IMAGE
+    assert in0.preprocessing.mean == [1, 2, 3]
+    assert in0.preprocessing.scale == [4, 5, 6]
+    assert in0.preprocessing.dai_type == "BGR888p"
 
 
 def test_iop_input_and_output(dummy_onnx: Path):

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -37,10 +37,11 @@ from modelconverter.utils.nn_archive import (
     find_archive_input,
     generate_archive,
     get_archive_input,
+    make_dai_type,
     modelconverter_config_to_nn,
     process_nn_archive,
 )
-from modelconverter.utils.types import DataType, Platform
+from modelconverter.utils.types import DataType, Encoding, Platform
 from tests.helpers.archive_factory import (
     default_archive_config,
     pack_archive,
@@ -804,6 +805,32 @@ def test_externalized_image_preprocessing_uses_converted_layout(
     assert inp.preprocessing.scale == [4, 5, 6]
     assert inp.preprocessing.dai_type == "RGB888i"
     assert inp.preprocessing.model_dump()["interleaved_to_planar"] is True
+
+
+def test_archive_image_overridden_with_none_encoding_becomes_raw(
+    dummy_onnx: Path,
+):
+    config = Config.get_config(
+        None,
+        {
+            "input_model": str(dummy_onnx),
+            "inputs.0.name": "input0",
+            "inputs.0.encoding": "NONE",
+            "inputs.1.name": "input1",
+        },
+    )
+    orig = archive_from_model(dummy_onnx)
+
+    nn = _config_to_nn(config, dummy_onnx, orig=orig)
+
+    inp = next(inp for inp in nn.model.inputs if inp.name == "input0")
+    assert inp.input_type == InputType.RAW
+    assert inp.preprocessing.dai_type is None
+
+
+def test_make_dai_type_rejects_none_encoding():
+    with pytest.raises(ValueError, match=r"Encoding\.NONE"):
+        make_dai_type(Encoding.NONE, DataType.FLOAT32, "NCHW")
 
 
 def test_iop_input_and_output(dummy_onnx: Path):

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -1000,6 +1000,48 @@ def test_builds_config_from_onnx(dummy_onnx: Path):
     assert archive.model.metadata.name == "dummy_model"
 
 
+@pytest.mark.parametrize(
+    ("shape", "expected_type"),
+    [
+        ([1, 3, 64, 64], InputType.IMAGE),
+        ([1, 1, 64, 64], InputType.IMAGE),
+        ([1, 4, 64, 64], InputType.RAW),
+        ([1, 512], InputType.RAW),
+        ([1, 3, 8400], InputType.RAW),
+    ],
+)
+def test_archive_from_model_infers_input_type(
+    tmp_path: Path, shape: list[int], expected_type: InputType
+):
+    model = single_io_onnx(
+        tmp_path / "model.onnx", shape=shape, output_shape=shape
+    )
+
+    archive = archive_from_model(model)
+
+    assert archive.model.inputs[0].input_type == expected_type
+
+
+def test_bare_archive_raw_input_roundtrip(work_dir: Path):
+    model = single_io_onnx(
+        work_dir / "rgba.onnx",
+        shape=[1, 4, 64, 64],
+        output_shape=[1, 4, 64, 64],
+    )
+    archive = archive_from_model(model)
+    tar = pack_archive(
+        work_dir / "rgba.tar",
+        model,
+        archive.model_dump(mode="json"),
+    )
+
+    config, _, main_stage = process_nn_archive(Platform.RVC4, tar, None)
+    inp = config.stages[main_stage].inputs[0]
+
+    assert inp.is_raw_input
+    inp.validate_input_contract()
+
+
 def test_get_archive_input_found(dummy_onnx: Path):
     archive = archive_from_model(dummy_onnx)
     assert get_archive_input(archive, "input1").name == "input1"

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -887,7 +887,7 @@ def test_raw_input_preprocessing_is_all_none():
 def test_image_float16_interleaved_with_mean_scale():
     inp = _input_config(
         name="x",
-        shape=[1, 3, 64, 64],
+        shape=[1, 64, 64, 3],
         layout="NHWC",
         data_type="float16",
         encoding={"from": "RGB", "to": "RGB"},
@@ -900,6 +900,18 @@ def test_image_float16_interleaved_with_mean_scale():
     assert block["interleaved_to_planar"] is True
     assert block["mean"] == [0, 0, 0]
     assert block["scale"] == [1, 1, 1]
+
+
+def test_image_preprocessing_rejects_nonstandard_channel_count():
+    inp = _input_config(
+        name="x",
+        shape=[1, 2, 64, 64],
+        layout="NCHW",
+        encoding="RGB",
+    )
+
+    with pytest.raises(ValueError, match="cannot use RGB/BGR encoding"):
+        _default_archive_preprocessing(inp, "NCHW", input_type="image")
 
 
 def test_image_uint8_planar_without_mean_scale():

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -902,6 +902,30 @@ def test_image_float16_interleaved_with_mean_scale():
     assert block["scale"] == [1, 1, 1]
 
 
+@pytest.mark.parametrize(
+    ("data_type", "expected_dai_type"),
+    [("float32", "GRAY8"), ("float16", "GRAYF16")],
+)
+def test_grayscale_image_uses_valid_dai_type(
+    data_type: str, expected_dai_type: str
+):
+    inp = _input_config(
+        name="x",
+        shape=[1, 1, 64, 64],
+        layout="NCHW",
+        data_type=data_type,
+        encoding="GRAY",
+        mean_values=[2],
+        scale_values=[3],
+    )
+
+    block = _default_archive_preprocessing(inp, "NCHW", input_type="image")
+
+    assert block["dai_type"] == expected_dai_type
+    assert block["mean"] == [0]
+    assert block["scale"] == [1]
+
+
 def test_image_preprocessing_rejects_nonstandard_channel_count():
     inp = _input_config(
         name="x",

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -664,9 +664,9 @@ def test_raw_input_default_type_without_orig(dummy_onnx: Path):
     assert in0.preprocessing.dai_type is None
 
 
-def test_raw_input_preprocessing_preserved_from_orig(dummy_onnx: Path):
-    # input0 as raw in the config; orig archive carries a raw input whose
-    # preprocessing block must be preserved verbatim.
+def test_embedded_raw_input_preprocessing_is_identity(dummy_onnx: Path):
+    # The original raw preprocessing has already been represented in the
+    # successfully converted model and must not be applied twice.
     config = Config.get_config(
         None,
         {
@@ -688,7 +688,71 @@ def test_raw_input_preprocessing_preserved_from_orig(dummy_onnx: Path):
     nn = _config_to_nn(config, dummy_onnx, orig=orig)
     in0 = next(i for i in nn.model.inputs if i.name == "input0")
     assert in0.input_type == InputType.RAW
+    assert in0.preprocessing.mean is None
+
+
+def test_embedded_raw_preprocessing_is_identity_in_archive(
+    dummy_onnx: Path,
+):
+    config = Config.get_config(
+        None,
+        {
+            "input_model": str(dummy_onnx),
+            "inputs.0.name": "input0",
+            "inputs.0.encoding": "NONE",
+            "inputs.0.mean_values": [9, 9, 9],
+            "inputs.1.name": "input1",
+        },
+    )
+    orig = archive_from_model(dummy_onnx)
+    orig.model.inputs[0].input_type = InputType.RAW
+    orig.model.inputs[0].preprocessing = PreprocessingBlock(
+        mean=[9, 9, 9],
+        scale=[2, 2, 2],
+        reverse_channels=None,
+        interleaved_to_planar=None,
+        dai_type=None,
+    )
+
+    nn = _config_to_nn(config, dummy_onnx, orig=orig)
+
+    in0 = next(i for i in nn.model.inputs if i.name == "input0")
+    assert in0.input_type == InputType.RAW
+    assert in0.preprocessing.mean is None
+    assert in0.preprocessing.scale is None
+
+
+def test_externalized_raw_preprocessing_is_kept_in_archive(
+    dummy_onnx: Path,
+):
+    config = Config.get_config(
+        None,
+        {
+            "input_model": str(dummy_onnx),
+            "inputs.0.name": "input0",
+            "inputs.0.encoding": "NONE",
+            "inputs.1.name": "input1",
+        },
+    )
+    orig = archive_from_model(dummy_onnx)
+    orig.model.inputs[0].input_type = InputType.RAW
+    preprocessing = {
+        "input0": PreprocessingBlock(
+            mean=[9, 9, 9],
+            scale=[2, 2, 2],
+            reverse_channels=None,
+            interleaved_to_planar=None,
+            dai_type=None,
+        )
+    }
+
+    nn = _config_to_nn(
+        config, dummy_onnx, orig=orig, preprocessing=preprocessing
+    )
+
+    in0 = next(i for i in nn.model.inputs if i.name == "input0")
     assert in0.preprocessing.mean == [9, 9, 9]
+    assert in0.preprocessing.scale == [2, 2, 2]
 
 
 def test_iop_input_and_output(dummy_onnx: Path):

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -940,6 +940,22 @@ def test_image_float16_interleaved_with_mean_scale():
     assert block["scale"] == [1, 1, 1]
 
 
+def test_scalar_preprocessing_produces_per_channel_identity_values():
+    inp = _input_config(
+        name="x",
+        shape=[1, 3, 64, 64],
+        layout="NCHW",
+        encoding="RGB",
+        mean_values=[2],
+        scale_values=[3],
+    )
+
+    block = _default_archive_preprocessing(inp, "NCHW", input_type="image")
+
+    assert block["mean"] == [0, 0, 0]
+    assert block["scale"] == [1, 1, 1]
+
+
 def test_grayscale_image_uses_valid_dai_type():
     inp = _input_config(
         name="x",

--- a/tests/unit/test_nn_archive.py
+++ b/tests/unit/test_nn_archive.py
@@ -34,7 +34,6 @@ from modelconverter.utils.nn_archive import (
     _default_archive_preprocessing,
     _get_io_dtype,
     archive_from_model,
-    find_archive_input,
     generate_archive,
     get_archive_input,
     make_dai_type,
@@ -1010,18 +1009,6 @@ def test_get_archive_input_missing_raises(dummy_onnx: Path):
     archive = archive_from_model(dummy_onnx)
     with pytest.raises(ValueError, match="not found"):
         get_archive_input(archive, "nope")
-
-
-def test_find_archive_input_none_cfg():
-    assert find_archive_input(None, "input0") is None
-
-
-def test_find_archive_input_found_and_missing(dummy_onnx: Path):
-    archive = archive_from_model(dummy_onnx)
-    found_input = find_archive_input(archive, "input0")
-    assert found_input is not None
-    assert found_input.name == "input0"
-    assert find_archive_input(archive, "nope") is None
 
 
 def _prepare_output(name: str) -> Path:

--- a/tests/unit/test_onnx_tools.py
+++ b/tests/unit/test_onnx_tools.py
@@ -12,7 +12,7 @@ import onnxruntime as ort
 import pytest
 from onnx import TensorProto, helper
 
-from modelconverter.utils.config import InputConfig
+from modelconverter.utils.config import EncodingConfig, InputConfig
 from modelconverter.utils.exceptions import (
     ONNXException,
     PreprocessingEmbeddingError,
@@ -21,6 +21,7 @@ from modelconverter.utils.onnx_tools import (
     ONNXModifier,
     onnx_attach_normalization_to_inputs,
 )
+from modelconverter.utils.types import Encoding
 from tests.helpers.onnx_factory import single_io_onnx, split_concat_onnx
 
 
@@ -69,7 +70,9 @@ def test_two_channel_normalization_is_embedded_and_numerically_correct(
         name="input0",
         shape=shape,
         layout=layout,
-        encoding="NONE",
+        encoding=EncodingConfig.model_validate(
+            {"from": Encoding.NONE, "to": Encoding.NONE}
+        ),
         mean_values=[10.0, 20.0],
         scale_values=[2.0, 4.0],
     )
@@ -87,7 +90,7 @@ def test_two_channel_normalization_is_embedded_and_numerically_correct(
         [2.0, 4.0]
     ).reshape(values_shape)
     actual = ort.InferenceSession(str(modified)).run(None, {"input0": x})[0]
-    np.testing.assert_allclose(actual, expected)
+    np.testing.assert_allclose(np.asarray(actual), expected)
 
 
 def test_scalar_normalization_broadcasts_to_every_channel(tmp_path: Path):
@@ -99,9 +102,11 @@ def test_scalar_normalization_broadcasts_to_every_channel(tmp_path: Path):
         name="input0",
         shape=shape,
         layout="NCHW",
-        encoding="NONE",
-        mean_values=3.0,
-        scale_values=2.0,
+        encoding=EncodingConfig.model_validate(
+            {"from": Encoding.NONE, "to": Encoding.NONE}
+        ),
+        mean_values=[3.0],
+        scale_values=[2.0],
     )
 
     modified = onnx_attach_normalization_to_inputs(
@@ -112,7 +117,7 @@ def test_scalar_normalization_broadcasts_to_every_channel(tmp_path: Path):
 
     x = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
     actual = ort.InferenceSession(str(modified)).run(None, {"input0": x})[0]
-    np.testing.assert_allclose(actual, (x - 3.0) / 2.0)
+    np.testing.assert_allclose(np.asarray(actual), (x - 3.0) / 2.0)
 
 
 def test_invalid_normalization_is_reported_as_onnx_error(tmp_path: Path):
@@ -124,7 +129,9 @@ def test_invalid_normalization_is_reported_as_onnx_error(tmp_path: Path):
         name="input0",
         shape=shape,
         layout="NCHW",
-        encoding="NONE",
+        encoding=EncodingConfig.model_validate(
+            {"from": Encoding.NONE, "to": Encoding.NONE}
+        ),
         mean_values=[1.0, 2.0, 3.0],
     )
 
@@ -145,7 +152,9 @@ def test_unsupported_layout_with_preprocessing_fails(tmp_path: Path):
         name="input0",
         shape=shape,
         layout="NC",
-        encoding="NONE",
+        encoding=EncodingConfig.model_validate(
+            {"from": Encoding.NONE, "to": Encoding.NONE}
+        ),
         mean_values=[1.0, 2.0],
     )
 
@@ -180,7 +189,9 @@ def test_input_exposed_directly_as_output_is_unembeddable(tmp_path: Path):
         name="input0",
         shape=shape,
         layout="NCHW",
-        encoding="NONE",
+        encoding=EncodingConfig.model_validate(
+            {"from": Encoding.NONE, "to": Encoding.NONE}
+        ),
         mean_values=[1.0, 2.0],
     )
 
@@ -205,7 +216,9 @@ def test_color_normalization_is_correct_without_mutating_config(
         name="input0",
         shape=shape,
         layout="NCHW",
-        encoding={"from": "RGB", "to": "BGR"},
+        encoding=EncodingConfig.model_validate(
+            {"from": Encoding.RGB, "to": Encoding.BGR}
+        ),
         mean_values=[1.0, 2.0, 3.0],
         scale_values=[4.0, 5.0, 6.0],
     )
@@ -226,7 +239,7 @@ def test_color_normalization_is_correct_without_mutating_config(
         rgb - np.array([1.0, 2.0, 3.0]).reshape(1, 3, 1, 1)
     ) / np.array([4.0, 5.0, 6.0]).reshape(1, 3, 1, 1)
     actual = ort.InferenceSession(str(modified)).run(None, {"input0": bgr})[0]
-    np.testing.assert_allclose(actual, expected)
+    np.testing.assert_allclose(np.asarray(actual), expected)
 
 
 def test_integer_mean_scale_normalization_is_unembeddable(tmp_path: Path):
@@ -241,7 +254,9 @@ def test_integer_mean_scale_normalization_is_unembeddable(tmp_path: Path):
         name="input0",
         shape=shape,
         layout="NCHW",
-        encoding="NONE",
+        encoding=EncodingConfig.model_validate(
+            {"from": Encoding.NONE, "to": Encoding.NONE}
+        ),
         mean_values=[10.0, 20.0],
         scale_values=[2.0, 4.0],
     )
@@ -269,7 +284,9 @@ def test_integer_channel_reversal_remains_supported(tmp_path: Path):
         name="input0",
         shape=shape,
         layout="NCHW",
-        encoding={"from": "RGB", "to": "BGR"},
+        encoding=EncodingConfig.model_validate(
+            {"from": Encoding.RGB, "to": Encoding.BGR}
+        ),
     )
 
     modified = onnx_attach_normalization_to_inputs(
@@ -280,4 +297,4 @@ def test_integer_channel_reversal_remains_supported(tmp_path: Path):
 
     bgr = np.arange(np.prod(shape), dtype=np.uint8).reshape(shape)
     actual = ort.InferenceSession(str(modified)).run(None, {"input0": bgr})[0]
-    np.testing.assert_array_equal(actual, bgr[:, ::-1, :, :])
+    np.testing.assert_array_equal(np.asarray(actual), bgr[:, ::-1, :, :])

--- a/tests/unit/test_onnx_tools.py
+++ b/tests/unit/test_onnx_tools.py
@@ -1,14 +1,23 @@
 """Host-side unit tests for the ONNX graph rewrites.
 
-Only the Split-Concat fusion is covered here. The rest of the rewrites
-need real models to say anything useful, so the conversion tests carry
-them.
+The normalization tests use tiny identity models so graph structure and
+numerical behavior can both be checked without a vendor toolchain.
 """
 
 from pathlib import Path
 
-from modelconverter.utils.onnx_tools import ONNXModifier
-from tests.helpers.onnx_factory import split_concat_onnx
+import numpy as np
+import onnx
+import onnxruntime as ort
+import pytest
+
+from modelconverter.utils.config import InputConfig
+from modelconverter.utils.exceptions import ONNXException
+from modelconverter.utils.onnx_tools import (
+    ONNXModifier,
+    onnx_attach_normalization_to_inputs,
+)
+from tests.helpers.onnx_factory import single_io_onnx, split_concat_onnx
 
 
 def test_split_concat_fusion_leaves_a_terminal_concat_alone(tmp_path: Path):
@@ -32,3 +41,157 @@ def test_split_concat_fusion_leaves_a_terminal_concat_alone(tmp_path: Path):
         "Split",
         "Concat",
     ]
+
+
+@pytest.mark.parametrize(
+    ("shape", "layout", "values_shape"),
+    [
+        ([1, 2, 3, 4], "NCHW", (1, 2, 1, 1)),
+        ([1, 3, 4, 2], "NHWC", (1, 1, 1, 2)),
+    ],
+)
+def test_two_channel_normalization_is_embedded_and_numerically_correct(
+    tmp_path: Path,
+    shape: list[int],
+    layout: str,
+    values_shape: tuple[int, ...],
+):
+    model_path = single_io_onnx(
+        tmp_path / f"{layout}.onnx",
+        shape=shape,
+        output_shape=shape,
+    )
+    config = InputConfig(
+        name="input0",
+        shape=shape,
+        layout=layout,
+        encoding="NONE",
+        mean_values=[10.0, 20.0],
+        scale_values=[2.0, 4.0],
+    )
+
+    modified = onnx_attach_normalization_to_inputs(
+        model_path,
+        tmp_path / f"{layout}-modified.onnx",
+        {"input0": config},
+    )
+
+    graph = onnx.load(modified).graph
+    assert [node.op_type for node in graph.node[:2]] == ["Sub", "Mul"]
+    x = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+    expected = (x - np.array([10.0, 20.0]).reshape(values_shape)) / np.array(
+        [2.0, 4.0]
+    ).reshape(values_shape)
+    actual = ort.InferenceSession(str(modified)).run(None, {"input0": x})[0]
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_scalar_normalization_broadcasts_to_every_channel(tmp_path: Path):
+    shape = [1, 2, 3, 4]
+    model_path = single_io_onnx(
+        tmp_path / "scalar.onnx", shape=shape, output_shape=shape
+    )
+    config = InputConfig(
+        name="input0",
+        shape=shape,
+        layout="NCHW",
+        encoding="NONE",
+        mean_values=3.0,
+        scale_values=2.0,
+    )
+
+    modified = onnx_attach_normalization_to_inputs(
+        model_path,
+        tmp_path / "scalar-modified.onnx",
+        {"input0": config},
+    )
+
+    x = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+    actual = ort.InferenceSession(str(modified)).run(None, {"input0": x})[0]
+    np.testing.assert_allclose(actual, (x - 3.0) / 2.0)
+
+
+def test_invalid_normalization_value_count_fails(tmp_path: Path):
+    shape = [1, 2, 3, 4]
+    model_path = single_io_onnx(
+        tmp_path / "count.onnx", shape=shape, output_shape=shape
+    )
+    config = InputConfig(
+        name="input0",
+        shape=shape,
+        layout="NCHW",
+        encoding="NONE",
+        mean_values=[1.0, 2.0, 3.0],
+    )
+
+    with pytest.raises(ONNXException, match="one value per channel"):
+        onnx_attach_normalization_to_inputs(
+            model_path,
+            tmp_path / "count-modified.onnx",
+            {"input0": config},
+        )
+
+
+def test_non_three_channel_color_reversal_fails(tmp_path: Path):
+    shape = [1, 2, 3, 4]
+    model_path = single_io_onnx(
+        tmp_path / "reverse.onnx", shape=shape, output_shape=shape
+    )
+    config = InputConfig(
+        name="input0",
+        shape=shape,
+        layout="NCHW",
+        encoding={"from": "RGB", "to": "BGR"},
+    )
+
+    with pytest.raises(ONNXException, match="requires exactly 3 channels"):
+        onnx_attach_normalization_to_inputs(
+            model_path,
+            tmp_path / "reverse-modified.onnx",
+            {"input0": config},
+        )
+
+
+def test_unsupported_layout_with_preprocessing_fails(tmp_path: Path):
+    shape = [1, 2]
+    model_path = single_io_onnx(
+        tmp_path / "layout.onnx", shape=shape, output_shape=shape
+    )
+    config = InputConfig(
+        name="input0",
+        shape=shape,
+        layout="NC",
+        encoding="NONE",
+        mean_values=[1.0, 2.0],
+    )
+
+    with pytest.raises(ONNXException, match="only 'NCHW' and 'NHWC'"):
+        onnx_attach_normalization_to_inputs(
+            model_path,
+            tmp_path / "layout-modified.onnx",
+            {"input0": config},
+        )
+
+
+def test_color_reversal_does_not_mutate_input_config(tmp_path: Path):
+    shape = [1, 3, 3, 4]
+    model_path = single_io_onnx(
+        tmp_path / "color.onnx", shape=shape, output_shape=shape
+    )
+    config = InputConfig(
+        name="input0",
+        shape=shape,
+        layout="NCHW",
+        encoding={"from": "RGB", "to": "BGR"},
+        mean_values=[1.0, 2.0, 3.0],
+        scale_values=[4.0, 5.0, 6.0],
+    )
+    original = config.model_dump()
+
+    onnx_attach_normalization_to_inputs(
+        model_path,
+        tmp_path / "color-modified.onnx",
+        {"input0": config},
+    )
+
+    assert config.model_dump() == original

--- a/tests/unit/test_onnx_tools.py
+++ b/tests/unit/test_onnx_tools.py
@@ -115,10 +115,10 @@ def test_scalar_normalization_broadcasts_to_every_channel(tmp_path: Path):
     np.testing.assert_allclose(actual, (x - 3.0) / 2.0)
 
 
-def test_invalid_normalization_value_count_fails(tmp_path: Path):
+def test_invalid_normalization_is_reported_as_onnx_error(tmp_path: Path):
     shape = [1, 2, 3, 4]
     model_path = single_io_onnx(
-        tmp_path / "count.onnx", shape=shape, output_shape=shape
+        tmp_path / "invalid.onnx", shape=shape, output_shape=shape
     )
     config = InputConfig(
         name="input0",
@@ -131,27 +131,7 @@ def test_invalid_normalization_value_count_fails(tmp_path: Path):
     with pytest.raises(ONNXException, match="one value per channel"):
         onnx_attach_normalization_to_inputs(
             model_path,
-            tmp_path / "count-modified.onnx",
-            {"input0": config},
-        )
-
-
-def test_non_three_channel_color_reversal_fails(tmp_path: Path):
-    shape = [1, 2, 3, 4]
-    model_path = single_io_onnx(
-        tmp_path / "reverse.onnx", shape=shape, output_shape=shape
-    )
-    config = InputConfig(
-        name="input0",
-        shape=shape,
-        layout="NCHW",
-        encoding={"from": "RGB", "to": "BGR"},
-    )
-
-    with pytest.raises(ONNXException, match="cannot use RGB/BGR encoding"):
-        onnx_attach_normalization_to_inputs(
-            model_path,
-            tmp_path / "reverse-modified.onnx",
+            tmp_path / "invalid-modified.onnx",
             {"input0": config},
         )
 

--- a/tests/unit/test_onnx_tools.py
+++ b/tests/unit/test_onnx_tools.py
@@ -148,7 +148,7 @@ def test_non_three_channel_color_reversal_fails(tmp_path: Path):
         encoding={"from": "RGB", "to": "BGR"},
     )
 
-    with pytest.raises(ONNXException, match="requires exactly 3 channels"):
+    with pytest.raises(ONNXException, match="cannot use RGB/BGR encoding"):
         onnx_attach_normalization_to_inputs(
             model_path,
             tmp_path / "reverse-modified.onnx",

--- a/tests/unit/test_onnx_tools.py
+++ b/tests/unit/test_onnx_tools.py
@@ -10,6 +10,7 @@ import numpy as np
 import onnx
 import onnxruntime as ort
 import pytest
+from onnx import TensorProto
 
 from modelconverter.utils.config import InputConfig
 from modelconverter.utils.exceptions import (
@@ -178,7 +179,9 @@ def test_unsupported_layout_with_preprocessing_fails(tmp_path: Path):
         )
 
 
-def test_color_reversal_does_not_mutate_input_config(tmp_path: Path):
+def test_color_normalization_is_correct_without_mutating_config(
+    tmp_path: Path,
+):
     shape = [1, 3, 3, 4]
     model_path = single_io_onnx(
         tmp_path / "color.onnx", shape=shape, output_shape=shape
@@ -193,10 +196,73 @@ def test_color_reversal_does_not_mutate_input_config(tmp_path: Path):
     )
     original = config.model_dump()
 
-    onnx_attach_normalization_to_inputs(
+    modified = onnx_attach_normalization_to_inputs(
         model_path,
         tmp_path / "color-modified.onnx",
         {"input0": config},
     )
 
     assert config.model_dump() == original
+
+    bgr = np.array([30.0, 20.0, 10.0], dtype=np.float32).reshape(1, 3, 1, 1)
+    bgr = np.broadcast_to(bgr, shape).copy()
+    rgb = bgr[:, ::-1, :, :]
+    expected = (
+        rgb - np.array([1.0, 2.0, 3.0]).reshape(1, 3, 1, 1)
+    ) / np.array([4.0, 5.0, 6.0]).reshape(1, 3, 1, 1)
+    actual = ort.InferenceSession(str(modified)).run(None, {"input0": bgr})[0]
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_integer_mean_scale_normalization_is_unembeddable(tmp_path: Path):
+    shape = [1, 2, 3, 4]
+    model_path = single_io_onnx(
+        tmp_path / "uint8.onnx",
+        shape=shape,
+        output_shape=shape,
+        dtype=TensorProto.UINT8,
+    )
+    config = InputConfig(
+        name="input0",
+        shape=shape,
+        layout="NCHW",
+        encoding="NONE",
+        mean_values=[10.0, 20.0],
+        scale_values=[2.0, 4.0],
+    )
+
+    with pytest.raises(
+        PreprocessingEmbeddingError,
+        match="normalization requires a floating-point input",
+    ):
+        onnx_attach_normalization_to_inputs(
+            model_path,
+            tmp_path / "uint8-modified.onnx",
+            {"input0": config},
+        )
+
+
+def test_integer_channel_reversal_remains_supported(tmp_path: Path):
+    shape = [1, 3, 2, 2]
+    model_path = single_io_onnx(
+        tmp_path / "uint8-reverse.onnx",
+        shape=shape,
+        output_shape=shape,
+        dtype=TensorProto.UINT8,
+    )
+    config = InputConfig(
+        name="input0",
+        shape=shape,
+        layout="NCHW",
+        encoding={"from": "RGB", "to": "BGR"},
+    )
+
+    modified = onnx_attach_normalization_to_inputs(
+        model_path,
+        tmp_path / "uint8-reverse-modified.onnx",
+        {"input0": config},
+    )
+
+    bgr = np.arange(np.prod(shape), dtype=np.uint8).reshape(shape)
+    actual = ort.InferenceSession(str(modified)).run(None, {"input0": bgr})[0]
+    np.testing.assert_array_equal(actual, bgr[:, ::-1, :, :])

--- a/tests/unit/test_onnx_tools.py
+++ b/tests/unit/test_onnx_tools.py
@@ -10,7 +10,7 @@ import numpy as np
 import onnx
 import onnxruntime as ort
 import pytest
-from onnx import TensorProto
+from onnx import TensorProto, helper
 
 from modelconverter.utils.config import InputConfig
 from modelconverter.utils.exceptions import (
@@ -175,6 +175,41 @@ def test_unsupported_layout_with_preprocessing_fails(tmp_path: Path):
         onnx_attach_normalization_to_inputs(
             model_path,
             tmp_path / "layout-modified.onnx",
+            {"input0": config},
+        )
+
+
+def test_input_exposed_directly_as_output_is_unembeddable(tmp_path: Path):
+    shape = [1, 2, 1, 1]
+    input_tensor = helper.make_tensor_value_info(
+        "input0", TensorProto.FLOAT, shape
+    )
+    output_tensor = helper.make_tensor_value_info(
+        "input0", TensorProto.FLOAT, shape
+    )
+    model = helper.make_model(
+        helper.make_graph(
+            [], "direct-output", [input_tensor], [output_tensor]
+        ),
+        opset_imports=[helper.make_opsetid("", 13)],
+        ir_version=8,
+    )
+    model_path = tmp_path / "direct-output.onnx"
+    onnx.save(model, model_path)
+    config = InputConfig(
+        name="input0",
+        shape=shape,
+        layout="NCHW",
+        encoding="NONE",
+        mean_values=[1.0, 2.0],
+    )
+
+    with pytest.raises(
+        PreprocessingEmbeddingError, match="exposed directly as a graph output"
+    ):
+        onnx_attach_normalization_to_inputs(
+            model_path,
+            tmp_path / "direct-output-modified.onnx",
             {"input0": config},
         )
 

--- a/tests/unit/test_onnx_tools.py
+++ b/tests/unit/test_onnx_tools.py
@@ -12,7 +12,10 @@ import onnxruntime as ort
 import pytest
 
 from modelconverter.utils.config import InputConfig
-from modelconverter.utils.exceptions import ONNXException
+from modelconverter.utils.exceptions import (
+    ONNXException,
+    PreprocessingEmbeddingError,
+)
 from modelconverter.utils.onnx_tools import (
     ONNXModifier,
     onnx_attach_normalization_to_inputs,
@@ -165,7 +168,9 @@ def test_unsupported_layout_with_preprocessing_fails(tmp_path: Path):
         mean_values=[1.0, 2.0],
     )
 
-    with pytest.raises(ONNXException, match="only 'NCHW' and 'NHWC'"):
+    with pytest.raises(
+        PreprocessingEmbeddingError, match="only 'NCHW' and 'NHWC'"
+    ):
         onnx_attach_normalization_to_inputs(
             model_path,
             tmp_path / "layout-modified.onnx",

--- a/tests/unit/test_random_calibration.py
+++ b/tests/unit/test_random_calibration.py
@@ -21,14 +21,18 @@ from modelconverter.utils.config import InputConfig, RandomCalibrationConfig
 
 
 def _prepare(
-    tmp_path: Path, shape: list[int], layout: str | None, *, raw: bool = False
+    tmp_path: Path,
+    shape: list[int],
+    layout: str | None,
+    *,
+    encoding: str | None = None,
 ) -> list[str]:
     """Run the calibration prep for one input, returning the written suffixes."""
     data: dict = {"name": "x", "shape": shape}
     if layout is not None:
         data["layout"] = layout
-    if raw:
-        data["encoding"] = {"from": "NONE", "to": "NONE"}
+    if encoding is not None:
+        data["encoding"] = encoding
     inp = InputConfig.model_validate(data)
     inp.calibration = RandomCalibrationConfig(max_images=2)
 
@@ -42,28 +46,34 @@ def _prepare(
 
 
 @pytest.mark.parametrize(
-    ("shape", "layout", "raw", "suffix"),
+    ("shape", "layout", "encoding", "suffix"),
     [
         # 4D NCHW image: channel axis is known from the layout (the path the
         # conversion tests already cover) -> written as a `.png`.
-        ([1, 3, 8, 8], None, False, ".png"),
-        # Rank-3 tensor with a C-less layout: the channels-first heuristic
-        # (`shape[0] in {1, 3}`) transposes to HWC before the `.png` write.
-        ([3, 4, 5], "TNF", False, ".png"),
+        ([1, 3, 8, 8], None, None, ".png"),
+        # Explicit color encoding keeps the legacy channels-first image path
+        # for a rank-3 tensor with a C-less layout.
+        ([3, 4, 5], "TNF", "RGB", ".png"),
+        # Without an explicit color contract, the same nonstandard layout is
+        # treated as a raw tensor.
+        ([3, 4, 5], "TNF", None, ".npy"),
         # Rank-1 feature vector: not image-like -> raw `.npy`.
-        ([8], None, False, ".npy"),
+        ([8], None, None, ".npy"),
         # Batched (N > 1) tensor: not image-like -> raw `.npy`.
-        ([2, 3, 8, 8], None, False, ".npy"),
+        ([2, 3, 8, 8], None, None, ".npy"),
         # Raw tensors use NumPy even when their rank resembles an image.
-        ([1, 32], "NC", True, ".npy"),
+        ([1, 32], "NC", "NONE", ".npy"),
     ],
 )
 def test_random_calibration_output_format(
     tmp_path: Path,
     shape: list[int],
     layout: str | None,
-    raw: bool,
+    encoding: str | None,
     suffix: str,
 ):
     np.random.seed(0)
-    assert _prepare(tmp_path, shape, layout, raw=raw) == [suffix, suffix]
+    assert _prepare(tmp_path, shape, layout, encoding=encoding) == [
+        suffix,
+        suffix,
+    ]

--- a/tests/unit/test_rvc2_exporter.py
+++ b/tests/unit/test_rvc2_exporter.py
@@ -10,7 +10,12 @@ from modelconverter.platforms.rvc2.exporter import (
 )
 from modelconverter.platforms.rvc3.exporter import RVC3Exporter
 from modelconverter.utils import PreprocessingEmbeddingError
-from modelconverter.utils.config import Config
+from modelconverter.utils.config import (
+    Config,
+    InputConfig,
+    OutputConfig,
+    SingleStageConfig,
+)
 from modelconverter.utils.types import InputFileType
 from tests.helpers.onnx_factory import single_io_onnx
 
@@ -109,3 +114,44 @@ def test_existing_ir_with_requested_preprocessing_fails(
         PreprocessingEmbeddingError, match="existing OpenVINO IR"
     ):
         exporter.export()
+
+
+def test_ir_preprocessing_retry_preserves_unsanitized_bin_source(
+    tmp_path: Path,
+):
+    xml_path = tmp_path / "model with spaces.xml"
+    bin_path = tmp_path / "model with spaces.bin"
+    xml_path.write_text("<net/>")
+    bin_path.write_bytes(b"weights")
+    config = SingleStageConfig.model_construct(
+        input_model=xml_path,
+        input_bin=bin_path,
+        input_file_type=InputFileType.IR,
+        inputs=[
+            InputConfig(
+                name="input0",
+                shape=[1, 2, 8, 8],
+                layout="NCHW",
+                encoding="NONE",
+                mean_values=[10, 20],
+            )
+        ],
+        outputs=[OutputConfig(name="output0", shape=[1], layout="N")],
+    )
+    output_dir = tmp_path / "out-ir-retry"
+    output_dir.mkdir()
+
+    first_exporter = RVC2Exporter(config, output_dir)
+    with pytest.raises(
+        PreprocessingEmbeddingError, match="existing OpenVINO IR"
+    ):
+        first_exporter.export()
+
+    assert config.input_bin == bin_path
+    config.inputs[0].mean_values = None
+
+    RVC2Exporter(config, output_dir)
+
+    assert (
+        output_dir / "intermediate_outputs" / "model_with_spaces.bin"
+    ).read_bytes() == b"weights"

--- a/tests/unit/test_rvc2_exporter.py
+++ b/tests/unit/test_rvc2_exporter.py
@@ -1,0 +1,109 @@
+"""Host-side preprocessing tests for the OpenVINO exporters."""
+
+from pathlib import Path
+
+import pytest
+
+from modelconverter.platforms.rvc2.exporter import (
+    RVC2Exporter,
+    _broadcast_preprocessing_values,
+)
+from modelconverter.platforms.rvc3.exporter import RVC3Exporter
+from modelconverter.utils import ModelconverterException
+from modelconverter.utils.config import Config
+from modelconverter.utils.types import InputFileType
+from tests.helpers.onnx_factory import single_io_onnx
+
+
+def test_scalar_preprocessing_is_expanded_to_resolved_channels():
+    assert _broadcast_preprocessing_values([127.0], 2) == [127.0, 127.0]
+
+
+@pytest.mark.parametrize(
+    ("exporter_type", "platform_key"),
+    [(RVC2Exporter, "rvc2"), (RVC3Exporter, "rvc3")],
+)
+def test_raw_two_channel_normalization_is_forwarded_to_model_optimizer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exporter_type: type[RVC2Exporter],
+    platform_key: str,
+):
+    shape = [1, 2, 8, 8]
+    model = single_io_onnx(
+        tmp_path / f"{platform_key}.onnx",
+        shape=shape,
+        output_shape=shape,
+    ).resolve()
+    config = Config.get_config(
+        None,
+        {
+            "input_model": str(model),
+            "shape": shape,
+            "encoding": "NONE",
+            "mean_values": [10, 20],
+            "scale_values": [2, 4],
+            "onnx_simplification": False,
+            "onnx_optimizations": {
+                "fuse_add_mul_to_bn": False,
+                "fuse_comb_add_mul_to_conv": False,
+                "fuse_single_add_mul_to_conv": False,
+                "fuse_split_concat_to_conv": False,
+                "substitute_sub_with_add": False,
+                "substitute_div_with_mul": False,
+            },
+            f"{platform_key}.disable_calibration": True,
+        },
+    )
+    output_dir = tmp_path / f"out-{platform_key}"
+    output_dir.mkdir()
+    exporter = exporter_type(next(iter(config.stages.values())), output_dir)
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        exporter,
+        "_subprocess_run",
+        lambda command, **_kwargs: commands.append(command),
+    )
+
+    exporter._export_openvino_ir()
+
+    command = commands[0]
+    assert command[0] == "mo"
+    assert command[command.index("--mean_values") + 1] == "input0[10.0,20.0]"
+    assert command[command.index("--scale_values") + 1] == "input0[2.0,4.0]"
+
+
+@pytest.mark.parametrize(
+    ("exporter_type", "platform_key"),
+    [(RVC2Exporter, "rvc2"), (RVC3Exporter, "rvc3")],
+)
+def test_existing_ir_with_requested_preprocessing_fails(
+    tmp_path: Path,
+    exporter_type: type[RVC2Exporter],
+    platform_key: str,
+):
+    shape = [1, 2, 8, 8]
+    model = single_io_onnx(
+        tmp_path / f"{platform_key}-ir-source.onnx",
+        shape=shape,
+        output_shape=shape,
+    ).resolve()
+    config = Config.get_config(
+        None,
+        {
+            "input_model": str(model),
+            "shape": shape,
+            "encoding": "NONE",
+            "mean_values": [10, 20],
+            "onnx_simplification": False,
+            f"{platform_key}.disable_calibration": True,
+        },
+    )
+    output_dir = tmp_path / f"out-{platform_key}-ir"
+    output_dir.mkdir()
+    exporter = exporter_type(next(iter(config.stages.values())), output_dir)
+    exporter._input_file_type = InputFileType.IR
+
+    with pytest.raises(ModelconverterException, match="existing OpenVINO IR"):
+        exporter.export()

--- a/tests/unit/test_rvc2_exporter.py
+++ b/tests/unit/test_rvc2_exporter.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+from onnx import TensorProto
 
 from modelconverter.platforms.rvc2.exporter import (
     RVC2Exporter,
@@ -16,8 +17,8 @@ from modelconverter.utils.config import (
     OutputConfig,
     SingleStageConfig,
 )
-from modelconverter.utils.types import InputFileType
-from tests.helpers.onnx_factory import single_io_onnx
+from modelconverter.utils.types import Encoding, InputFileType
+from tests.helpers.onnx_factory import build_onnx, single_io_onnx
 
 
 def test_scalar_preprocessing_is_expanded_to_resolved_channels():
@@ -77,6 +78,63 @@ def test_raw_two_channel_normalization_is_forwarded_to_model_optimizer(
     assert command[0] == "mo"
     assert command[command.index("--mean_values") + 1] == "input0[10.0,20.0]"
     assert command[command.index("--scale_values") + 1] == "input0[2.0,4.0]"
+
+
+@pytest.mark.parametrize(
+    ("exporter_type", "platform_key"),
+    [(RVC2Exporter, "rvc2"), (RVC3Exporter, "rvc3")],
+)
+def test_selective_bgr_to_rgb_reversal_preserves_runtime_encoding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exporter_type: type[RVC2Exporter],
+    platform_key: str,
+):
+    shape = [1, 3, 8, 8]
+    model = build_onnx(
+        tmp_path / f"{platform_key}-mixed-reversal.onnx",
+        [
+            ("reversed", shape, TensorProto.FLOAT),
+            ("unchanged", shape, TensorProto.FLOAT),
+        ],
+        [
+            ("reversed_out", shape, TensorProto.FLOAT),
+            ("unchanged_out", shape, TensorProto.FLOAT),
+        ],
+    ).resolve()
+    config = Config.get_config(
+        None,
+        {
+            "input_model": str(model),
+            "inputs": [
+                {
+                    "name": "reversed",
+                    "layout": "NCHW",
+                    "encoding": {"from": "BGR", "to": "RGB"},
+                },
+                {
+                    "name": "unchanged",
+                    "layout": "NCHW",
+                    "encoding": "BGR",
+                },
+            ],
+            "onnx_simplification": False,
+            "onnx_optimizations": False,
+            f"{platform_key}.disable_calibration": True,
+        },
+    )
+    output_dir = tmp_path / f"out-{platform_key}-mixed-reversal"
+    output_dir.mkdir()
+    exporter = exporter_type(next(iter(config.stages.values())), output_dir)
+    monkeypatch.setattr(
+        exporter, "_subprocess_run", lambda *_args, **_kwargs: None
+    )
+
+    exporter._export_openvino_ir()
+
+    reversed_input = exporter.inputs["reversed"]
+    assert reversed_input.encoding.from_ == Encoding.RGB
+    assert reversed_input.encoding.to == Encoding.RGB
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_rvc2_exporter.py
+++ b/tests/unit/test_rvc2_exporter.py
@@ -9,7 +9,7 @@ from modelconverter.platforms.rvc2.exporter import (
     _broadcast_preprocessing_values,
 )
 from modelconverter.platforms.rvc3.exporter import RVC3Exporter
-from modelconverter.utils import ModelconverterException
+from modelconverter.utils import PreprocessingEmbeddingError
 from modelconverter.utils.config import Config
 from modelconverter.utils.types import InputFileType
 from tests.helpers.onnx_factory import single_io_onnx
@@ -105,5 +105,7 @@ def test_existing_ir_with_requested_preprocessing_fails(
     exporter = exporter_type(next(iter(config.stages.values())), output_dir)
     exporter._input_file_type = InputFileType.IR
 
-    with pytest.raises(ModelconverterException, match="existing OpenVINO IR"):
+    with pytest.raises(
+        PreprocessingEmbeddingError, match="existing OpenVINO IR"
+    ):
         exporter.export()

--- a/tests/unit/test_rvc2_exporter.py
+++ b/tests/unit/test_rvc2_exporter.py
@@ -5,10 +5,7 @@ from pathlib import Path
 import pytest
 from onnx import TensorProto
 
-from modelconverter.platforms.rvc2.exporter import (
-    RVC2Exporter,
-    _broadcast_preprocessing_values,
-)
+from modelconverter.platforms.rvc2.exporter import RVC2Exporter
 from modelconverter.platforms.rvc3.exporter import RVC3Exporter
 from modelconverter.utils import PreprocessingEmbeddingError
 from modelconverter.utils.config import (
@@ -17,13 +14,14 @@ from modelconverter.utils.config import (
     InputConfig,
     OutputConfig,
     SingleStageConfig,
+    broadcast_preprocessing_values,
 )
 from modelconverter.utils.types import Encoding, InputFileType
 from tests.helpers.onnx_factory import build_onnx, single_io_onnx
 
 
 def test_scalar_preprocessing_is_expanded_to_resolved_channels():
-    assert _broadcast_preprocessing_values([127.0], 2) == [127.0, 127.0]
+    assert broadcast_preprocessing_values([127.0], 2) == [127.0, 127.0]
 
 
 def test_raw_two_channel_normalization_is_forwarded_to_model_optimizer(

--- a/tests/unit/test_rvc2_exporter.py
+++ b/tests/unit/test_rvc2_exporter.py
@@ -13,6 +13,7 @@ from modelconverter.platforms.rvc3.exporter import RVC3Exporter
 from modelconverter.utils import PreprocessingEmbeddingError
 from modelconverter.utils.config import (
     Config,
+    EncodingConfig,
     InputConfig,
     OutputConfig,
     SingleStageConfig,
@@ -178,8 +179,10 @@ def test_ir_preprocessing_retry_preserves_unsanitized_bin_source(
                 name="input0",
                 shape=[1, 2, 8, 8],
                 layout="NCHW",
-                encoding="NONE",
-                mean_values=[10, 20],
+                encoding=EncodingConfig.model_validate(
+                    {"from": Encoding.NONE, "to": Encoding.NONE}
+                ),
+                mean_values=[10.0, 20.0],
             )
         ],
         outputs=[OutputConfig(name="output0", shape=[1], layout="N")],

--- a/tests/unit/test_rvc2_exporter.py
+++ b/tests/unit/test_rvc2_exporter.py
@@ -25,19 +25,13 @@ def test_scalar_preprocessing_is_expanded_to_resolved_channels():
     assert _broadcast_preprocessing_values([127.0], 2) == [127.0, 127.0]
 
 
-@pytest.mark.parametrize(
-    ("exporter_type", "platform_key"),
-    [(RVC2Exporter, "rvc2"), (RVC3Exporter, "rvc3")],
-)
 def test_raw_two_channel_normalization_is_forwarded_to_model_optimizer(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    exporter_type: type[RVC2Exporter],
-    platform_key: str,
 ):
     shape = [1, 2, 8, 8]
     model = single_io_onnx(
-        tmp_path / f"{platform_key}.onnx",
+        tmp_path / "rvc2.onnx",
         shape=shape,
         output_shape=shape,
     ).resolve()
@@ -58,12 +52,12 @@ def test_raw_two_channel_normalization_is_forwarded_to_model_optimizer(
                 "substitute_sub_with_add": False,
                 "substitute_div_with_mul": False,
             },
-            f"{platform_key}.disable_calibration": True,
+            "rvc2.disable_calibration": True,
         },
     )
-    output_dir = tmp_path / f"out-{platform_key}"
+    output_dir = tmp_path / "out-rvc2"
     output_dir.mkdir()
-    exporter = exporter_type(next(iter(config.stages.values())), output_dir)
+    exporter = RVC2Exporter(next(iter(config.stages.values())), output_dir)
     commands: list[list[str]] = []
 
     monkeypatch.setattr(
@@ -80,19 +74,13 @@ def test_raw_two_channel_normalization_is_forwarded_to_model_optimizer(
     assert command[command.index("--scale_values") + 1] == "input0[2.0,4.0]"
 
 
-@pytest.mark.parametrize(
-    ("exporter_type", "platform_key"),
-    [(RVC2Exporter, "rvc2"), (RVC3Exporter, "rvc3")],
-)
 def test_selective_bgr_to_rgb_reversal_preserves_runtime_encoding(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    exporter_type: type[RVC2Exporter],
-    platform_key: str,
 ):
     shape = [1, 3, 8, 8]
     model = build_onnx(
-        tmp_path / f"{platform_key}-mixed-reversal.onnx",
+        tmp_path / "rvc2-mixed-reversal.onnx",
         [
             ("reversed", shape, TensorProto.FLOAT),
             ("unchanged", shape, TensorProto.FLOAT),
@@ -120,12 +108,12 @@ def test_selective_bgr_to_rgb_reversal_preserves_runtime_encoding(
             ],
             "onnx_simplification": False,
             "onnx_optimizations": False,
-            f"{platform_key}.disable_calibration": True,
+            "rvc2.disable_calibration": True,
         },
     )
-    output_dir = tmp_path / f"out-{platform_key}-mixed-reversal"
+    output_dir = tmp_path / "out-rvc2-mixed-reversal"
     output_dir.mkdir()
-    exporter = exporter_type(next(iter(config.stages.values())), output_dir)
+    exporter = RVC2Exporter(next(iter(config.stages.values())), output_dir)
     monkeypatch.setattr(
         exporter, "_subprocess_run", lambda *_args, **_kwargs: None
     )

--- a/tests/unit/test_rvc4_exporter.py
+++ b/tests/unit/test_rvc4_exporter.py
@@ -2,10 +2,13 @@
 
 from pathlib import Path
 
+import onnx
 import pytest
 
 from modelconverter.platforms.rvc4.exporter import RVC4Exporter
+from modelconverter.utils import ONNXException
 from modelconverter.utils.config import Config
+from modelconverter.utils.types import InputFileType
 from tests.helpers.onnx_factory import single_io_onnx
 
 
@@ -135,3 +138,65 @@ def test_int16_standard_does_not_change_per_row_behavior(
 
     assert "--use_per_channel_quantization" not in command
     assert "--use_per_row_quantization" in command
+
+
+def test_non_onnx_preprocessing_request_fails(tmp_path: Path):
+    onnx_model = single_io_onnx(tmp_path / "model.onnx").resolve()
+    config = Config.get_config(
+        None,
+        {
+            "input_model": str(onnx_model),
+            "shape": [1, 3, 64, 64],
+            "encoding": "NONE",
+            "mean_values": [1, 2, 3],
+            "rvc4.disable_calibration": True,
+        },
+    )
+    model = tmp_path / "model.tflite"
+    model.write_bytes(b"TFL3")
+    stage = next(iter(config.stages.values()))
+    stage.input_model = model
+    stage.input_file_type = InputFileType.TFLITE
+    output_dir = tmp_path / "out-tflite"
+    output_dir.mkdir()
+
+    with pytest.raises(ONNXException, match=r"only embed.*ONNX"):
+        RVC4Exporter(stage, output_dir)
+
+
+def test_two_channel_normalization_is_embedded(tmp_path: Path):
+    shape = [1, 2, 8, 8]
+    model = single_io_onnx(
+        tmp_path / "two-channel.onnx",
+        shape=shape,
+        output_shape=shape,
+    ).resolve()
+    config = Config.get_config(
+        None,
+        {
+            "input_model": str(model),
+            "shape": shape,
+            "encoding": "NONE",
+            "mean_values": [113.55, 113.55],
+            "scale_values": [68.646, 68.646],
+            "onnx_simplification": False,
+            "onnx_optimizations": {
+                "fuse_add_mul_to_bn": False,
+                "fuse_comb_add_mul_to_conv": False,
+                "fuse_single_add_mul_to_conv": False,
+                "fuse_split_concat_to_conv": False,
+                "substitute_sub_with_add": False,
+                "substitute_div_with_mul": False,
+            },
+            "rvc4.disable_calibration": True,
+        },
+    )
+    output_dir = tmp_path / "out-two-channel"
+    output_dir.mkdir()
+
+    exporter = RVC4Exporter(next(iter(config.stages.values())), output_dir)
+
+    operations = [
+        node.op_type for node in onnx.load(exporter._input_model).graph.node
+    ]
+    assert operations[:2] == ["Sub", "Mul"]

--- a/tests/unit/test_rvc4_exporter.py
+++ b/tests/unit/test_rvc4_exporter.py
@@ -164,6 +164,30 @@ def test_non_onnx_preprocessing_request_fails(tmp_path: Path):
         RVC4Exporter(stage, output_dir)
 
 
+def test_non_onnx_without_preprocessing_is_accepted(tmp_path: Path):
+    onnx_model = single_io_onnx(tmp_path / "source.onnx").resolve()
+    config = Config.get_config(
+        None,
+        {
+            "input_model": str(onnx_model),
+            "shape": [1, 3, 64, 64],
+            "encoding": "RGB",
+            "rvc4.disable_calibration": True,
+        },
+    )
+    model = tmp_path / "model.tflite"
+    model.write_bytes(b"TFL3")
+    stage = next(iter(config.stages.values()))
+    stage.input_model = model
+    stage.input_file_type = InputFileType.TFLITE
+    output_dir = tmp_path / "out-tflite-no-preprocessing"
+    output_dir.mkdir()
+
+    exporter = RVC4Exporter(stage, output_dir)
+
+    assert exporter.inputs["input0"].requires_input_preprocessing() is False
+
+
 def test_two_channel_normalization_is_embedded(tmp_path: Path):
     shape = [1, 2, 8, 8]
     model = single_io_onnx(

--- a/tests/unit/test_rvc4_exporter.py
+++ b/tests/unit/test_rvc4_exporter.py
@@ -6,7 +6,7 @@ import onnx
 import pytest
 
 from modelconverter.platforms.rvc4.exporter import RVC4Exporter
-from modelconverter.utils import ONNXException
+from modelconverter.utils import PreprocessingEmbeddingError
 from modelconverter.utils.config import Config
 from modelconverter.utils.types import InputFileType
 from tests.helpers.onnx_factory import single_io_onnx
@@ -160,7 +160,7 @@ def test_non_onnx_preprocessing_request_fails(tmp_path: Path):
     output_dir = tmp_path / "out-tflite"
     output_dir.mkdir()
 
-    with pytest.raises(ONNXException, match=r"only embed.*ONNX"):
+    with pytest.raises(PreprocessingEmbeddingError, match=r"only embed.*ONNX"):
         RVC4Exporter(stage, output_dir)
 
 


### PR DESCRIPTION
## Purpose

Fix cases where input preprocessing could be silently skipped, incorrectly embedded, or represented incorrectly in generated NN Archives. This ensures that channel conversion, mean/scale normalization, input type, layout, and `dai_type` remain consistent throughout conversion and at DepthAI runtime.

## Specification

- Validate input preprocessing contracts:
  - RGB/BGR inputs require exactly three channels.
  - GRAY inputs require exactly one channel.
  - Non-image tensors must use `encoding: NONE`.
  - Mean and scale values must be scalar or match the channel count.
  - Scale values must be non-zero.
- Support scalar broadcasting and per-channel normalization for arbitrary channel counts.
- Correctly embed preprocessing into NCHW and NHWC ONNX models without mutating the input configuration.
- Correct selective RGB/BGR reversal for multi-input RVC2/RVC3 models.
- Reject preprocessing combinations that cannot be embedded, including unsupported layouts, integer mean/scale normalization, existing OpenVINO IR inputs, and non-ONNX RVC4 inputs.
- For single-stage NN Archive output, automatically retry conversion with preprocessing moved to archive metadata when embedding is unsupported.
- Restrict `--archive-preprocess` to NN Archive output.
- Preserve image/raw input types and generate correct archive preprocessing metadata, including grayscale `dai_type` and converted layouts.
- Improve Hailo preprocessing handling and reject embedded preprocessing when calibration is disabled.
- Update preprocessing documentation and CLI guidance.

## Dependencies & Potential Impact

No new dependencies or affected services.

Potential behavioral impact:

- Previously accepted invalid preprocessing configurations now fail with actionable validation errors.
- Native and multi-stage outputs fail when requested preprocessing cannot be embedded, because they cannot safely use the NN Archive fallback.
- Existing OpenVINO IR models cannot receive additional preprocessing during RVC2/RVC3 conversion.
- RVC4 preprocessing embedding requires an ONNX source.
- Hailo preprocessing embedding requires calibration to be enabled.
- Generated NN Archive preprocessing metadata may change to correctly reflect the model’s effective input contract.

## Deployment Plan

Release through the normal ModelConverter package and platform-container release process. No migrations or coordinated service rollout are required.

After deployment, monitor conversion failures and warnings related to preprocessing validation or automatic NN Archive fallback. Roll back by reverting this change and republishing the previous package/container versions if regressions are found.

## Testing & Validation

Ran the complete unit test suite:

```text
1005 passed, 5 skipped, 59 warnings in 18.73s
```

Coverage includes input-contract validation, scalar and multi-channel normalization, NCHW/NHWC embedding, RGB/BGR reversal, raw and grayscale inputs, RVC2/RVC4 exporter behavior, automatic archive fallback, and generated NN Archive metadata.

Platform conversion tests requiring vendor toolchains were not run locally.

## AI Usage

Assisted-by: Codex:GPT-5

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation for input encoding, channel compatibility, normalization values, and preprocessing requirements.
  - Improved preprocessing for image and raw tensor inputs, including grayscale, multi-channel, and layout-specific handling.
  - Added automatic NN Archive fallback when preprocessing embedding fails for eligible single-stage conversions.
  - Preserved configured tensor encodings when normalization is disabled.
  - Improved output handling for configured tensor layouts.
  - Added clearer errors for unsupported preprocessing and incompatible CLI options.

- **Documentation**
  - Clarified preprocessing defaults, value broadcasting, encoding requirements, layout conversion, and NN Archive CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->