### PR TITLE
Added option to set input_fps for DAI benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,8 @@ optionally saves the results to a `.csv` file.
 > `depthai` backend (default):
 >
 > - `--benchmark-time`: The duration of the benchmark in seconds (default is 20 seconds).
+> - `--max-fps`: The maximum rate at which inputs are sent. It accepts `-1`
+>   for no limit or a positive float (default is `-1`).
 >
 > `SNPE` backend (only **RVC4** with `--no-dai-benchmark`):
 >

--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ optionally saves the results to a `.csv` file.
 > `depthai` backend (default):
 >
 > - `--benchmark-time`: The duration of the benchmark in seconds (default is 20 seconds).
-> - `--max-fps`: The maximum rate at which inputs are sent. It accepts `-1`
+> - `--input-fps`: The rate at which inputs are sent. It accepts `-1`
 >   for no limit or a positive float (default is `-1`).
 >
 > `SNPE` backend (only **RVC4** with `--no-dai-benchmark`):

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -505,7 +505,7 @@ def benchmark(
     save: bool = False,
     repetitions: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 10,
     benchmark_time: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 20,
-    max_fps: Annotated[float, Parameter(group=["RVC2", "RVC4"])] = -1.0,
+    input_fps: Annotated[float, Parameter(group=["RVC2", "RVC4"])] = -1.0,
     num_threads: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 2,
     num_messages: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 50,
     requests: Annotated[int, Parameter(group="RVC3")] = 1,
@@ -543,7 +543,7 @@ def benchmark(
             for DAI benchmark.
         benchmark_time: The duration in seconds for time-based
             benchmarking (overrides repetitions).
-        max_fps: Maximum rate at which inputs are sent by the DAI
+        input_fps: Rate at which inputs are sent by the DAI
             benchmark. Use ``-1`` for no limit.
         num_threads: The number of threads to use for inference. Only
             relevant for DAI benchmark.
@@ -573,7 +573,7 @@ def benchmark(
         kwargs: Configuration = {
             "repetitions": repetitions,
             "benchmark_time": benchmark_time,
-            "max_fps": max_fps,
+            "input_fps": input_fps,
             "num_threads": num_threads,
             "num_messages": num_messages,
         }

--- a/modelconverter/__main__.py
+++ b/modelconverter/__main__.py
@@ -505,6 +505,7 @@ def benchmark(
     save: bool = False,
     repetitions: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 10,
     benchmark_time: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 20,
+    max_fps: Annotated[float, Parameter(group=["RVC2", "RVC4"])] = -1.0,
     num_threads: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 2,
     num_messages: Annotated[int, Parameter(group=["RVC2", "RVC4"])] = 50,
     requests: Annotated[int, Parameter(group="RVC3")] = 1,
@@ -542,6 +543,8 @@ def benchmark(
             for DAI benchmark.
         benchmark_time: The duration in seconds for time-based
             benchmarking (overrides repetitions).
+        max_fps: Maximum rate at which inputs are sent by the DAI
+            benchmark. Use ``-1`` for no limit.
         num_threads: The number of threads to use for inference. Only
             relevant for DAI benchmark.
         num_messages: The number of messages to measure for each report.
@@ -570,6 +573,7 @@ def benchmark(
         kwargs: Configuration = {
             "repetitions": repetitions,
             "benchmark_time": benchmark_time,
+            "max_fps": max_fps,
             "num_threads": num_threads,
             "num_messages": num_messages,
         }

--- a/modelconverter/platforms/base_benchmark.py
+++ b/modelconverter/platforms/base_benchmark.py
@@ -10,6 +10,7 @@ which the per-platform benchmarks subclass.
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from math import isfinite
 from pathlib import Path
 from typing import TypeAlias, TypeVar
 
@@ -19,12 +20,12 @@ from luxonis_ml.typing import PathType
 
 from modelconverter.utils import is_hubai_model_variant_available, resolve_path
 
-ConfigValue: TypeAlias = str | int | bool | None
+ConfigValue: TypeAlias = str | int | float | bool | None
 Configuration: TypeAlias = dict[str, ConfigValue]
 
 Result: TypeAlias = dict[str, float | str | None]
 
-OptionT = TypeVar("OptionT", bound=str | int | bool)
+OptionT = TypeVar("OptionT", bound=str | int | float | bool)
 
 
 def get_option(
@@ -73,6 +74,27 @@ def get_optional_option(
     if configuration.get(key) is None:
         return None
     return get_option(configuration, key, option_type)
+
+
+def get_max_fps(configuration: Configuration) -> float:
+    """Read and validate the maximum input rate for a DAI benchmark.
+
+    ``-1`` lets the benchmark run without a rate limit. Otherwise the
+    value must be a positive, finite number.
+    """
+    value = configuration.get("max_fps")
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise TypeError(
+            "The benchmark option 'max_fps' must be of type 'float', "
+            f"got {value!r}."
+        )
+    max_fps = float(value)
+    if not isfinite(max_fps) or (max_fps != -1 and max_fps <= 0):
+        raise ValueError(
+            "The benchmark option 'max_fps' must be -1 or a positive "
+            f"float, got {value!r}."
+        )
+    return max_fps
 
 
 class Benchmark(ABC):

--- a/modelconverter/platforms/base_benchmark.py
+++ b/modelconverter/platforms/base_benchmark.py
@@ -76,25 +76,25 @@ def get_optional_option(
     return get_option(configuration, key, option_type)
 
 
-def get_max_fps(configuration: Configuration) -> float:
-    """Read and validate the maximum input rate for a DAI benchmark.
+def get_input_fps(configuration: Configuration) -> float:
+    """Read and validate the input rate for a DAI benchmark.
 
     ``-1`` lets the benchmark run without a rate limit. Otherwise the
     value must be a positive, finite number.
     """
-    value = configuration.get("max_fps")
+    value = configuration.get("input_fps")
     if isinstance(value, bool) or not isinstance(value, int | float):
         raise TypeError(
-            "The benchmark option 'max_fps' must be of type 'float', "
+            "The benchmark option 'input_fps' must be of type 'float', "
             f"got {value!r}."
         )
-    max_fps = float(value)
-    if not isfinite(max_fps) or (max_fps != -1 and max_fps <= 0):
+    input_fps = float(value)
+    if not isfinite(input_fps) or (input_fps != -1 and input_fps <= 0):
         raise ValueError(
-            "The benchmark option 'max_fps' must be -1 or a positive "
+            "The benchmark option 'input_fps' must be -1 or a positive "
             f"float, got {value!r}."
         )
-    return max_fps
+    return input_fps
 
 
 class Benchmark(ABC):

--- a/modelconverter/platforms/rvc2/benchmark.py
+++ b/modelconverter/platforms/rvc2/benchmark.py
@@ -33,16 +33,20 @@ class RVC2Benchmark(Benchmark):
     def default_configuration(self) -> Configuration:
         """Default configuration for RVC2 benchmarking.
 
-        Options:
-            repetitions: The number of repetitions to perform (ignored if
-            benchmark_time is set).
-
-            benchmark_time: Duration in seconds for time-based
-            benchmarking (overrides repetitions).
-            max_fps: Maximum rate at which inputs are sent. ``-1`` removes
-                the limit.
-            num_messages: The number of messages measured for each report.
-            num_threads: The number of threads to use for inference.
+        Configuration options:
+            ``repetitions``
+                The number of repetitions to perform (ignored if
+                ``benchmark_time`` is set).
+            ``benchmark_time``
+                Duration in seconds for time-based benchmarking (overrides
+                ``repetitions``).
+            ``max_fps``
+                Maximum rate at which inputs are sent. ``-1`` removes the
+                limit.
+            ``num_messages``
+                The number of messages measured for each report.
+            ``num_threads``
+                The number of threads to use for inference.
         """
         return {
             "repetitions": 10,

--- a/modelconverter/platforms/rvc2/benchmark.py
+++ b/modelconverter/platforms/rvc2/benchmark.py
@@ -16,7 +16,7 @@ from modelconverter.platforms.base_benchmark import (
     Benchmark,
     Configuration,
     Result,
-    get_max_fps,
+    get_input_fps,
     get_option,
 )
 from modelconverter.utils import create_progress_handler, environ
@@ -40,8 +40,8 @@ class RVC2Benchmark(Benchmark):
             ``benchmark_time``
                 Duration in seconds for time-based benchmarking (overrides
                 ``repetitions``).
-            ``max_fps``
-                Maximum rate at which inputs are sent. ``-1`` removes the
+            ``input_fps``
+                Rate at which inputs are sent. ``-1`` removes the
                 limit.
             ``num_messages``
                 The number of messages measured for each report.
@@ -51,7 +51,7 @@ class RVC2Benchmark(Benchmark):
         return {
             "repetitions": 10,
             "benchmark_time": 20,
-            "max_fps": -1.0,
+            "input_fps": -1.0,
             "num_messages": 50,
             "num_threads": 2,
         }
@@ -84,7 +84,7 @@ class RVC2Benchmark(Benchmark):
             num_messages=get_option(configuration, "num_messages", int),
             num_threads=get_option(configuration, "num_threads", int),
             benchmark_time=get_option(configuration, "benchmark_time", int),
-            max_fps=get_max_fps(configuration),
+            input_fps=get_input_fps(configuration),
         )
 
     @staticmethod
@@ -94,7 +94,7 @@ class RVC2Benchmark(Benchmark):
         num_messages: int,
         num_threads: int,
         benchmark_time: int,
-        max_fps: float,
+        input_fps: float,
     ) -> Result:
         device = dai.Device()
         if device.getPlatform() != dai.Platform.RVC2:
@@ -161,7 +161,7 @@ class RVC2Benchmark(Benchmark):
             with dai.Pipeline(device) as pipeline:
                 benchmarkOut = pipeline.create(dai.node.BenchmarkOut)
                 benchmarkOut.setRunOnHost(False)
-                benchmarkOut.setFps(max_fps)
+                benchmarkOut.setFps(input_fps)
 
                 neuralNetwork = pipeline.create(dai.node.NeuralNetwork)
                 if isinstance(model_path, str) or str(model_path).endswith(

--- a/modelconverter/platforms/rvc2/benchmark.py
+++ b/modelconverter/platforms/rvc2/benchmark.py
@@ -16,6 +16,7 @@ from modelconverter.platforms.base_benchmark import (
     Benchmark,
     Configuration,
     Result,
+    get_max_fps,
     get_option,
 )
 from modelconverter.utils import create_progress_handler, environ
@@ -38,12 +39,15 @@ class RVC2Benchmark(Benchmark):
 
             benchmark_time: Duration in seconds for time-based
             benchmarking (overrides repetitions).
+            max_fps: Maximum rate at which inputs are sent. ``-1`` removes
+                the limit.
             num_messages: The number of messages measured for each report.
             num_threads: The number of threads to use for inference.
         """
         return {
             "repetitions": 10,
             "benchmark_time": 20,
+            "max_fps": -1.0,
             "num_messages": 50,
             "num_threads": 2,
         }
@@ -76,6 +80,7 @@ class RVC2Benchmark(Benchmark):
             num_messages=get_option(configuration, "num_messages", int),
             num_threads=get_option(configuration, "num_threads", int),
             benchmark_time=get_option(configuration, "benchmark_time", int),
+            max_fps=get_max_fps(configuration),
         )
 
     @staticmethod
@@ -85,6 +90,7 @@ class RVC2Benchmark(Benchmark):
         num_messages: int,
         num_threads: int,
         benchmark_time: int,
+        max_fps: float,
     ) -> Result:
         device = dai.Device()
         if device.getPlatform() != dai.Platform.RVC2:
@@ -151,7 +157,7 @@ class RVC2Benchmark(Benchmark):
             with dai.Pipeline(device) as pipeline:
                 benchmarkOut = pipeline.create(dai.node.BenchmarkOut)
                 benchmarkOut.setRunOnHost(False)
-                benchmarkOut.setFps(-1)
+                benchmarkOut.setFps(max_fps)
 
                 neuralNetwork = pipeline.create(dai.node.NeuralNetwork)
                 if isinstance(model_path, str) or str(model_path).endswith(

--- a/modelconverter/platforms/rvc4/benchmark.py
+++ b/modelconverter/platforms/rvc4/benchmark.py
@@ -31,6 +31,7 @@ from modelconverter.platforms.base_benchmark import (
     Benchmark,
     Configuration,
     Result,
+    get_max_fps,
     get_option,
     get_optional_option,
 )
@@ -116,6 +117,8 @@ class RVC4Benchmark(Benchmark):
             dai_benchmark: Whether to use the DepthAI for benchmarking.
             repetitions: The number of repetitions to perform (dai-benchmark only, ignored if benchmark_time is set).
             benchmark_time: Duration in seconds for time-based benchmarking (overrides repetitions).
+            max_fps: Maximum rate at which inputs are sent by the DAI
+                benchmark. ``-1`` removes the limit.
             num_threads: The number of threads to use for inference (dai-benchmark only).
             num_messages: The number of messages to use for inference (dai-benchmark only).
             device_ip: Address of the device to benchmark on, or None to use the first one found.
@@ -130,6 +133,7 @@ class RVC4Benchmark(Benchmark):
             "dai_benchmark": True,
             "repetitions": 10,
             "benchmark_time": 20,
+            "max_fps": -1.0,
             "num_threads": 2,
             "num_messages": 50,
             "device_ip": None,
@@ -365,6 +369,7 @@ class RVC4Benchmark(Benchmark):
         """
         dai_benchmark = get_option(configuration, "dai_benchmark", bool)
         device_monitor = get_option(configuration, "device_monitor", bool)
+        max_fps = get_max_fps(configuration)
 
         device_ip, device_adb_id = get_device_info(
             get_optional_option(configuration, "device_ip", str),
@@ -405,6 +410,7 @@ class RVC4Benchmark(Benchmark):
                     benchmark_time=get_option(
                         configuration, "benchmark_time", int
                     ),
+                    max_fps=max_fps,
                     device_ip=device_ip,
                 )
             else:
@@ -414,6 +420,7 @@ class RVC4Benchmark(Benchmark):
                     "num_threads",
                     "num_messages",
                     "benchmark_time",
+                    "max_fps",
                     "device_ip",
                     "device_id",
                     "device_monitor",
@@ -554,6 +561,7 @@ class RVC4Benchmark(Benchmark):
         num_threads: int,
         num_messages: int,
         benchmark_time: int,
+        max_fps: float,
         device_ip: str | None = None,
     ) -> Result:
         if isinstance(model_path, str):
@@ -639,7 +647,7 @@ class RVC4Benchmark(Benchmark):
             with dai.Pipeline(device) as pipeline:
                 benchmark_out = pipeline.create(dai.node.BenchmarkOut)
                 benchmark_out.setRunOnHost(False)
-                benchmark_out.setFps(-1)
+                benchmark_out.setFps(max_fps)
 
                 neural_network = pipeline.create(dai.node.NeuralNetwork)
                 neural_network.setNNArchive(model_archive)

--- a/modelconverter/platforms/rvc4/benchmark.py
+++ b/modelconverter/platforms/rvc4/benchmark.py
@@ -31,7 +31,7 @@ from modelconverter.platforms.base_benchmark import (
     Benchmark,
     Configuration,
     Result,
-    get_max_fps,
+    get_input_fps,
     get_option,
     get_optional_option,
 )
@@ -125,8 +125,8 @@ class RVC4Benchmark(Benchmark):
             ``benchmark_time``
                 Duration in seconds for time-based benchmarking (overrides
                 ``repetitions``).
-            ``max_fps``
-                Maximum rate at which inputs are sent by the DepthAI
+            ``input_fps``
+                Rate at which inputs are sent by the DepthAI
                 benchmark. ``-1`` removes the limit.
             ``num_threads``
                 The number of inference threads (DepthAI only).
@@ -150,7 +150,7 @@ class RVC4Benchmark(Benchmark):
             "dai_benchmark": True,
             "repetitions": 10,
             "benchmark_time": 20,
-            "max_fps": -1.0,
+            "input_fps": -1.0,
             "num_threads": 2,
             "num_messages": 50,
             "device_ip": None,
@@ -386,7 +386,7 @@ class RVC4Benchmark(Benchmark):
         """
         dai_benchmark = get_option(configuration, "dai_benchmark", bool)
         device_monitor = get_option(configuration, "device_monitor", bool)
-        max_fps = get_max_fps(configuration)
+        input_fps = get_input_fps(configuration)
 
         device_ip, device_adb_id = get_device_info(
             get_optional_option(configuration, "device_ip", str),
@@ -427,7 +427,7 @@ class RVC4Benchmark(Benchmark):
                     benchmark_time=get_option(
                         configuration, "benchmark_time", int
                     ),
-                    max_fps=max_fps,
+                    input_fps=input_fps,
                     device_ip=device_ip,
                 )
             else:
@@ -437,7 +437,7 @@ class RVC4Benchmark(Benchmark):
                     "num_threads",
                     "num_messages",
                     "benchmark_time",
-                    "max_fps",
+                    "input_fps",
                     "device_ip",
                     "device_id",
                     "device_monitor",
@@ -578,7 +578,7 @@ class RVC4Benchmark(Benchmark):
         num_threads: int,
         num_messages: int,
         benchmark_time: int,
-        max_fps: float,
+        input_fps: float,
         device_ip: str | None = None,
     ) -> Result:
         if isinstance(model_path, str):
@@ -664,7 +664,7 @@ class RVC4Benchmark(Benchmark):
             with dai.Pipeline(device) as pipeline:
                 benchmark_out = pipeline.create(dai.node.BenchmarkOut)
                 benchmark_out.setRunOnHost(False)
-                benchmark_out.setFps(max_fps)
+                benchmark_out.setFps(input_fps)
 
                 neural_network = pipeline.create(dai.node.NeuralNetwork)
                 neural_network.setNNArchive(model_archive)

--- a/modelconverter/platforms/rvc4/benchmark.py
+++ b/modelconverter/platforms/rvc4/benchmark.py
@@ -110,20 +110,37 @@ class RVC4Benchmark(Benchmark):
     def default_configuration(self) -> Configuration:
         """Default configuration for RVC4 benchmarking.
 
-        Options:
-            profile: The SNPE profile to use for inference.
-            runtime: The SNPE runtime to use for inference.
-            num_images: The number of images to use for inference.
-            dai_benchmark: Whether to use the DepthAI for benchmarking.
-            repetitions: The number of repetitions to perform (dai-benchmark only, ignored if benchmark_time is set).
-            benchmark_time: Duration in seconds for time-based benchmarking (overrides repetitions).
-            max_fps: Maximum rate at which inputs are sent by the DAI
+        Configuration options:
+            ``profile``
+                The SNPE profile to use for inference.
+            ``runtime``
+                The SNPE runtime to use for inference.
+            ``num_images``
+                The number of images to use for inference.
+            ``dai_benchmark``
+                Whether to use DepthAI for benchmarking.
+            ``repetitions``
+                The number of repetitions to perform (DepthAI only, ignored
+                if ``benchmark_time`` is set).
+            ``benchmark_time``
+                Duration in seconds for time-based benchmarking (overrides
+                ``repetitions``).
+            ``max_fps``
+                Maximum rate at which inputs are sent by the DepthAI
                 benchmark. ``-1`` removes the limit.
-            num_threads: The number of threads to use for inference (dai-benchmark only).
-            num_messages: The number of messages to use for inference (dai-benchmark only).
-            device_ip: Address of the device to benchmark on, or None to use the first one found.
-            device_id: Device ID or ADB serial of the device to benchmark on, or None to use the first one found.
-            device_monitor: Whether to sample power, DSP, memory and CPU usage alongside the benchmark.
+            ``num_threads``
+                The number of inference threads (DepthAI only).
+            ``num_messages``
+                The number of messages measured for each report (DepthAI
+                only).
+            ``device_ip``
+                Address of the device, or ``None`` to use the first one found.
+            ``device_id``
+                Device ID or ADB serial, or ``None`` to use the first one
+                found.
+            ``device_monitor``
+                Whether to sample power, DSP, memory, and CPU usage alongside
+                the benchmark.
 
         """
         return {

--- a/tests/unit/test_base_benchmark.py
+++ b/tests/unit/test_base_benchmark.py
@@ -8,6 +8,7 @@ from modelconverter.platforms.base_benchmark import (
     Benchmark,
     Configuration,
     Result,
+    get_max_fps,
     get_option,
     get_optional_option,
 )
@@ -104,3 +105,20 @@ def test_get_option_rejects_a_missing_option():
 
 def test_get_optional_option_accepts_an_unset_option():
     assert get_optional_option({"device_ip": None}, "device_ip", str) is None
+
+
+@pytest.mark.parametrize("max_fps", [-1, -1.0, 1, 12.5])
+def test_get_max_fps_accepts_unlimited_or_positive_values(max_fps: float):
+    assert get_max_fps({"max_fps": max_fps}) == float(max_fps)
+
+
+@pytest.mark.parametrize("max_fps", [-2, -0.5, 0, float("inf"), float("nan")])
+def test_get_max_fps_rejects_invalid_numeric_values(max_fps: float):
+    with pytest.raises(ValueError, match="must be -1 or a positive float"):
+        get_max_fps({"max_fps": max_fps})
+
+
+@pytest.mark.parametrize("max_fps", ["30", True])
+def test_get_max_fps_rejects_non_numeric_values(max_fps: object):
+    with pytest.raises(TypeError, match="must be of type 'float'"):
+        get_max_fps({"max_fps": max_fps})  # type: ignore[dict-item]

--- a/tests/unit/test_base_benchmark.py
+++ b/tests/unit/test_base_benchmark.py
@@ -8,7 +8,7 @@ from modelconverter.platforms.base_benchmark import (
     Benchmark,
     Configuration,
     Result,
-    get_max_fps,
+    get_input_fps,
     get_option,
     get_optional_option,
 )
@@ -107,18 +107,20 @@ def test_get_optional_option_accepts_an_unset_option():
     assert get_optional_option({"device_ip": None}, "device_ip", str) is None
 
 
-@pytest.mark.parametrize("max_fps", [-1, -1.0, 1, 12.5])
-def test_get_max_fps_accepts_unlimited_or_positive_values(max_fps: float):
-    assert get_max_fps({"max_fps": max_fps}) == float(max_fps)
+@pytest.mark.parametrize("input_fps", [-1, -1.0, 1, 12.5])
+def test_get_input_fps_accepts_unlimited_or_positive_values(input_fps: float):
+    assert get_input_fps({"input_fps": input_fps}) == float(input_fps)
 
 
-@pytest.mark.parametrize("max_fps", [-2, -0.5, 0, float("inf"), float("nan")])
-def test_get_max_fps_rejects_invalid_numeric_values(max_fps: float):
+@pytest.mark.parametrize(
+    "input_fps", [-2, -0.5, 0, float("inf"), float("nan")]
+)
+def test_get_input_fps_rejects_invalid_numeric_values(input_fps: float):
     with pytest.raises(ValueError, match="must be -1 or a positive float"):
-        get_max_fps({"max_fps": max_fps})
+        get_input_fps({"input_fps": input_fps})
 
 
-@pytest.mark.parametrize("max_fps", ["30", True])
-def test_get_max_fps_rejects_non_numeric_values(max_fps: object):
+@pytest.mark.parametrize("input_fps", ["30", True])
+def test_get_input_fps_rejects_non_numeric_values(input_fps: object):
     with pytest.raises(TypeError, match="must be of type 'float'"):
-        get_max_fps({"max_fps": max_fps})  # type: ignore[dict-item]
+        get_input_fps({"input_fps": input_fps})  # type: ignore[dict-item]


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

The primary purpose of this feature is to measure benchmark metrics at a fixed input rate, such as DSP utilization, RAM usage, and CPU usage at a specific FPS.

It also provides more representative latency measurements. While `input_fps=-1` is useful for determining theoretical maximum throughput, it can cause SNPE to queue inputs, resulting in inflated latency. A more accurate workflow is to first measure the maximum throughput with `input_fps=-1`, then rerun the benchmark with `input_fps` set to the measured value. This produces latency measurements that better reflect real-world performance.

Practical example with `luxonis/dinov3-backbone:convnext-base-512x384`:
- `input_fps=-1` and `num_threads=1` on `RVC4` device: 37.25FPS and 26.55ms latency
- `input_fps=-1` and `num_threads=4` on `RVC4` device: 40.29FPS and 99.09ms latency
- `input_fps=40` and `num_threads=4` on `RVC4` device: 40FPS and 24.45ms latency

**Finding: When we limit the FPS to what is actually acceptable we get representative latency**

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Add a `--input_fps` benchmark parameter for RVC2 and RVC4.
- Default `input_fps` to `-1`, indicating unlimited input rate.
- Accept positive finite floating-point FPS limits.
- Validate and normalize `input_fps` before device benchmarking.
- Pass the configured value to `BenchmarkOut.setFps()` in both DepthAI benchmarkers.
- Exclude `input_fps` from the RVC4 SNPE benchmark configuration.
- Extend benchmark configuration values to support floats.
- Document the new option and add unit tests for valid and invalid values.


## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `--input-fps` benchmark option for RVC2 and RVC4.
  * Configure the input frame rate with a positive value, or use `-1` for unlimited operation by default.
  * Applied the configured rate when sending inputs to the device.

* **Bug Fixes**
  * Added validation for invalid, non-positive, non-finite, boolean, and non-numeric frame-rate values.

* **Documentation**
  * Updated benchmarking documentation to use `--input-fps` and describe accepted values.

* **Tests**
  * Added coverage for valid and invalid input frame-rate values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->